### PR TITLE
Update poms version to 2.0.0-SNAPSHOT

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,14 +23,14 @@
     <parent>
         <groupId>io.helidon.extensions.mcp</groupId>
         <artifactId>helidon4-extensions-mcp-project</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>helidon4-extensions-mcp-bom</artifactId>
     <packaging>pom</packaging>
     <name>Helidon 4 Extensions MCP BOM</name>
 
     <properties>
-        <helidon.mcp.version>1.0.0-SNAPSHOT</helidon.mcp.version>
+        <helidon.mcp.version>2.0.0-SNAPSHOT</helidon.mcp.version>
     </properties>
 
     <dependencyManagement>

--- a/codegen/pom.xml
+++ b/codegen/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.extensions.mcp</groupId>
         <artifactId>helidon4-extensions-mcp-project</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/calendar-application/calendar-declarative/pom.xml
+++ b/examples/calendar-application/calendar-declarative/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@
 
     <groupId>io.helidon.extensions.mcp.examples</groupId>
     <artifactId>helidon4-extensions-mcp-examples-calendar-declarative</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>Helidon 4 Extensions MCP Calendar Example Declarative</name>
 
     <properties>

--- a/examples/calendar-application/calendar/pom.xml
+++ b/examples/calendar-application/calendar/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@
 
     <groupId>io.helidon.examples.extensions.mcp</groupId>
     <artifactId>helidon4-extensions-mcp-examples-calendar</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>Helidon 4 Extensions MCP Calendar Example</name>
 
     <properties>

--- a/examples/calendar-application/pom.xml
+++ b/examples/calendar-application/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.extensions.mcp.examples</groupId>
         <artifactId>helidon4-extensions-mcp-examples-project</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.extensions.mcp</groupId>
         <artifactId>helidon4-extensions-mcp-project</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/secured-server/pom.xml
+++ b/examples/secured-server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@
 
     <groupId>io.helidon.examples.extensions.mcp</groupId>
     <artifactId>helidon4-extensions-mcp-examples-secured-server</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>Helidon 4 Extensions MCP Secured Server Example</name>
 
     <properties>

--- a/examples/weather-application/mcp-client/pom.xml
+++ b/examples/weather-application/mcp-client/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@
 
     <groupId>io.helidon.examples.extensions.mcp</groupId>
     <artifactId>helidon4-extensions-mcp-examples-weather-client</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>Helidon 4 Extensions MCP Weather Client Example</name>
 
     <properties>

--- a/examples/weather-application/mcp-server-declarative/pom.xml
+++ b/examples/weather-application/mcp-server-declarative/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@
 
     <groupId>io.helidon.examples.extensions.mcp</groupId>
     <artifactId>helidon4-extensions-mcp-examples-weather-declarative</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>Helidon 4 Extensions MCP Weather Declarative Example</name>
 
     <properties>

--- a/examples/weather-application/mcp-server/pom.xml
+++ b/examples/weather-application/mcp-server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@
 
     <groupId>io.helidon.examples.extensions.mcp</groupId>
     <artifactId>helidon4-extensions-mcp-examples-weather</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>Helidon 4 Extensions MCP Weather Server Example</name>
 
     <properties>

--- a/examples/weather-application/pom.xml
+++ b/examples/weather-application/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.extensions.mcp.examples</groupId>
         <artifactId>helidon4-extensions-mcp-examples-project</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.helidon.extensions.mcp</groupId>
     <artifactId>helidon4-extensions-mcp-project</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Helidon 4 MCP Extension</name>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.extensions.mcp</groupId>
         <artifactId>helidon4-extensions-mcp-project</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/2024-11-05/mcp/pom.xml
+++ b/tests/2024-11-05/mcp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.extensions.mcp</groupId>
         <artifactId>helidon4-extensions-mcp-2024-11-05-tests-project</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/2024-11-05/pom.xml
+++ b/tests/2024-11-05/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.extensions.mcp</groupId>
         <artifactId>helidon4-extensions-mcp-tests-project</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/2025-03-26/mcp/pom.xml
+++ b/tests/2025-03-26/mcp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.extensions.mcp</groupId>
         <artifactId>helidon4-extensions-mcp-2025-03-26-tests-project</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/2025-03-26/pom.xml
+++ b/tests/2025-03-26/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.extensions.mcp</groupId>
         <artifactId>helidon4-extensions-mcp-tests-project</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/2025-06-18/declarative/pom.xml
+++ b/tests/2025-06-18/declarative/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.extensions.mcp</groupId>
         <artifactId>helidon4-extensions-mcp-2025-06-18-tests-project</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/2025-06-18/mcp/pom.xml
+++ b/tests/2025-06-18/mcp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.extensions.mcp</groupId>
         <artifactId>helidon4-extensions-mcp-2025-06-18-tests-project</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/2025-06-18/pom.xml
+++ b/tests/2025-06-18/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.extensions.mcp</groupId>
         <artifactId>helidon4-extensions-mcp-tests-project</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/codegen/pom.xml
+++ b/tests/codegen/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.extensions.mcp</groupId>
         <artifactId>helidon4-extensions-mcp-tests-project</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.extensions.mcp</groupId>
         <artifactId>helidon4-extensions-mcp-project</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Because of future backward incompatible changes to support `2025-06-18` MCP specification, introducing Helidon MCP 2.x. A new branch `helidon-mcp-1.x` was created for bug fixes of user using Helidon MCP 1.x.