### PR TITLE
Add resolved parameters for Resource templates

### DIFF
--- a/docs/mcp-declarative/README.md
+++ b/docs/mcp-declarative/README.md
@@ -205,10 +205,7 @@ McpPromptContent image = McpPromptContents.imageContent("base64", MediaTypes.cre
 
 `Resources` allow servers to share data that provides context to language models, such as files, database schemas, or 
 application-specific information. Clients can list and read them. Resources are identified by name, description, and media type.
-
-**Resource Templates** use [URI templates](https://datatracker.ietf.org/doc/html/rfc6570) to define parameterized URIs. They help 
-clients discover dynamic content; note that templates are not directly readable. 
-Define both resources and templates using `@Mcp.Resource`:
+Define resources using `@Mcp.Resource`:
 
 ```java
 @Mcp.Server
@@ -239,6 +236,32 @@ class Server {
     @Mcp.Name("MyResource")
     String resource(McpRequest request) {
         return "text";
+    }
+}
+```
+
+### Resource Templates
+
+Resource Templates utilize [URI templates](https://datatracker.ietf.org/doc/html/rfc6570) to facilitate dynamic resource discovery.
+The URI template is matched against the corresponding URI in the client request. To define a resource or template, the same
+API as `McpResource` is employed. Parameters enclosed in `{}` denote template variables, which can be accessed via `McpParameters`
+using keys that correspond to these variables.
+
+#### Configuration
+
+Use `String` return types for text-only resources. The `@Mcp.Name` annotation lets you override the default resource name.
+
+```java
+@Mcp.Server
+class Server {
+    
+    @Mcp.Resource(
+            uri = "file://{path}",
+            description = "Resource description",
+            mediaType = MediaTypes.TEXT_PLAIN_VALUE)
+    @Mcp.Name("MyResource")
+    String resource(String path) {
+        return "File at path " + path + " does not exist.";
     }
 }
 ```

--- a/examples/calendar/pom.xml
+++ b/examples/calendar/pom.xml
@@ -75,6 +75,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>

--- a/examples/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/Calendar.java
+++ b/examples/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/Calendar.java
@@ -22,6 +22,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import io.helidon.extensions.mcp.server.McpException;
 
@@ -37,7 +39,7 @@ final class Calendar {
         try {
             this.file = Files.createTempFile("calendar", "-calendar");
             this.uri = file.toUri().toString();
-            this.uriTemplate = uri.substring(0, uri.lastIndexOf('-') + 1) + "{path}";
+            this.uriTemplate = "file://events/{name}";
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
         }
@@ -55,7 +57,18 @@ final class Calendar {
         try {
             return Files.readString(file);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    String readContentMatchesLine(Predicate<String> lineMatcher) {
+        try {
+            return Files.readAllLines(file)
+                    .stream()
+                    .filter(lineMatcher)
+                    .collect(Collectors.joining("\n"));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/examples/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/CalendarEventResourceTemplate.java
+++ b/examples/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/CalendarEventResourceTemplate.java
@@ -21,10 +21,10 @@ import java.util.function.Function;
 
 import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
-import io.helidon.extensions.mcp.server.McpException;
 import io.helidon.extensions.mcp.server.McpRequest;
 import io.helidon.extensions.mcp.server.McpResource;
 import io.helidon.extensions.mcp.server.McpResourceContent;
+import io.helidon.extensions.mcp.server.McpResourceContents;
 
 /**
  * Resource template to help accessing to the event registry.
@@ -48,7 +48,7 @@ final class CalendarEventResourceTemplate implements McpResource {
 
     @Override
     public String description() {
-        return "Resource Template to find calendar events registry, path is \"calendar\"";
+        return "Resource Template to find calendar events with name";
     }
 
     @Override
@@ -58,6 +58,13 @@ final class CalendarEventResourceTemplate implements McpResource {
 
     @Override
     public Function<McpRequest, List<McpResourceContent>> resource() {
-        throw new McpException("Resource template cannot be read.");
+        return request -> {
+          String name = request.parameters()
+                  .get("name")
+                  .asString()
+                  .orElse("Unknown");
+          String content = calendar.readContentMatchesLine(line -> line.startsWith("Event: { name: " + name + ","));
+          return List.of(McpResourceContents.textContent(content));
+        };
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonRpc.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonRpc.java
@@ -217,7 +217,7 @@ final class McpJsonRpc {
         return resources.build();
     }
 
-    static JsonObject listResourceTemplates(McpPage<McpResource> page) {
+    static JsonObject listResourceTemplates(McpPage<McpResourceTemplate> page) {
         JsonArrayBuilder builder = JSON_BUILDER_FACTORY.createArrayBuilder();
         page.components().stream()
                 .map(McpJsonRpc::resourceTemplates)

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceTemplate.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceTemplate.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.mcp.server;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.helidon.common.media.type.MediaType;
+import io.helidon.jsonrpc.core.JsonRpcParams;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+
+class McpResourceTemplate implements McpResource {
+    private final Pattern pattern;
+    private final McpResource delegate;
+    private final List<String> variables;
+
+    McpResourceTemplate(McpResource resource) {
+        this.delegate = resource;
+        this.variables = new ArrayList<>();
+        this.pattern = createPattern(resource.uri());
+    }
+
+    @Override
+    public String uri() {
+        return delegate.uri();
+    }
+
+    @Override
+    public String name() {
+        return delegate.name();
+    }
+
+    @Override
+    public String description() {
+        return delegate.description();
+    }
+
+    @Override
+    public MediaType mediaType() {
+        return delegate.mediaType();
+    }
+
+    @Override
+    public Function<McpRequest, List<McpResourceContent>> resource() {
+        return delegate.resource();
+    }
+
+    boolean matches(String uri) {
+        return pattern.matcher(uri).matches();
+    }
+
+    McpParameters parameters(JsonRpcParams params, String uri) {
+        JsonObjectBuilder builder = Json.createObjectBuilder();
+        Matcher matcher = pattern.matcher(uri);
+        if (matcher.matches()) {
+            for (int i = 0; i < matcher.groupCount(); i++) {
+                builder.add(variables.get(i), matcher.group(i + 1));
+            }
+        }
+        JsonObject parameters = builder.build();
+        return new McpParameters(JsonRpcParams.create(parameters), parameters);
+    }
+
+    private Pattern createPattern(String uri) {
+        Matcher matcher = Pattern.compile("\\{(\\w+)}").matcher(uri);
+        StringBuilder regex = new StringBuilder();
+        while (matcher.find()) {
+            variables.add(matcher.group(1));
+            matcher.appendReplacement(regex, "([^/]+)");
+        }
+        matcher.appendTail(regex);
+        return Pattern.compile(regex.toString());
+    }
+}

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceTemplate.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceTemplate.java
@@ -25,9 +25,10 @@ import java.util.regex.Pattern;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.jsonrpc.core.JsonRpcParams;
 
-import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
+
+import static io.helidon.extensions.mcp.server.McpJsonRpc.JSON_BUILDER_FACTORY;
 
 class McpResourceTemplate implements McpResource {
     private final Pattern pattern;
@@ -70,7 +71,7 @@ class McpResourceTemplate implements McpResource {
     }
 
     McpParameters parameters(JsonRpcParams params, String uri) {
-        JsonObjectBuilder builder = Json.createObjectBuilder();
+        JsonObjectBuilder builder = JSON_BUILDER_FACTORY.createObjectBuilder();
         Matcher matcher = pattern.matcher(uri);
         if (matcher.matches()) {
             for (int i = 0; i < matcher.groupCount(); i++) {

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
@@ -100,7 +100,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
     private final McpPagination<McpTool> tools;
     private final McpPagination<McpPrompt> prompts;
     private final McpPagination<McpResource> resources;
-    private final McpPagination<McpResource> resourceTemplates;
+    private final McpPagination<McpResourceTemplate> resourceTemplates;
     private final Set<McpCapability> capabilities = new HashSet<>();
     private final Map<String, McpCompletion> completions = new ConcurrentHashMap<>();
     private final LruCache<String, McpSession> sessions = LruCache.create(SESSION_CACHE_SIZE);
@@ -110,14 +110,14 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         List<McpTool> tools = new CopyOnWriteArrayList<>(config.tools());
         List<McpPrompt> prompts = new CopyOnWriteArrayList<>(config.prompts());
         List<McpResource> resources = new CopyOnWriteArrayList<>();
-        List<McpResource> templates = new CopyOnWriteArrayList<>();
+        List<McpResourceTemplate> templates = new CopyOnWriteArrayList<>();
         JsonRpcHandlers.Builder builder = JsonRpcHandlers.builder();
 
         this.config = config;
         this.endpoint = path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
         for (McpResource resource : config.resources()) {
             if (isTemplate(resource)) {
-                templates.add(resource);
+                templates.add(new McpResourceTemplate(resource));
             } else {
                 resources.add(resource);
             }
@@ -465,16 +465,20 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
                 .filter(r -> resourceUri.equals(r.uri()))
                 .findFirst();
 
+        // Fall back on resource template processing if resource is not found
         if (resource.isEmpty()) {
-            res.error(INVALID_REQUEST, "Resource does not exist");
-            sendResponse(req, res, session);
-            return;
-        }
+            var templates = resourceTemplates.content().stream()
+                    .filter(template -> template.matches(resourceUri))
+                    .findFirst();
 
-        if (isTemplate(resource.get())) {
-            res.error(INVALID_REQUEST, "Resource Template cannot be read.");
-            sendResponse(req, res, session);
-            return;
+            if (templates.isEmpty()) {
+                session.send(res.error(JsonRpcError.INVALID_REQUEST, "Resource does not exist"));
+                return;
+            }
+
+            McpResourceTemplate template = templates.get();
+            parameters = template.parameters(req.params(), resourceUri);
+            resource = templates.map(Function.identity());
         }
 
         enableProgress(session, parameters);
@@ -502,7 +506,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             return;
         }
         McpSession session = foundSession.get();
-        McpPage<McpResource> page = page(resourceTemplates, req.params());
+        McpPage<McpResourceTemplate> page = page(resourceTemplates, req.params());
         if (page == null) {
             res.error(INVALID_PARAMS, "Wrong cursor provided.");
             sendResponse(req, res, session);

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
@@ -472,7 +472,8 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
                     .findFirst();
 
             if (templates.isEmpty()) {
-                session.send(res.error(JsonRpcError.INVALID_REQUEST, "Resource does not exist"));
+                res.error(JsonRpcError.INVALID_REQUEST, "Resource does not exist");
+                sendResponse(req, res, session);
                 return;
             }
 

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpResourceTemplateParameterTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpResourceTemplateParameterTest.java
@@ -29,7 +29,6 @@ import static org.hamcrest.Matchers.is;
 
 class McpResourceTemplateParameterTest {
     private final McpResource.Builder builder = McpResource.builder()
-            .uri("https://{path}")
             .name("name")
             .description("description")
             .mediaType(MediaTypes.TEXT_PLAIN)
@@ -38,9 +37,7 @@ class McpResourceTemplateParameterTest {
     @Test
     void testSimpleParameter() {
         JsonRpcParams params = JsonRpcParams.create(JsonValue.EMPTY_JSON_OBJECT);
-        var resource = builder
-                .uri("https://{path}")
-                .build();
+        var resource = builder.uri("https://{path}").build();
         McpResourceTemplate template = new McpResourceTemplate(resource);
         McpParameters parameters = template.parameters(params, "https://foo");
 
@@ -50,9 +47,7 @@ class McpResourceTemplateParameterTest {
     @Test
     void testTwoParameter() {
         JsonRpcParams params = JsonRpcParams.create(JsonValue.EMPTY_JSON_OBJECT);
-        var resource = builder
-                .uri("https://{foo}/{bar}")
-                .build();
+        var resource = builder.uri("https://{foo}/{bar}").build();
         McpResourceTemplate template = new McpResourceTemplate(resource);
         McpParameters parameters = template.parameters(params, "https://foo/bar");
 
@@ -63,9 +58,7 @@ class McpResourceTemplateParameterTest {
     @Test
     void testSpaceParameter() {
         JsonRpcParams params = JsonRpcParams.create(JsonValue.EMPTY_JSON_OBJECT);
-        var resource = builder
-                .uri("https://{foo}/{bar}")
-                .build();
+        var resource = builder.uri("https://{foo}/{bar}").build();
         McpResourceTemplate template = new McpResourceTemplate(resource);
         McpParameters parameters = template.parameters(params, "https://foo foo/bar bar");
 
@@ -76,9 +69,7 @@ class McpResourceTemplateParameterTest {
     @Test
     void testMiddleParameter() {
         JsonRpcParams params = JsonRpcParams.create(JsonValue.EMPTY_JSON_OBJECT);
-        var resource = builder
-                .uri("https://{foo}/path")
-                .build();
+        var resource = builder.uri("https://{foo}/path").build();
         McpResourceTemplate template = new McpResourceTemplate(resource);
         McpParameters parameters = template.parameters(params, "https://foo/path");
 
@@ -88,9 +79,7 @@ class McpResourceTemplateParameterTest {
     @Test
     void testProtocolParameter() {
         JsonRpcParams params = JsonRpcParams.create(JsonValue.EMPTY_JSON_OBJECT);
-        var resource = builder
-                .uri("{protocol}://{foo}")
-                .build();
+        var resource = builder.uri("{protocol}://{foo}").build();
         McpResourceTemplate template = new McpResourceTemplate(resource);
         McpParameters parameters = template.parameters(params, "https://foo");
 

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpResourceTemplateParameterTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpResourceTemplateParameterTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.mcp.server;
+
+import java.util.List;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.jsonrpc.core.JsonRpcParams;
+
+import jakarta.json.JsonValue;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class McpResourceTemplateParameterTest {
+    private final McpResource.Builder builder = McpResource.builder()
+            .uri("https://{path}")
+            .name("name")
+            .description("description")
+            .mediaType(MediaTypes.TEXT_PLAIN)
+            .resource(request -> List.of());
+
+    @Test
+    void testSimpleParameter() {
+        JsonRpcParams params = JsonRpcParams.create(JsonValue.EMPTY_JSON_OBJECT);
+        var resource = builder
+                .uri("https://{path}")
+                .build();
+        McpResourceTemplate template = new McpResourceTemplate(resource);
+        McpParameters parameters = template.parameters(params, "https://foo");
+
+        assertThat(parameters.get("path").asString().get(), is("foo"));
+    }
+
+    @Test
+    void testTwoParameter() {
+        JsonRpcParams params = JsonRpcParams.create(JsonValue.EMPTY_JSON_OBJECT);
+        var resource = builder
+                .uri("https://{foo}/{bar}")
+                .build();
+        McpResourceTemplate template = new McpResourceTemplate(resource);
+        McpParameters parameters = template.parameters(params, "https://foo/bar");
+
+        assertThat(parameters.get("foo").asString().get(), is("foo"));
+        assertThat(parameters.get("bar").asString().get(), is("bar"));
+    }
+
+    @Test
+    void testSpaceParameter() {
+        JsonRpcParams params = JsonRpcParams.create(JsonValue.EMPTY_JSON_OBJECT);
+        var resource = builder
+                .uri("https://{foo}/{bar}")
+                .build();
+        McpResourceTemplate template = new McpResourceTemplate(resource);
+        McpParameters parameters = template.parameters(params, "https://foo foo/bar bar");
+
+        assertThat(parameters.get("foo").asString().get(), is("foo foo"));
+        assertThat(parameters.get("bar").asString().get(), is("bar bar"));
+    }
+
+    @Test
+    void testMiddleParameter() {
+        JsonRpcParams params = JsonRpcParams.create(JsonValue.EMPTY_JSON_OBJECT);
+        var resource = builder
+                .uri("https://{foo}/path")
+                .build();
+        McpResourceTemplate template = new McpResourceTemplate(resource);
+        McpParameters parameters = template.parameters(params, "https://foo/path");
+
+        assertThat(parameters.get("foo").asString().get(), is("foo"));
+    }
+
+    @Test
+    void testProtocolParameter() {
+        JsonRpcParams params = JsonRpcParams.create(JsonValue.EMPTY_JSON_OBJECT);
+        var resource = builder
+                .uri("{protocol}://{foo}")
+                .build();
+        McpResourceTemplate template = new McpResourceTemplate(resource);
+        McpParameters parameters = template.parameters(params, "https://foo");
+
+        assertThat(parameters.get("foo").asString().get(), is("foo"));
+        assertThat(parameters.get("protocol").asString().get(), is("https"));
+    }
+}

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpResourceTemplatePathMatchingTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpResourceTemplatePathMatchingTest.java
@@ -28,16 +28,15 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
 class McpResourceTemplatePathMatchingTest {
+    private final McpResource.Builder builder = McpResource.builder()
+            .name("name")
+            .description("description")
+            .mediaType(MediaTypes.TEXT_PLAIN)
+            .resource(this::resource);
 
     @Test
     void testSingleVariablePath() {
-        var resource = McpResource.builder()
-                .uri("https://{path}")
-                .name("name")
-                .description("description")
-                .mediaType(MediaTypes.TEXT_PLAIN)
-                .resource(this::resource)
-                .build();
+        var resource = builder.uri("https://{path}").build();
         McpResourceTemplate template = new McpResourceTemplate(resource);
 
         assertThat(template.matches("https://foo"), is(true));
@@ -55,13 +54,7 @@ class McpResourceTemplatePathMatchingTest {
 
     @Test
     void testMultipleVariablePath() {
-        var resource = McpResource.builder()
-                .uri("https://{path}/{path1}")
-                .name("name")
-                .description("description")
-                .mediaType(MediaTypes.TEXT_PLAIN)
-                .resource(this::resource)
-                .build();
+        var resource = builder.uri("https://{path}/{path1}").build();
         McpResourceTemplate template = new McpResourceTemplate(resource);
 
         assertThat(template.matches("https://foo/bar"), is(true));
@@ -78,13 +71,7 @@ class McpResourceTemplatePathMatchingTest {
 
     @Test
     void testWrongVariablePath() {
-        var resource = McpResource.builder()
-                .uri("https://{path/path1}")
-                .name("name")
-                .description("description")
-                .mediaType(MediaTypes.TEXT_PLAIN)
-                .resource(this::resource)
-                .build();
+        var resource = builder.uri("https://{path/path1}").build();
         try {
             McpResourceTemplate template = new McpResourceTemplate(resource);
         } catch (PatternSyntaxException e) {
@@ -94,13 +81,7 @@ class McpResourceTemplatePathMatchingTest {
 
     @Test
     void testWrongPath() {
-        var resource = McpResource.builder()
-                .uri("https://{path/path1")
-                .name("name")
-                .description("description")
-                .mediaType(MediaTypes.TEXT_PLAIN)
-                .resource(this::resource)
-                .build();
+        var resource = builder.uri("https://{path/path1").build();
         try {
             McpResourceTemplate template = new McpResourceTemplate(resource);
         } catch (PatternSyntaxException e) {

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpResourceTemplatePathMatchingTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpResourceTemplatePathMatchingTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.mcp.server;
+
+import java.util.List;
+import java.util.regex.PatternSyntaxException;
+
+import io.helidon.common.media.type.MediaTypes;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+
+class McpResourceTemplatePathMatchingTest {
+
+    @Test
+    void testSingleVariablePath() {
+        var resource = McpResource.builder()
+                .uri("https://{path}")
+                .name("name")
+                .description("description")
+                .mediaType(MediaTypes.TEXT_PLAIN)
+                .resource(this::resource)
+                .build();
+        McpResourceTemplate template = new McpResourceTemplate(resource);
+
+        assertThat(template.matches("https://foo"), is(true));
+        assertThat(template.matches("https://foo/"), is(false));
+        assertThat(template.matches("https://foo-bar"), is(true));
+        assertThat(template.matches("https://foo-bar/"), is(false));
+        assertThat(template.matches("https://foo bar"), is(true));
+        assertThat(template.matches("https://foo bar/"), is(false));
+
+        assertThat(template.matches("https://foo/bar"), is(false));
+        assertThat(template.matches("https://foo/bar/"), is(false));
+        assertThat(template.matches("https:/foo/bar/"), is(false));
+        assertThat(template.matches("https:/foo/bar"), is(false));
+    }
+
+    @Test
+    void testMultipleVariablePath() {
+        var resource = McpResource.builder()
+                .uri("https://{path}/{path1}")
+                .name("name")
+                .description("description")
+                .mediaType(MediaTypes.TEXT_PLAIN)
+                .resource(this::resource)
+                .build();
+        McpResourceTemplate template = new McpResourceTemplate(resource);
+
+        assertThat(template.matches("https://foo/bar"), is(true));
+        assertThat(template.matches("https://foo-bar/foo-bar"), is(true));
+        assertThat(template.matches("https://foo bar/ foo bar"), is(true));
+        assertThat(template.matches("https://foo bar/ "), is(true));
+
+        assertThat(template.matches("https://foo/bar/foo"), is(false));
+        assertThat(template.matches("https://foo/"), is(false));
+        assertThat(template.matches("http:/foo/bar/"), is(false));
+        assertThat(template.matches("http:/foo bar/"), is(false));
+        assertThat(template.matches("https:/foo-bar/bar/foo"), is(false));
+    }
+
+    @Test
+    void testWrongVariablePath() {
+        var resource = McpResource.builder()
+                .uri("https://{path/path1}")
+                .name("name")
+                .description("description")
+                .mediaType(MediaTypes.TEXT_PLAIN)
+                .resource(this::resource)
+                .build();
+        try {
+            McpResourceTemplate template = new McpResourceTemplate(resource);
+        } catch (PatternSyntaxException e) {
+            assertThat(e.getMessage(), startsWith("Illegal repetition near index 9"));
+        }
+    }
+
+    @Test
+    void testWrongPath() {
+        var resource = McpResource.builder()
+                .uri("https://{path/path1")
+                .name("name")
+                .description("description")
+                .mediaType(MediaTypes.TEXT_PLAIN)
+                .resource(this::resource)
+                .build();
+        try {
+            McpResourceTemplate template = new McpResourceTemplate(resource);
+        } catch (PatternSyntaxException e) {
+            assertThat(e.getMessage(), startsWith("Illegal repetition near index 9"));
+        }
+    }
+
+    private List<McpResourceContent> resource(McpRequest request) {
+        return List.of();
+    }
+}

--- a/tests/declarative/src/main/java/io/helidon/extensions/mcp/tests/declarative/McpResourceTemplatesServer.java
+++ b/tests/declarative/src/main/java/io/helidon/extensions/mcp/tests/declarative/McpResourceTemplatesServer.java
@@ -21,6 +21,8 @@ import java.util.List;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.extensions.mcp.server.Mcp;
 import io.helidon.extensions.mcp.server.McpFeatures;
+import io.helidon.extensions.mcp.server.McpParameters;
+import io.helidon.extensions.mcp.server.McpRequest;
 import io.helidon.extensions.mcp.server.McpResourceContent;
 import io.helidon.extensions.mcp.server.McpResourceContents;
 
@@ -61,5 +63,21 @@ class McpResourceTemplatesServer {
             description = RESOURCE_DESCRIPTION)
     List<McpResourceContent> resource3(McpFeatures features) {
         return List.of(McpResourceContents.textContent(RESOURCE_CONTENT));
+    }
+
+    @Mcp.Resource(
+            uri = "https://{path}/foo",
+            mediaType = RESOURCE_MEDIA_TYPE,
+            description = RESOURCE_DESCRIPTION)
+    String resource4(String path) {
+        return path;
+    }
+
+    @Mcp.Resource(
+            uri = "{protocol}://{path}",
+            mediaType = RESOURCE_MEDIA_TYPE,
+            description = RESOURCE_DESCRIPTION)
+    String resource5(String protocol, String path, McpRequest request, McpFeatures features, McpParameters parameters) {
+        return protocol + path;
     }
 }

--- a/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/AbstractLangchain4jResourceTemplatesServerTest.java
+++ b/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/AbstractLangchain4jResourceTemplatesServerTest.java
@@ -19,13 +19,17 @@ package io.helidon.extensions.mcp.tests.declarative;
 import java.util.List;
 
 import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.McpReadResourceResult;
+import dev.langchain4j.mcp.client.McpResourceContents;
 import dev.langchain4j.mcp.client.McpResourceTemplate;
+import dev.langchain4j.mcp.client.McpTextResourceContents;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.extensions.mcp.tests.declarative.McpResourceTemplatesServer.RESOURCE_DESCRIPTION;
 import static io.helidon.extensions.mcp.tests.declarative.McpResourceTemplatesServer.RESOURCE_MEDIA_TYPE;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 abstract class AbstractLangchain4jResourceTemplatesServerTest {
@@ -41,7 +45,7 @@ abstract class AbstractLangchain4jResourceTemplatesServerTest {
     @Test
     void readResource() {
         List<McpResourceTemplate> result = client.listResourceTemplates();
-        assertThat(result.size(), is(4));
+        assertThat(result.size(), is(6));
 
         McpResourceTemplate first = result.getFirst();
         assertThat(first.name(), is("resource"));
@@ -66,5 +70,47 @@ abstract class AbstractLangchain4jResourceTemplatesServerTest {
         assertThat(fourth.uriTemplate(), is("git://{path}"));
         assertThat(fourth.mimeType(), is(RESOURCE_MEDIA_TYPE));
         assertThat(fourth.description(), is(RESOURCE_DESCRIPTION));
+
+        McpResourceTemplate fifth = result.get(4);
+        assertThat(fifth.name(), is("resource4"));
+        assertThat(fifth.uriTemplate(), is("https://{path}/foo"));
+        assertThat(fifth.mimeType(), is(RESOURCE_MEDIA_TYPE));
+        assertThat(fifth.description(), is(RESOURCE_DESCRIPTION));
+
+        McpResourceTemplate sixth = result.get(5);
+        assertThat(sixth.name(), is("resource5"));
+        assertThat(sixth.uriTemplate(), is("{protocol}://{path}"));
+        assertThat(sixth.mimeType(), is(RESOURCE_MEDIA_TYPE));
+        assertThat(sixth.description(), is(RESOURCE_DESCRIPTION));
+    }
+
+    @Test
+    void readResource4() {
+        McpReadResourceResult result = client.readResource("https://foo/foo");
+        List<McpResourceContents> contents = result.contents();
+        assertThat(contents.size(), is(1));
+
+        McpResourceContents content = contents.getFirst();
+        assertThat(content, instanceOf(McpTextResourceContents.class));
+
+        McpTextResourceContents text = (McpTextResourceContents) content;
+        assertThat(text.text(), is("foo"));
+        assertThat(text.uri(), is("https://foo/foo"));
+        assertThat(text.mimeType(), is(RESOURCE_MEDIA_TYPE));
+    }
+
+    @Test
+    void readResource5() {
+        McpReadResourceResult result = client.readResource("foo://bar");
+        List<McpResourceContents> contents = result.contents();
+        assertThat(contents.size(), is(1));
+
+        McpResourceContents content = contents.getFirst();
+        assertThat(content, instanceOf(McpTextResourceContents.class));
+
+        McpTextResourceContents text = (McpTextResourceContents) content;
+        assertThat(text.text(), is("foobar"));
+        assertThat(text.uri(), is("foo://bar"));
+        assertThat(text.mimeType(), is(RESOURCE_MEDIA_TYPE));
     }
 }

--- a/tests/mcp/src/test/java/io/helidon/extensions/mcp/tests/Langchain4jStreamableMultipleResourceTemplateTest.java
+++ b/tests/mcp/src/test/java/io/helidon/extensions/mcp/tests/Langchain4jStreamableMultipleResourceTemplateTest.java
@@ -22,10 +22,8 @@ import io.helidon.webserver.testing.junit5.ServerTest;
 import dev.langchain4j.mcp.client.DefaultMcpClient;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
-import org.junit.jupiter.api.Disabled;
 
 @ServerTest
-@Disabled
 class Langchain4jStreamableMultipleResourceTemplateTest extends AbstractLangchain4jMultipleResourceTemplateTest {
 
     Langchain4jStreamableMultipleResourceTemplateTest(WebServer server) {

--- a/tests/mcp/src/test/java/io/helidon/extensions/mcp/tests/McpSdkMultipleResourceTemplateTest.java
+++ b/tests/mcp/src/test/java/io/helidon/extensions/mcp/tests/McpSdkMultipleResourceTemplateTest.java
@@ -31,12 +31,14 @@ import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.extensions.mcp.tests.MultipleResourceTemplate.RESOURCE1_URI;
 import static io.helidon.extensions.mcp.tests.MultipleResourceTemplate.RESOURCE2_URI;
 import static io.helidon.extensions.mcp.tests.MultipleResourceTemplate.RESOURCE3_URI;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -88,13 +90,52 @@ class McpSdkMultipleResourceTemplateTest {
     }
 
     @Test
-    void readResourceTemplate() {
-        try {
-            client.readResource(new McpSchema.ReadResourceRequest(RESOURCE1_URI));
-            fail("Attempt to read resource template must fail");
-        } catch (McpError e) {
-            assertThat(e.getMessage(), is("Resource does not exist"));
-            assertThat(e.getJsonRpcError().code(), is(JsonRpcError.INVALID_REQUEST));
-        }
+    void readResource1Template() {
+        var result = client.readResource(new McpSchema.ReadResourceRequest("https://foo"));
+        assertThat(result.contents().size(), is(1));
+
+        var resource = result.contents().getFirst();
+        assertThat(resource, instanceOf(McpSchema.TextResourceContents.class));
+
+        var text = (McpSchema.TextResourceContents) resource;
+        assertThat(text.text(), is("foo"));
+        assertThat(text.uri(), is("https://foo"));
+        assertThat(text.mimeType(), is(MediaTypes.TEXT_PLAIN_VALUE));
+    }
+
+    @Test
+    void readResource2Template() {
+        var result = client.readResource(new McpSchema.ReadResourceRequest("https://foo/foo1/foo2"));
+        assertThat(result.contents().size(), is(1));
+
+        var content = result.contents().getFirst();
+        assertThat(content, instanceOf(McpSchema.TextResourceContents.class));
+
+        var text = (McpSchema.TextResourceContents) content;
+        assertThat(text.text(), is("foo2"));
+        assertThat(text.uri(), is("https://foo/foo1/foo2"));
+        assertThat(text.mimeType(), is(MediaTypes.TEXT_PLAIN_VALUE));
+    }
+
+    @Test
+    void readResource3Template() {
+        var result = client.readResource(new McpSchema.ReadResourceRequest("https://foo/bar"));
+        assertThat(result.contents().size(), is(2));
+
+        var content = result.contents().getFirst();
+        assertThat(content, instanceOf(McpSchema.TextResourceContents.class));
+
+        var text = (McpSchema.TextResourceContents) content;
+        assertThat(text.text(), is("foo"));
+        assertThat(text.uri(), is("https://foo/bar"));
+        assertThat(text.mimeType(), is(MediaTypes.TEXT_PLAIN_VALUE));
+
+        var content1 = result.contents().get(1);
+        assertThat(content1, instanceOf(McpSchema.TextResourceContents.class));
+
+        var text1 = (McpSchema.TextResourceContents) content1;
+        assertThat(text1.text(), is("bar"));
+        assertThat(text1.uri(), is("https://foo/bar"));
+        assertThat(text1.mimeType(), is(MediaTypes.TEXT_PLAIN_VALUE));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/helidon-io/helidon-mcp/issues/32

This PR does not impact the API, but introduce new capabilities.

For the imperative way, templates parameters can be accessed from `McpParameters` class:

```java
request -> {
          String name = request.parameters()
                  .get("name")
                  .asString()
                  .orElse("Unknown");
}
```

For declarative, parameter can be accessed from the method parameters:

```java
@Mcp.Resource(
          uri = "https://{path}/foo",
          description = "Description",
          mediaType = MediaTypes.TEXT_PLAIN_VALUE)
String resource4(String path) {
    return path;
}
```

The examples and documentation have been also updated to reflect that change.