### PR TITLE
Add convenient factory method to completion content

### DIFF
--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegen.java
@@ -337,7 +337,8 @@ final class McpCodegen implements CodegenExtension {
                     .addContent(element.elementName())
                     .addContent("(")
                     .addContent(params)
-                    .addContentLine(").toArray(new String[0]));")
+                    .addContentLine("));")
+                    .decreaseContentPadding()
                     .addContentLine("};");
             return;
         }

--- a/examples/calendar-application/calendar-declarative/src/main/java/io/helidon/extensions/mcp/examples/calendar/declarative/McpCalendarServer.java
+++ b/examples/calendar-application/calendar-declarative/src/main/java/io/helidon/extensions/mcp/examples/calendar/declarative/McpCalendarServer.java
@@ -147,7 +147,7 @@ class McpCalendarServer {
                 .stream()
                 .filter(name -> name.contains(nameValue))
                 .toList();
-        return McpCompletionContents.completion(values.toArray(new String[0]));
+        return McpCompletionContents.completion(values);
     }
 
     // -- Prompts -------------------------------------------------------------

--- a/examples/calendar-application/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/CalendarEventResourceCompletion.java
+++ b/examples/calendar-application/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/CalendarEventResourceCompletion.java
@@ -59,6 +59,6 @@ final class CalendarEventResourceCompletion implements McpCompletion {
                 .stream()
                 .filter(name -> name.contains(nameValue))
                 .toList();
-        return McpCompletionContents.completion(values.toArray(new String[0]));
+        return McpCompletionContents.completion(values);
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionContents.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionContents.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.helidon.extensions.mcp.server;
 
 import java.util.List;
@@ -27,13 +26,25 @@ public final class McpCompletionContents {
     }
 
     /**
-     * Create a completion content from the provided list of string.
+     * Create a completion content from the provided list of string. The maximum
+     * number of suggestion cannot exceed 100.
      *
      * @param values completion values
      * @return completion content
      */
     public static McpCompletionContent completion(String... values) {
         return new McpCompletionContentImpl(List.of(values));
+    }
+
+    /**
+     * Create a completion content from provided list of string. The maximum
+     * number of suggestion cannot exceed 100.
+     *
+     * @param values completion values
+     * @return completion content
+     */
+    public static McpCompletionContent completion(List<String> values) {
+        return new McpCompletionContentImpl(values);
     }
 
     /**

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpCompletionContentTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpCompletionContentTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.server;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class McpCompletionContentTest {
+
+    @Test
+    void testDefaultMcpCompletion() {
+        var content = McpCompletionContents.completion(List.of());
+        assertThat(content.total(), is(0));
+        assertThat(content.hasMore(), is(false));
+        assertThat(content.values(), is(List.of()));
+    }
+
+    @Test
+    void testDefaultArrayMcpCompletion() {
+        var content = McpCompletionContents.completion();
+        assertThat(content.total(), is(0));
+        assertThat(content.hasMore(), is(false));
+        assertThat(content.values(), is(List.of()));
+    }
+
+    @Test
+    void testMcpCompletion() {
+        var content = McpCompletionContents.completion(List.of("foo"));
+        assertThat(content.total(), is(1));
+        assertThat(content.hasMore(), is(false));
+        assertThat(content.values(), is(List.of("foo")));
+    }
+
+    @Test
+    void testArrayMcpCompletion() {
+        var content = McpCompletionContents.completion("foo");
+        assertThat(content.total(), is(1));
+        assertThat(content.hasMore(), is(false));
+        assertThat(content.values(), is(List.of("foo")));
+    }
+}


### PR DESCRIPTION
Fixes #88 

Add a new factory method to create `McpCompletionContent` using list of `String`. This also clean up the code generated for declarative as a side effect.