### PR TITLE
Improve support for prompt and resource completions

### DIFF
--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegen.java
@@ -249,7 +249,7 @@ final class McpCodegen implements CodegenExtension {
     private void addCompletionReferenceMethod(Method.Builder builder, String reference) {
         builder.name("reference")
                 .addAnnotation(Annotations.OVERRIDE)
-                .returnType(TypeNames.STRING)       // TODO
+                .returnType(TypeNames.STRING)
                 .addContentLine("return \"" + reference + "\";");
     }
 

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpTypes.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpTypes.java
@@ -54,6 +54,7 @@ final class McpTypes {
     static final TypeName MCP_RESOURCE_INTERFACE = TypeName.create("io.helidon.extensions.mcp.server.McpResource");
     static final TypeName MCP_PROMPT_CONTENTS = TypeName.create("io.helidon.extensions.mcp.server.McpPromptContents");
     static final TypeName MCP_PROMPT_ARGUMENT = TypeName.create("io.helidon.extensions.mcp.server.McpPromptArgument");
+    static final TypeName MCP_COMPLETION_TYPE = TypeName.create("io.helidon.extensions.mcp.server.McpCompletionType");
     static final TypeName MCP_COMPLETION_INTERFACE = TypeName.create("io.helidon.extensions.mcp.server.McpCompletion");
     static final TypeName MCP_TOOL_ANNOTATIONS = TypeName.create("io.helidon.extensions.mcp.server.McpToolAnnotations");
     static final TypeName MCP_RESOURCE_CONTENTS = TypeName.create("io.helidon.extensions.mcp.server.McpResourceContents");

--- a/docs/mcp-declarative/README.md
+++ b/docs/mcp-declarative/README.md
@@ -289,7 +289,22 @@ to use and explore. Bind completions to prompts (by name) or resource templates 
 @Mcp.Server
 class Server {
 
-    @Mcp.Completion("http://path")
+    @Mcp.Completion("create")
+    McpCompletionContent completionPromptArgument(McpRequest request) {
+        String value = request.parameters().get("value").asString().orElse(null);
+        return McpCompletionContents.completion(value + ".");
+    }
+}
+```
+
+The default type of completion is prompt. When creating a completion for a resource template, use the 
+`type` property in the `McpCompletion` annotation as shown next:
+
+```java
+@Mcp.Server
+class Server {
+
+    @Mcp.Completion(value = "resource/{path1}", type = McpCompletionType.RESOURCE)
     McpCompletionContent completionPromptArgument(McpRequest request) {
         String value = request.parameters().get("value").asString().orElse(null);
         return McpCompletionContents.completion(value + ".");

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -365,7 +365,8 @@ McpResourceContent binary = McpResourceContents.binaryContent(gzipBytes(), "appl
 ### Completion
 
 The `Completion` feature offers auto-suggestions for prompt arguments or resource template parameters, making the server easier 
-to use and explore. Each completion is bound to a prompt name or a URI template. Access arguments from `McpRequest`.
+to use and explore. Each completion is bound to a prompt name or a URI template. Access arguments from `McpRequest`. 
+The completion's type, either prompt or resource template, is returned by the `referenceType` method.
 
 #### Interface
 
@@ -376,6 +377,11 @@ class MyCompletion implements McpCompletion {
     @Override
     public String reference() {
         return "MyPrompt";
+    }
+
+    @Override
+    public McpCompletionType referenceType() {
+        return McpCompletionType.PROMPT;
     }
 
     @Override

--- a/examples/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/Calendar.java
+++ b/examples/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/Calendar.java
@@ -31,6 +31,8 @@ import io.helidon.extensions.mcp.server.McpException;
  * The calendar is a temporary file containing a list of created events.
  */
 final class Calendar {
+    static final String URI_TEMPLATE = "file://events/{name}";
+
     private final Path file;
     private final String uri;
     private final String uriTemplate;
@@ -39,18 +41,18 @@ final class Calendar {
         try {
             this.file = Files.createTempFile("calendar", "-calendar");
             this.uri = file.toUri().toString();
-            this.uriTemplate = "file://events/{name}";
+            this.uriTemplate = URI_TEMPLATE;
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
         }
     }
 
     String uri() {
-        return this.uri;
+        return uri;
     }
 
     String uriTemplate() {
-        return this.uriTemplate;
+        return uriTemplate;
     }
 
     String readContent() {

--- a/examples/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/CalendarEventResource.java
+++ b/examples/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/CalendarEventResource.java
@@ -27,7 +27,7 @@ import io.helidon.extensions.mcp.server.McpResourceContent;
 import io.helidon.extensions.mcp.server.McpResourceContents;
 
 /**
- * Resource that represent a calendar event registry.
+ * Resource that represents a calendar event registry.
  */
 final class CalendarEventResource implements McpResource {
     private final Calendar calendar;

--- a/examples/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/CalendarEventResourceCompletion.java
+++ b/examples/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/CalendarEventResourceCompletion.java
@@ -22,22 +22,18 @@ import io.helidon.extensions.mcp.server.McpCompletion;
 import io.helidon.extensions.mcp.server.McpCompletionContent;
 import io.helidon.extensions.mcp.server.McpCompletionContents;
 import io.helidon.extensions.mcp.server.McpCompletionType;
-import io.helidon.extensions.mcp.server.McpException;
 import io.helidon.extensions.mcp.server.McpRequest;
 
-/**
- * Auto-completion for {@link CalendarEventResourceTemplate} path.
- */
-final class ResourceCompletion implements McpCompletion {
-    private final Calendar calendar;
+import static io.helidon.extensions.mcp.examples.calendar.Calendar.URI_TEMPLATE;
 
-    ResourceCompletion(Calendar calendar) {
-        this.calendar = calendar;
-    }
+/**
+ * Auto-completion for {@link CalendarEventResourceTemplate}.
+ */
+final class CalendarEventResourceCompletion implements McpCompletion {
 
     @Override
     public String reference() {
-        return calendar.uriTemplate();
+        return URI_TEMPLATE;
     }
 
     @Override
@@ -55,18 +51,10 @@ final class ResourceCompletion implements McpCompletion {
                 .get("name")
                 .asString()
                 .orElse(null);
-        String argumentValue = request.parameters()
-                .get("value")
-                .asString()
-                .orElse(null);
 
-        if (argumentName == null || argumentValue == null) {
-            return McpCompletionContents.completion();
-        }
-        if (argumentName.equals("path")) {
+        if ("name".equals(argumentName)) {
             return McpCompletionContents.completion("events");
         }
-
-        throw new McpException("Invalid argument: " + argumentName);
+        return McpCompletionContents.completion();
     }
 }

--- a/examples/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/CreateCalendarEventPrompt.java
+++ b/examples/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/CreateCalendarEventPrompt.java
@@ -33,10 +33,11 @@ import io.helidon.extensions.mcp.server.McpRole;
  * Prompt to create a new calendar event and add it to the calendar.
  */
 final class CreateCalendarEventPrompt implements McpPrompt {
+    static final String PROMPT_NAME = "create-event";
 
     @Override
     public String name() {
-        return "create-event";
+        return PROMPT_NAME;
     }
 
     @Override

--- a/examples/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/CreateCalendarEventPromptCompletion.java
+++ b/examples/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/CreateCalendarEventPromptCompletion.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.mcp.examples.calendar;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.function.Function;
+
+import io.helidon.extensions.mcp.server.McpCompletion;
+import io.helidon.extensions.mcp.server.McpCompletionContent;
+import io.helidon.extensions.mcp.server.McpCompletionContents;
+import io.helidon.extensions.mcp.server.McpCompletionType;
+import io.helidon.extensions.mcp.server.McpRequest;
+
+/**
+ * Auto-completion for {@link CreateCalendarEventPrompt}.
+ */
+final class CreateCalendarEventPromptCompletion implements McpCompletion {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    private static final String[] FRIENDS = new String[] {
+            "Frank, Tweety", "Frank, Daffy", "Frank, Tweety, Daffy"
+    };
+
+    @Override
+    public String reference() {
+        return CreateCalendarEventPrompt.PROMPT_NAME;
+    }
+
+    @Override
+    public McpCompletionType referenceType() {
+        return McpCompletionType.PROMPT;
+    }
+
+    @Override
+    public Function<McpRequest, McpCompletionContent> completion() {
+        return this::complete;
+    }
+
+    private McpCompletionContent complete(McpRequest request) {
+        String name = request.parameters()
+                .get("name")
+                .asString()
+                .orElse(null);
+        if ("name".equals(name)) {
+            return McpCompletionContents.completion("Frank & Friends");
+        }
+
+        String date = request.parameters()
+                .get("name")
+                .asString()
+                .orElse(null);
+        if ("date".equals(date)) {
+            LocalDate today = LocalDate.now();
+            String[] dates = new String[3];
+            for (int i = 0; i < dates.length; i++) {
+                dates[i] = today.plusDays(i).format(FORMATTER);
+            }
+            return McpCompletionContents.completion(dates);
+        }
+
+        String attendees = request.parameters()
+                .get("name")
+                .asString()
+                .orElse(null);
+        if ("attendees".equals(attendees)) {
+            return McpCompletionContents.completion(FRIENDS);
+        }
+
+        // no completion
+        return McpCompletionContents.completion();
+    }
+}

--- a/examples/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/Main.java
+++ b/examples/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/Main.java
@@ -54,7 +54,8 @@ public class Main {
                         .addTool(new AddCalendarEventTool(calendar))
                         .addResource(new CalendarEventResource(calendar))
                         .addPrompt(new CreateCalendarEventPrompt())
+                        .addCompletion(new CreateCalendarEventPromptCompletion())
                         .addResource(new CalendarEventResourceTemplate(calendar))
-                        .addCompletion(new ResourceCompletion(calendar)));
+                        .addCompletion(new CalendarEventResourceCompletion()));
     }
 }

--- a/examples/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/ResourceCompletion.java
+++ b/examples/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/ResourceCompletion.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 import io.helidon.extensions.mcp.server.McpCompletion;
 import io.helidon.extensions.mcp.server.McpCompletionContent;
 import io.helidon.extensions.mcp.server.McpCompletionContents;
+import io.helidon.extensions.mcp.server.McpCompletionType;
 import io.helidon.extensions.mcp.server.McpException;
 import io.helidon.extensions.mcp.server.McpRequest;
 
@@ -37,6 +38,11 @@ final class ResourceCompletion implements McpCompletion {
     @Override
     public String reference() {
         return calendar.uriTemplate();
+    }
+
+    @Override
+    public McpCompletionType referenceType() {
+        return McpCompletionType.RESOURCE;
     }
 
     @Override

--- a/server/src/main/java/io/helidon/extensions/mcp/server/Mcp.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/Mcp.java
@@ -261,6 +261,14 @@ public final class Mcp {
          * @return uri or prompt name
          */
         String value();
+
+        /**
+         * The type of this completion. Defaults to
+         * {@link io.helidon.extensions.mcp.server.McpCompletionType#PROMPT}.
+         *
+         * @return completion type
+         */
+        McpCompletionType type() default McpCompletionType.PROMPT;
     }
 
     /**

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionBlueprint.java
@@ -18,6 +18,7 @@ package io.helidon.extensions.mcp.server;
 
 import java.util.function.Function;
 
+import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 
 /**
@@ -27,11 +28,48 @@ import io.helidon.builder.api.Prototype;
 interface McpCompletionBlueprint {
 
     /**
+     * MCP completion reference type.
+     */
+    enum ReferenceType {
+        PROMPT("ref/prompt"),
+        RESOURCE("ref/resource");
+
+        final String type;
+
+        ReferenceType(String type) {
+            this.type = type;
+        }
+
+        String type() {
+            return type;
+        }
+
+        static ReferenceType fromString(String type) {
+            for (ReferenceType b : ReferenceType.values()) {
+                if (b.type.equals(type)) {
+                    return b;
+                }
+            }
+            throw new IllegalArgumentException("Invalid completion reference type " + type);
+        }
+    }
+
+    /**
      * Completion reference must be a {@link McpPromptArgument} name or a {@link McpResource} uri template.
      *
      * @return completion reference
      */
     String reference();
+
+    /**
+     * The reference type of this completion.
+     *
+     * @return reference type
+     */
+    @Option.Default("ref/prompt")
+    default ReferenceType referenceType() {
+        return ReferenceType.PROMPT;
+    }
 
     /**
      * Complete the client argument accessible from parameters. The returned {@link McpCompletionContent}

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionBlueprint.java
@@ -18,7 +18,6 @@ package io.helidon.extensions.mcp.server;
 
 import java.util.function.Function;
 
-import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 
 /**
@@ -39,7 +38,6 @@ interface McpCompletionBlueprint {
      *
      * @return reference type
      */
-    @Option.Default("ref/prompt")
     default McpCompletionType referenceType() {
         return McpCompletionType.PROMPT;
     }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionBlueprint.java
@@ -28,33 +28,6 @@ import io.helidon.builder.api.Prototype;
 interface McpCompletionBlueprint {
 
     /**
-     * MCP completion reference type.
-     */
-    enum ReferenceType {
-        PROMPT("ref/prompt"),
-        RESOURCE("ref/resource");
-
-        final String type;
-
-        ReferenceType(String type) {
-            this.type = type;
-        }
-
-        String type() {
-            return type;
-        }
-
-        static ReferenceType fromString(String type) {
-            for (ReferenceType b : ReferenceType.values()) {
-                if (b.type.equals(type)) {
-                    return b;
-                }
-            }
-            throw new IllegalArgumentException("Invalid completion reference type " + type);
-        }
-    }
-
-    /**
      * Completion reference must be a {@link McpPromptArgument} name or a {@link McpResource} uri template.
      *
      * @return completion reference
@@ -67,8 +40,8 @@ interface McpCompletionBlueprint {
      * @return reference type
      */
     @Option.Default("ref/prompt")
-    default ReferenceType referenceType() {
-        return ReferenceType.PROMPT;
+    default McpCompletionType referenceType() {
+        return McpCompletionType.PROMPT;
     }
 
     /**

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionType.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionType.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.server;
+
+/**
+ * MCP completion reference type.
+ */
+public enum McpCompletionType {
+    PROMPT("ref/prompt"),
+    RESOURCE("ref/resource");
+
+    final String type;
+
+    McpCompletionType(String type) {
+        this.type = type;
+    }
+
+    String type() {
+        return type;
+    }
+
+    static McpCompletionType fromString(String type) {
+        for (McpCompletionType b : McpCompletionType.values()) {
+            if (b.type().equals(type)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Invalid completion reference type " + type);
+    }
+}

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonRpc.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonRpc.java
@@ -34,6 +34,7 @@ final class McpJsonRpc {
     static final JsonReaderFactory JSON_READER_FACTORY = Json.createReaderFactory(Map.of());
 
     private static final Map<String, JsonObject> CACHE = new ConcurrentHashMap<>();
+    private static final JsonObject EMPTY_OBJECT = Json.createObjectBuilder().build();
     private static final JsonObject EMPTY_OBJECT_SCHEMA = JSON_BUILDER_FACTORY.createObjectBuilder()
             .add("type", "object")
             .add("properties", JsonObject.EMPTY_JSON_OBJECT)
@@ -147,14 +148,15 @@ final class McpJsonRpc {
         return JSON_BUILDER_FACTORY.createObjectBuilder()
                 .add("protocolVersion", protocolVersion)
                 .add("capabilities", JSON_BUILDER_FACTORY.createObjectBuilder()
-                        .add("logging", JSON_BUILDER_FACTORY.createObjectBuilder())
+                        .add("logging", EMPTY_OBJECT)
                         .add("prompts", JSON_BUILDER_FACTORY.createObjectBuilder()
                                 .add("listChanged", capabilities.contains(McpCapability.PROMPT_LIST_CHANGED)))
                         .add("tools", JSON_BUILDER_FACTORY.createObjectBuilder()
                                 .add("listChanged", capabilities.contains(McpCapability.TOOL_LIST_CHANGED)))
                         .add("resources", JSON_BUILDER_FACTORY.createObjectBuilder()
                                 .add("listChanged", capabilities.contains(McpCapability.RESOURCE_LIST_CHANGED))
-                                .add("subscribe", capabilities.contains(McpCapability.RESOURCE_SUBSCRIBE))))
+                                .add("subscribe", capabilities.contains(McpCapability.RESOURCE_SUBSCRIBE)))
+                        .add("completions", EMPTY_OBJECT))
                 .add("serverInfo", JSON_BUILDER_FACTORY.createObjectBuilder()
                         .add("name", config.name())
                         .add("version", config.version()))

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpCompletionTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpCompletionTest.java
@@ -15,33 +15,20 @@
  */
 package io.helidon.extensions.mcp.server;
 
-/**
- * MCP completion reference type.
- */
-public enum McpCompletionType {
+import org.junit.jupiter.api.Test;
 
-    /**
-     * A prompt completion type.
-     */
-    PROMPT("ref/prompt"),
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-    /**
-     * A resource completion type.
-     */
-    RESOURCE("ref/resource");
+class McpCompletionTest {
 
-    private final String type;
-
-    McpCompletionType(String type) {
-        this.type = type;
-    }
-
-    static McpCompletionType fromString(String type) {
-        for (McpCompletionType b : McpCompletionType.values()) {
-            if (b.type.equals(type)) {
-                return b;
-            }
-        }
-        throw new IllegalArgumentException("Invalid completion reference type " + type);
+    @Test
+    void testDefaultMcpCompletion() {
+        McpCompletion completion = McpCompletion.builder()
+                .reference("acompletion")
+                .completion(r -> McpCompletionContents.completion(""))
+                .build();
+        assertThat(completion.reference(), is("acompletion"));
+        assertThat(completion.referenceType(), is(McpCompletionType.PROMPT));       // default
     }
 }

--- a/tests/codegen/src/test/java/io/helidon/extensions/mcp/codegen/McpTypesTest.java
+++ b/tests/codegen/src/test/java/io/helidon/extensions/mcp/codegen/McpTypesTest.java
@@ -31,6 +31,7 @@ import io.helidon.common.types.TypeName;
 import io.helidon.extensions.mcp.server.Mcp;
 import io.helidon.extensions.mcp.server.McpCompletion;
 import io.helidon.extensions.mcp.server.McpCompletionContents;
+import io.helidon.extensions.mcp.server.McpCompletionType;
 import io.helidon.extensions.mcp.server.McpFeatures;
 import io.helidon.extensions.mcp.server.McpLogger;
 import io.helidon.extensions.mcp.server.McpParameters;
@@ -119,6 +120,7 @@ class McpTypesTest {
         checkField(toCheck, checked, fields, "MCP_PROMPT_ARGUMENT", McpPromptArgument.class);
         checkField(toCheck, checked, fields, "MCP_COMPLETION_INTERFACE", McpCompletion.class);
         checkField(toCheck, checked, fields, "MCP_RESOURCE_CONTENTS", McpResourceContents.class);
+        checkField(toCheck, checked, fields, "MCP_COMPLETION_TYPE", McpCompletionType.class);
         checkField(toCheck, checked, fields, "MCP_COMPLETION_CONTENTS", McpCompletionContents.class);
         checkField(toCheck, checked, fields, "HTTP_FEATURE", HttpFeature.class);
         checkField(toCheck, checked, fields, "HELIDON_MEDIA_TYPE", MediaType.class);

--- a/tests/declarative/src/main/java/io/helidon/extensions/mcp/tests/declarative/McpCompletionsServer.java
+++ b/tests/declarative/src/main/java/io/helidon/extensions/mcp/tests/declarative/McpCompletionsServer.java
@@ -21,6 +21,7 @@ import java.util.List;
 import io.helidon.extensions.mcp.server.Mcp;
 import io.helidon.extensions.mcp.server.McpCompletionContent;
 import io.helidon.extensions.mcp.server.McpCompletionContents;
+import io.helidon.extensions.mcp.server.McpCompletionType;
 import io.helidon.extensions.mcp.server.McpFeatures;
 import io.helidon.extensions.mcp.server.McpParameters;
 import io.helidon.extensions.mcp.server.McpRequest;
@@ -66,24 +67,24 @@ class McpCompletionsServer {
         return McpCompletionContents.completion(argument);
     }
 
-    @Mcp.Completion("resource/{path1}")
+    @Mcp.Completion(value = "resource/{path1}", type = McpCompletionType.RESOURCE)
     McpCompletionContent completionResource(McpParameters parameters) {
         String argument = parameters.get("value").asString().orElse(null);
         return McpCompletionContents.completion(argument);
     }
 
-    @Mcp.Completion("resource/{path2}")
+    @Mcp.Completion(value = "resource/{path2}", type = McpCompletionType.RESOURCE)
     McpCompletionContent completionResourceArgument(String path2) {
         return McpCompletionContents.completion(path2);
     }
 
-    @Mcp.Completion("resource/{path8}")
+    @Mcp.Completion(value = "resource/{path8}", type = McpCompletionType.RESOURCE)
     McpCompletionContent completionMcpRequest(McpRequest request) {
         String argument = request.parameters().get("value").asString().orElse(null);
         return McpCompletionContents.completion(argument);
     }
 
-    @Mcp.Completion("resource/{path10}")
+    @Mcp.Completion(value = "resource/{path10}", type = McpCompletionType.RESOURCE)
     McpCompletionContent completion1StringMcpRequest(String argument, McpRequest request) {
         return McpCompletionContents.completion(argument);
     }
@@ -126,40 +127,40 @@ class McpCompletionsServer {
         return List.of(argument);
     }
 
-    @Mcp.Completion("resource/{path3}")
+    @Mcp.Completion(value = "resource/{path3}", type = McpCompletionType.RESOURCE)
     List<String> completionResourceListArgument(String path3) {
         return List.of(path3);
     }
 
-    @Mcp.Completion("resource/{path4}")
+    @Mcp.Completion(value = "resource/{path4}", type = McpCompletionType.RESOURCE)
     List<String> completionResourceListArgumentFeatures(String path4, McpFeatures features) {
         return List.of(path4);
     }
 
-    @Mcp.Completion("resource/{path5}")
+    @Mcp.Completion(value = "resource/{path5}", type = McpCompletionType.RESOURCE)
     List<String> completionResourceListParametersFeatures(McpParameters parameters, McpFeatures features) {
         String argument = parameters.get("value").asString().orElse(null);
         return List.of(argument);
     }
 
-    @Mcp.Completion("resource/{path6}")
+    @Mcp.Completion(value = "resource/{path6}", type = McpCompletionType.RESOURCE)
     List<String> completionResourceListParameters(McpParameters parameters) {
         String argument = parameters.get("value").asString().orElse(null);
         return List.of(argument);
     }
 
-    @Mcp.Completion("resource/{path7}")
+    @Mcp.Completion(value = "resource/{path7}", type = McpCompletionType.RESOURCE)
     List<String> completionResourceListFeatures(McpFeatures features) {
         return List.of("path7");
     }
 
-    @Mcp.Completion("resource/{path9}")
+    @Mcp.Completion(value = "resource/{path9}", type = McpCompletionType.RESOURCE)
     List<String> completion1McpRequest(McpRequest request) {
         String argument = request.parameters().get("value").asString().orElse(null);
         return List.of(argument);
     }
 
-    @Mcp.Completion("resource/{path9}")
+    @Mcp.Completion(value = "resource/{path9}", type = McpCompletionType.RESOURCE)
     List<String> completionStringMcpRequest(String argument, McpRequest request) {
         return List.of(argument);
     }

--- a/tests/mcp/src/main/java/io/helidon/extensions/mcp/tests/CompletionNotifications.java
+++ b/tests/mcp/src/main/java/io/helidon/extensions/mcp/tests/CompletionNotifications.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 import io.helidon.extensions.mcp.server.McpCompletion;
 import io.helidon.extensions.mcp.server.McpCompletionContent;
 import io.helidon.extensions.mcp.server.McpCompletionContents;
+import io.helidon.extensions.mcp.server.McpCompletionType;
 import io.helidon.extensions.mcp.server.McpRequest;
 import io.helidon.extensions.mcp.server.McpServerFeature;
 import io.helidon.webserver.http.HttpRouting;
@@ -40,7 +41,12 @@ class CompletionNotifications {
 
         @Override
         public String reference() {
-            return "prompt";
+            return "helidon";
+        }
+
+        @Override
+        public McpCompletionType referenceType() {
+            return McpCompletionType.PROMPT;
         }
 
         @Override


### PR DESCRIPTION
- Refactoring of prompt and resource completions
  - Use separate maps for each completion type to avoid possible name clashes
- Each completion now has to provide its type (resource or prompt)
- Several tests updated
- Calendar example slightly refactored with the addition of completions
  - Some classes were renamed for consistency