### PR TITLE
Fix subscriptions URI in Calendar example

### DIFF
--- a/examples/calendar-application/calendar-declarative/src/main/java/io/helidon/extensions/mcp/examples/calendar/declarative/Calendar.java
+++ b/examples/calendar-application/calendar-declarative/src/main/java/io/helidon/extensions/mcp/examples/calendar/declarative/Calendar.java
@@ -36,19 +36,13 @@ import io.helidon.service.registry.Service;
 final class Calendar {
 
     private final Path file;
-    private final String uri;
 
     Calendar() {
         try {
             this.file = Files.createTempFile("calendar", "-calendar");
-            this.uri = file.toUri().toString();
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
         }
-    }
-
-    String uri() {
-        return uri;
     }
 
     String readContent() {

--- a/examples/calendar-application/calendar-declarative/src/main/java/io/helidon/extensions/mcp/examples/calendar/declarative/McpCalendarServer.java
+++ b/examples/calendar-application/calendar-declarative/src/main/java/io/helidon/extensions/mcp/examples/calendar/declarative/McpCalendarServer.java
@@ -94,7 +94,7 @@ class McpCalendarServer {
         progress.send(0);
         calendar.createNewEvent(name, date, attendees);
         progress.send(50);
-        features.subscriptions().sendUpdate(calendar.uri());
+        features.subscriptions().sendUpdate(EVENTS_URI);
         progress.send(100);
 
         return List.of(McpToolContents.textContent("New event added to the calendar"));

--- a/examples/calendar-application/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/AddCalendarEventTool.java
+++ b/examples/calendar-application/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/AddCalendarEventTool.java
@@ -30,6 +30,8 @@ import io.helidon.extensions.mcp.server.McpTool;
 import io.helidon.extensions.mcp.server.McpToolContent;
 import io.helidon.extensions.mcp.server.McpToolContents;
 
+import static io.helidon.extensions.mcp.examples.calendar.Calendar.EVENTS_URI;
+
 /**
  * MCP tool to add a new Event to the calendar.
  */
@@ -111,7 +113,7 @@ final class AddCalendarEventTool implements McpTool {
 
         progress.send(50);
         calendar.createNewEvent(name, date, attendees);
-        features.subscriptions().sendUpdate(calendar.uri());
+        features.subscriptions().sendUpdate(EVENTS_URI);
         progress.send(100);
 
         return List.of(McpToolContents.textContent("New event added to the calendar"));

--- a/examples/calendar-application/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/Calendar.java
+++ b/examples/calendar-application/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/Calendar.java
@@ -36,19 +36,13 @@ final class Calendar {
     static final String EVENTS_URI_TEMPLATE = EVENTS_URI + "/{name}";
 
     private final Path file;
-    private final String uri;
 
     Calendar() {
         try {
             this.file = Files.createTempFile("calendar", "-calendar");
-            this.uri = file.toUri().toString();
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
         }
-    }
-
-    String uri() {
-        return uri;
     }
 
     String readContent() {


### PR DESCRIPTION
Fix subscriptions URI. We no longer expose the internal file URI to the clients.