### PR TITLE
Add context field to CompletionRequest

### DIFF
--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCompletionCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCompletionCodegen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.MCP_TYPES;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.createClassName;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.getElementsWithAnnotation;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isMcpType;
-import static io.helidon.extensions.mcp.codegen.McpTypes.FUNCTION_REQUEST_COMPLETION_CONTENT;
+import static io.helidon.extensions.mcp.codegen.McpTypes.FUNCTION_COMPLETION_REQUEST_COMPLETION_CONTENT;
 import static io.helidon.extensions.mcp.codegen.McpTypes.LIST_STRING;
 import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_COMPLETION;
 import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_COMPLETION_CONTENT;
@@ -92,7 +92,7 @@ class McpCompletionCodegen {
         List<String> parameters = new ArrayList<>();
 
         builder.name("completion")
-                .returnType(returned -> returned.type(FUNCTION_REQUEST_COMPLETION_CONTENT))
+                .returnType(returned -> returned.type(FUNCTION_COMPLETION_REQUEST_COMPLETION_CONTENT))
                 .addAnnotation(Annotations.OVERRIDE);
         builder.addContentLine("return request -> {");
 
@@ -104,7 +104,7 @@ class McpCompletionCodegen {
                 parameters.add(parameter.elementName());
                 builder.addContent("var ")
                         .addContent(parameter.elementName())
-                        .addContentLine(" = request.parameters().get(\"value\").asString().orElse(\"\");");
+                        .addContentLine(" = request.value();");
                 continue;
             }
             throw new CodegenException(String.format("Wrong parameter type for method: %s. Supported types are: %s, or String.",

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpTypes.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpTypes.java
@@ -74,6 +74,7 @@ final class McpTypes {
     static final TypeName MCP_TOOL_ANNOTATIONS = TypeName.create("io.helidon.extensions.mcp.server.McpToolAnnotations");
     static final TypeName MCP_RESOURCE_CONTENT = TypeName.create("io.helidon.extensions.mcp.server.McpResourceContent");
     static final TypeName MCP_RESOURCE_CONTENTS = TypeName.create("io.helidon.extensions.mcp.server.McpResourceContents");
+    static final TypeName MCP_COMPLETION_REQUEST = TypeName.create("io.helidon.extensions.mcp.server.McpCompletionRequest");
     static final TypeName MCP_COMPLETION_CONTENT = TypeName.create("io.helidon.extensions.mcp.server.McpCompletionContent");
     static final TypeName MCP_COMPLETION_CONTENTS = TypeName.create("io.helidon.extensions.mcp.server.McpCompletionContents");
     static final TypeName MCP_RESOURCE_SUBSCRIBER_INTERFACE =
@@ -94,11 +95,10 @@ final class McpTypes {
     static final TypeName LIST_MCP_PROMPT_ARGUMENT = TypeName.builder(LIST)
             .addTypeArgument(MCP_PROMPT_ARGUMENT)
             .build();
-    static final TypeName FUNCTION_REQUEST_COMPLETION_CONTENT =
-            ResolvedType.create(TypeName.builder(FUNCTION)
-                                        .addTypeArguments(List.of(MCP_REQUEST,
-                                                                  MCP_COMPLETION_CONTENT))
-                                        .build()).type();
+    static final TypeName FUNCTION_COMPLETION_REQUEST_COMPLETION_CONTENT = TypeName.builder(FUNCTION)
+            .addTypeArgument(MCP_COMPLETION_REQUEST)
+            .addTypeArgument(MCP_COMPLETION_CONTENT)
+            .build();
     static final TypeName LIST_MCP_RESOURCE_CONTENT = ResolvedType.create(TypeName.builder(LIST)
                                                                                   .addTypeArgument(MCP_RESOURCE_CONTENT)
                                                                                   .build()).type();

--- a/examples/calendar-application/calendar-declarative/src/main/java/io/helidon/extensions/mcp/examples/calendar/declarative/McpCalendarServer.java
+++ b/examples/calendar-application/calendar-declarative/src/main/java/io/helidon/extensions/mcp/examples/calendar/declarative/McpCalendarServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -178,7 +178,7 @@ class McpCalendarServer {
     @Mcp.Completion(value = "createEventPrompt",
                     type = McpCompletionType.PROMPT)
     McpCompletionContent createEventPromptCompletion(McpParameters parameters) {
-        String promptName = parameters.get("name").asString().orElse(null);
+        String promptName = parameters.get("argument").get("name").asString().orElse(null);
         if ("name".equals(promptName)) {
             return McpCompletionContents.completion("Frank & Friends");
         }

--- a/examples/calendar-application/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/CalendarEventResourceCompletion.java
+++ b/examples/calendar-application/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/CalendarEventResourceCompletion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import java.util.function.Function;
 import io.helidon.extensions.mcp.server.McpCompletion;
 import io.helidon.extensions.mcp.server.McpCompletionContent;
 import io.helidon.extensions.mcp.server.McpCompletionContents;
+import io.helidon.extensions.mcp.server.McpCompletionRequest;
 import io.helidon.extensions.mcp.server.McpCompletionType;
-import io.helidon.extensions.mcp.server.McpRequest;
 
 /**
  * Auto-completion for {@link CalendarEventResourceTemplate}.
@@ -46,18 +46,14 @@ final class CalendarEventResourceCompletion implements McpCompletion {
     }
 
     @Override
-    public Function<McpRequest, McpCompletionContent> completion() {
+    public Function<McpCompletionRequest, McpCompletionContent> completion() {
         return this::complete;
     }
 
-    private McpCompletionContent complete(McpRequest request) {
-        String nameValue = request.parameters()
-                .get("value")
-                .asString()
-                .orElse("");
+    private McpCompletionContent complete(McpCompletionRequest request) {
         List<String> values = calendar.readEventNames()
                 .stream()
-                .filter(name -> name.contains(nameValue))
+                .filter(name -> name.contains(request.value()))
                 .toList();
         return McpCompletionContents.completion(values);
     }

--- a/examples/calendar-application/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/CreateCalendarEventPromptCompletion.java
+++ b/examples/calendar-application/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/CreateCalendarEventPromptCompletion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@ import java.util.function.Function;
 import io.helidon.extensions.mcp.server.McpCompletion;
 import io.helidon.extensions.mcp.server.McpCompletionContent;
 import io.helidon.extensions.mcp.server.McpCompletionContents;
+import io.helidon.extensions.mcp.server.McpCompletionRequest;
 import io.helidon.extensions.mcp.server.McpCompletionType;
-import io.helidon.extensions.mcp.server.McpRequest;
 
 /**
  * Auto-completion for {@link CreateCalendarEventPrompt}.
@@ -47,15 +47,12 @@ final class CreateCalendarEventPromptCompletion implements McpCompletion {
     }
 
     @Override
-    public Function<McpRequest, McpCompletionContent> completion() {
+    public Function<McpCompletionRequest, McpCompletionContent> completion() {
         return this::complete;
     }
 
-    private McpCompletionContent complete(McpRequest request) {
-        String promptName = request.parameters()
-                .get("name")
-                .asString()
-                .orElse(null);
+    private McpCompletionContent complete(McpCompletionRequest request) {
+        String promptName = request.name();
         if ("name".equals(promptName)) {
             return McpCompletionContents.completion("Frank & Friends");
         }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,15 @@ package io.helidon.extensions.mcp.server;
 
 import java.util.function.Function;
 
+import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 
 /**
  * Configuration of an MCP Completion.
  */
 @Prototype.Blueprint
+@Prototype.IncludeDefaultMethods
 interface McpCompletionBlueprint {
-
     /**
      * Completion reference must be a {@link McpPromptArgument} name or a {@link McpResource} uri template.
      *
@@ -38,6 +39,7 @@ interface McpCompletionBlueprint {
      *
      * @return reference type
      */
+    @Option.Default("PROMPT")
     default McpCompletionType referenceType() {
         return McpCompletionType.PROMPT;
     }
@@ -48,5 +50,5 @@ interface McpCompletionBlueprint {
      *
      * @return completion suggestion
      */
-    Function<McpRequest, McpCompletionContent> completion();
+    Function<McpCompletionRequest, McpCompletionContent> completion();
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionContext.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionContext.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.server;
+
+import java.util.Map;
+
+/**
+ * Completion context.
+ */
+public sealed interface McpCompletionContext permits McpCompletionContextImpl {
+    /**
+     * Previously resolved completion arguments.
+     *
+     * @return arguments
+     */
+    Map<String, String> arguments();
+}

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionContextImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionContextImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.server;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+final class McpCompletionContextImpl implements McpCompletionContext {
+    private final Map<String, String> arguments;
+
+    McpCompletionContextImpl(McpParameters parameters) {
+        this.arguments = parameters.get("arguments").as(this::parse).orElseGet(HashMap::new);
+    }
+
+    @Override
+    public Map<String, String> arguments() {
+        return arguments;
+    }
+
+    private Map<String, String> parse(McpParameters parameters) {
+        return parameters.asMap()
+                .orElseGet(HashMap::new)
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                                          e -> e.getValue().asString().orElse("")));
+    }
+}

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionRequest.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.server;
+
+import java.util.Optional;
+
+/**
+ * Completion request.
+ */
+public sealed interface McpCompletionRequest extends McpRequest permits McpCompletionRequestImpl {
+    /**
+     * Completion request name.
+     *
+     * @return name
+     */
+    String name();
+
+    /**
+     * Completion request value.
+     *
+     * @return value
+     */
+    String value();
+
+    /**
+     * Completion context.
+     *
+     * @return context
+     */
+    Optional<McpCompletionContext> context();
+}

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionRequestImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionRequestImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.server;
+
+import java.util.Optional;
+
+import io.helidon.common.context.Context;
+
+final class McpCompletionRequestImpl implements McpCompletionRequest {
+    private final String name;
+    private final String value;
+    private final McpRequest request;
+    private final McpCompletionContext context;
+
+    McpCompletionRequestImpl(McpRequest request) {
+        McpParameters parameters = request.parameters();
+        this.request = request;
+        this.name = parameters.get("argument").get("name").asString()
+                .orElseThrow(() -> new McpInternalException("Completion request is missing parameter 'name'"));
+        this.value = parameters.get("argument").get("value").asString()
+                .orElseThrow(() -> new McpInternalException("Completion request is missing parameter 'value'"));
+        this.context = parameters.get("context").as(McpCompletionContextImpl::new).orElse(null);
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public Optional<McpCompletionContext> context() {
+        return Optional.ofNullable(context);
+    }
+
+    @Override
+    public McpParameters parameters() {
+        return request.parameters();
+    }
+
+    @Override
+    public McpFeatures features() {
+        return request.features();
+    }
+
+    @Override
+    public String protocolVersion() {
+        return request.protocolVersion();
+    }
+
+    @Override
+    public Context sessionContext() {
+        return request.sessionContext();
+    }
+
+    @Override
+    public Context requestContext() {
+        return request.requestContext();
+    }
+}

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpParameters.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,9 @@
 package io.helidon.extensions.mcp.server;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
@@ -279,6 +281,23 @@ public final class McpParameters {
             return empty();
         }
         throw new IllegalStateException("Cannot get " + value.getValueType() + "as a list");
+    }
+
+    /**
+     * Get optional value of the parameter as a map.
+     *
+     * @return optional map value
+     */
+    public OptionalValue<Map<String, McpParameters>> asMap() {
+        if (value instanceof JsonObject object) {
+            Map<String, McpParameters> map = new HashMap<>();
+            object.forEach((key, value) -> map.put(key, new McpParameters(params, value, key + "-" + value)));
+            return OptionalValue.create(MAPPERS, key, map);
+        }
+        if (value == JsonValue.NULL) {
+            return empty();
+        }
+        throw new IllegalStateException("Cannot get " + value.getValueType() + "as a map");
     }
 
     /**

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
@@ -718,14 +718,14 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             };
             McpFeatures features = session.createFeatures(requestId, req, res);
             session.beforeFeatureRequest(parameters, requestId);
-            McpCompletionContent result = completion.completion()
-                    .apply(McpRequest.builder()
-                                   .parameters(parameters.get("argument"))
-                                   .features(features)
-                                   .protocolVersion(session.protocolVersion().text())
-                                   .sessionContext(session.context())
-                                   .requestContext(req.context())
-                                   .build());
+            McpRequest request = McpRequest.builder()
+                    .parameters(parameters)
+                    .features(features)
+                    .protocolVersion(session.protocolVersion().text())
+                    .sessionContext(session.context())
+                    .requestContext(req.context())
+                    .build();
+            McpCompletionContent result = completion.completion().apply(new McpCompletionRequestImpl(request));
             session.afterFeatureRequest(parameters, requestId);
             var payload = session.serializer().toJson(result);
             res.result(payload);

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpParametersTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpParametersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,25 +16,29 @@
 
 package io.helidon.extensions.mcp.server;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import io.helidon.common.mapper.OptionalValue;
 import io.helidon.jsonrpc.core.JsonRpcParams;
 
-import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonStructure;
+import jakarta.json.spi.JsonProvider;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 class McpParametersTest {
+    private static final JsonProvider JSON_PROVIDER = JsonProvider.provider();
 
     @Test
     void testSimpleString() {
-        JsonObject object = Json.createObjectBuilder()
+        JsonObject object = JSON_PROVIDER.createObjectBuilder()
                 .add("foo", "bar")
                 .build();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
@@ -45,7 +49,7 @@ class McpParametersTest {
 
     @Test
     void testSimpleBoolean() {
-        JsonObject object = Json.createObjectBuilder()
+        JsonObject object = JSON_PROVIDER.createObjectBuilder()
                 .add("foo", true)
                 .build();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
@@ -56,7 +60,7 @@ class McpParametersTest {
 
     @Test
     void testSimpleByte() {
-        JsonObject object = Json.createObjectBuilder()
+        JsonObject object = JSON_PROVIDER.createObjectBuilder()
                 .add("foo", 1)
                 .build();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
@@ -67,7 +71,7 @@ class McpParametersTest {
 
     @Test
     void testSimpleShort() {
-        JsonObject object = Json.createObjectBuilder()
+        JsonObject object = JSON_PROVIDER.createObjectBuilder()
                 .add("foo", 1)
                 .build();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
@@ -78,7 +82,7 @@ class McpParametersTest {
 
     @Test
     void testSimpleInteger() {
-        JsonObject object = Json.createObjectBuilder()
+        JsonObject object = JSON_PROVIDER.createObjectBuilder()
                 .add("foo", 1)
                 .build();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
@@ -89,7 +93,7 @@ class McpParametersTest {
 
     @Test
     void testSimpleLong() {
-        JsonObject object = Json.createObjectBuilder()
+        JsonObject object = JSON_PROVIDER.createObjectBuilder()
                 .add("foo", 1L)
                 .build();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
@@ -100,7 +104,7 @@ class McpParametersTest {
 
     @Test
     void testSimpleDouble() {
-        JsonObject object = Json.createObjectBuilder()
+        JsonObject object = JSON_PROVIDER.createObjectBuilder()
                 .add("foo", 1.0D)
                 .build();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
@@ -111,7 +115,7 @@ class McpParametersTest {
 
     @Test
     void testSimpleFloat() {
-        JsonObject object = Json.createObjectBuilder()
+        JsonObject object = JSON_PROVIDER.createObjectBuilder()
                 .add("foo", 1.0F)
                 .build();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
@@ -122,8 +126,8 @@ class McpParametersTest {
 
     @Test
     void testSimpleList() {
-        JsonObject object = Json.createObjectBuilder()
-                .add("foo", Json.createArrayBuilder()
+        JsonObject object = JSON_PROVIDER.createObjectBuilder()
+                .add("foo", JSON_PROVIDER.createArrayBuilder()
                         .add("foo1")
                         .add("foo2"))
                 .build();
@@ -141,8 +145,8 @@ class McpParametersTest {
 
     @Test
     void testNestedObject() {
-        JsonObject object = Json.createObjectBuilder()
-                .add("person", Json.createObjectBuilder()
+        JsonObject object = JSON_PROVIDER.createObjectBuilder()
+                .add("person", JSON_PROVIDER.createObjectBuilder()
                         .add("name", "Frank")
                         .add("age", 10))
                 .build();
@@ -157,7 +161,7 @@ class McpParametersTest {
 
     @Test
     void testCasting() {
-        JsonStructure object = Json.createObjectBuilder()
+        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
                 .add("foo", "value1")
                 .add("bar", "value2")
                 .build();
@@ -171,8 +175,8 @@ class McpParametersTest {
 
     @Test
     void testNestedCasting() {
-        JsonStructure object = Json.createObjectBuilder()
-                .add("foo", Json.createObjectBuilder()
+        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
+                .add("foo", JSON_PROVIDER.createObjectBuilder()
                         .add("foo", "value1")
                         .add("bar", "value2"))
                 .build();
@@ -186,7 +190,7 @@ class McpParametersTest {
 
     @Test
     void testIsNumberInt() {
-        JsonStructure object = Json.createObjectBuilder()
+        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
                 .add("foo", 1)
                 .build();
         JsonRpcParams params = JsonRpcParams.create(object);
@@ -198,7 +202,7 @@ class McpParametersTest {
 
     @Test
     void testIsNumberDouble() {
-        JsonStructure object = Json.createObjectBuilder()
+        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
                 .add("foo", 1.0)
                 .build();
         JsonRpcParams params = JsonRpcParams.create(object);
@@ -210,7 +214,7 @@ class McpParametersTest {
 
     @Test
     void testIsNumberString() {
-        JsonStructure object = Json.createObjectBuilder()
+        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
                 .add("foo", "notANumber")
                 .build();
         JsonRpcParams params = JsonRpcParams.create(object);
@@ -222,7 +226,7 @@ class McpParametersTest {
 
     @Test
     void testIsString() {
-        JsonStructure object = Json.createObjectBuilder()
+        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
                 .add("foo", "notANumber")
                 .build();
         JsonRpcParams params = JsonRpcParams.create(object);
@@ -234,7 +238,7 @@ class McpParametersTest {
 
     @Test
     void testIsStringNumber() {
-        JsonStructure object = Json.createObjectBuilder()
+        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
                 .add("foo", 1)
                 .build();
         JsonRpcParams params = JsonRpcParams.create(object);
@@ -247,7 +251,7 @@ class McpParametersTest {
     @Test
     void testIfPresent() {
         AtomicBoolean present = new AtomicBoolean(false);
-        JsonStructure object = Json.createObjectBuilder()
+        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
                 .add("foo", 1)
                 .build();
         JsonRpcParams params = JsonRpcParams.create(object);
@@ -259,7 +263,7 @@ class McpParametersTest {
     @Test
     void testIfNotPresent() {
         AtomicBoolean present = new AtomicBoolean(false);
-        JsonStructure object = Json.createObjectBuilder()
+        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
                 .add("foo", 1)
                 .build();
         JsonRpcParams params = JsonRpcParams.create(object);
@@ -270,7 +274,7 @@ class McpParametersTest {
 
     @Test
     void testIfPresentNullPointerException() {
-        JsonStructure object = Json.createObjectBuilder()
+        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
                 .add("foo", 1)
                 .build();
         JsonRpcParams params = JsonRpcParams.create(object);
@@ -281,6 +285,53 @@ class McpParametersTest {
         } catch (NullPointerException exception) {
             assertThat(exception.getMessage(), is("action is null"));
         }
+    }
+
+    @Test
+    void testAsMap() {
+        JsonObject object = JSON_PROVIDER.createObjectBuilder()
+                .add("foo", "foo")
+                .add("bar", "bar")
+                .build();
+        JsonRpcParams params = JsonRpcParams.create(object);
+        McpParameters parameters = new McpParameters(params, object);
+
+        Map<String, McpParameters> map = parameters.asMap()
+                .orElseGet(HashMap::new);
+        assertThat(map.size(), is(2));
+        assertThat(map.containsKey("foo"), is(true));
+        assertThat(map.containsKey("bar"), is(true));
+
+        McpParameters foo = map.get("foo");
+        assertThat(foo.isPresent(), is(true));
+        assertThat(foo.asString().orElse(""), is("foo"));
+
+        McpParameters bar = map.get("bar");
+        assertThat(bar.isPresent(), is(true));
+        assertThat(bar.asString().orElse(""), is("bar"));
+    }
+
+    @Test
+    void testAsStringMap() {
+        JsonObject object = JSON_PROVIDER.createObjectBuilder()
+                .add("foo", "foo")
+                .add("bar", "bar")
+                .build();
+        JsonRpcParams params = JsonRpcParams.create(object);
+        McpParameters parameters = new McpParameters(params, object);
+
+        Map<String, String> map = parameters.asMap()
+                .orElseGet(HashMap::new)
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                                          e -> e.getValue().asString().orElse("")));
+
+        assertThat(map.size(), is(2));
+        assertThat(map.containsKey("foo"), is(true));
+        assertThat(map.containsKey("bar"), is(true));
+        assertThat(map.get("foo"), is("foo"));
+        assertThat(map.get("bar"), is("bar"));
     }
 
     public static class Foo {

--- a/tests/2024-11-05/mcp/src/main/java/io/helidon/extensions/mcp/tests/CompletionNotifications.java
+++ b/tests/2024-11-05/mcp/src/main/java/io/helidon/extensions/mcp/tests/CompletionNotifications.java
@@ -22,8 +22,8 @@ import java.util.function.Function;
 import io.helidon.extensions.mcp.server.McpCompletion;
 import io.helidon.extensions.mcp.server.McpCompletionContent;
 import io.helidon.extensions.mcp.server.McpCompletionContents;
+import io.helidon.extensions.mcp.server.McpCompletionRequest;
 import io.helidon.extensions.mcp.server.McpCompletionType;
-import io.helidon.extensions.mcp.server.McpRequest;
 import io.helidon.extensions.mcp.server.McpServerFeature;
 import io.helidon.webserver.http.HttpRouting;
 
@@ -50,13 +50,12 @@ class CompletionNotifications {
         }
 
         @Override
-        public Function<McpRequest, McpCompletionContent> completion() {
+        public Function<McpCompletionRequest, McpCompletionContent> completion() {
             return this::complete;
         }
 
-        McpCompletionContent complete(McpRequest request) {
-            String argument = request.parameters().get("value").asString().get();
-            if (Objects.equals(argument, "Hel")) {
+        McpCompletionContent complete(McpCompletionRequest request) {
+            if (Objects.equals(request.value(), "Hel")) {
                 return McpCompletionContents.completion("Helidon");
             }
             return McpCompletionContents.completion();

--- a/tests/2024-11-05/mcp/src/main/java/io/helidon/extensions/mcp/tests/McpExceptionServer.java
+++ b/tests/2024-11-05/mcp/src/main/java/io/helidon/extensions/mcp/tests/McpExceptionServer.java
@@ -23,6 +23,7 @@ import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.extensions.mcp.server.McpCompletion;
 import io.helidon.extensions.mcp.server.McpCompletionContent;
+import io.helidon.extensions.mcp.server.McpCompletionRequest;
 import io.helidon.extensions.mcp.server.McpException;
 import io.helidon.extensions.mcp.server.McpPrompt;
 import io.helidon.extensions.mcp.server.McpPromptArgument;
@@ -196,7 +197,7 @@ class McpExceptionServer {
         }
 
         @Override
-        public Function<McpRequest, McpCompletionContent> completion() {
+        public Function<McpCompletionRequest, McpCompletionContent> completion() {
             return request -> {
                 throw new McpException(INTERNAL_ERROR, MESSAGE);
             };
@@ -210,7 +211,7 @@ class McpExceptionServer {
         }
 
         @Override
-        public Function<McpRequest, McpCompletionContent> completion() {
+        public Function<McpCompletionRequest, McpCompletionContent> completion() {
             return request -> {
                 request.features().logger().info("Switching to the SSE channel");
                 throw new McpException(INTERNAL_ERROR, MESSAGE);

--- a/tests/2025-03-26/mcp/src/main/java/io/helidon/extensions/mcp/tests/CompletionNotifications.java
+++ b/tests/2025-03-26/mcp/src/main/java/io/helidon/extensions/mcp/tests/CompletionNotifications.java
@@ -22,8 +22,8 @@ import java.util.function.Function;
 import io.helidon.extensions.mcp.server.McpCompletion;
 import io.helidon.extensions.mcp.server.McpCompletionContent;
 import io.helidon.extensions.mcp.server.McpCompletionContents;
+import io.helidon.extensions.mcp.server.McpCompletionRequest;
 import io.helidon.extensions.mcp.server.McpCompletionType;
-import io.helidon.extensions.mcp.server.McpRequest;
 import io.helidon.extensions.mcp.server.McpServerFeature;
 import io.helidon.webserver.http.HttpRouting;
 
@@ -50,13 +50,12 @@ class CompletionNotifications {
         }
 
         @Override
-        public Function<McpRequest, McpCompletionContent> completion() {
+        public Function<McpCompletionRequest, McpCompletionContent> completion() {
             return this::complete;
         }
 
-        McpCompletionContent complete(McpRequest request) {
-            String argument = request.parameters().get("value").asString().get();
-            if (Objects.equals(argument, "Hel")) {
+        McpCompletionContent complete(McpCompletionRequest request) {
+            if (Objects.equals(request.value(), "Hel")) {
                 return McpCompletionContents.completion("Helidon");
             }
             return McpCompletionContents.completion();

--- a/tests/2025-03-26/mcp/src/main/java/io/helidon/extensions/mcp/tests/McpExceptionServer.java
+++ b/tests/2025-03-26/mcp/src/main/java/io/helidon/extensions/mcp/tests/McpExceptionServer.java
@@ -23,6 +23,7 @@ import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.extensions.mcp.server.McpCompletion;
 import io.helidon.extensions.mcp.server.McpCompletionContent;
+import io.helidon.extensions.mcp.server.McpCompletionRequest;
 import io.helidon.extensions.mcp.server.McpException;
 import io.helidon.extensions.mcp.server.McpPrompt;
 import io.helidon.extensions.mcp.server.McpPromptArgument;
@@ -196,7 +197,7 @@ class McpExceptionServer {
         }
 
         @Override
-        public Function<McpRequest, McpCompletionContent> completion() {
+        public Function<McpCompletionRequest, McpCompletionContent> completion() {
             return request -> {
                 throw new McpException(INTERNAL_ERROR, MESSAGE);
             };
@@ -210,7 +211,7 @@ class McpExceptionServer {
         }
 
         @Override
-        public Function<McpRequest, McpCompletionContent> completion() {
+        public Function<McpCompletionRequest, McpCompletionContent> completion() {
             return request -> {
                 request.features().logger().info("Switching to the SSE channel");
                 throw new McpException(INTERNAL_ERROR, MESSAGE);

--- a/tests/2025-03-26/mcp/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableErrorServerTest.java
+++ b/tests/2025-03-26/mcp/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableErrorServerTest.java
@@ -109,7 +109,8 @@ class McpSdkStreamableErrorServerTest extends AbstractMcpSdkTest {
     void testErrorCompletion(String name) {
         try {
             var reference = new McpSchema.PromptReference(name);
-            var request = new McpSchema.CompleteRequest(reference, null);
+            var argument = new McpSchema.CompleteRequest.CompleteArgument("foo", "bar");
+            var request = new McpSchema.CompleteRequest(reference, argument);
             client().completeCompletion(request);
             assertThat("Completion execution must throw an exception", true, is(false));
         } catch (McpError e) {

--- a/tests/2025-06-18/declarative/src/main/java/io/helidon/extensions/mcp/tests/declarative/McpCompletionsServer.java
+++ b/tests/2025-06-18/declarative/src/main/java/io/helidon/extensions/mcp/tests/declarative/McpCompletionsServer.java
@@ -31,7 +31,7 @@ import io.helidon.extensions.mcp.server.McpRequest;
 class McpCompletionsServer {
     @Mcp.Completion("prompt1")
     McpCompletionContent completionPrompt(McpParameters parameters) {
-        String argument = parameters.get("value").asString().orElse(null);
+        String argument = parameters.get("argument").get("value").asString().orElse(null);
         return McpCompletionContents.completion(argument);
     }
 
@@ -42,13 +42,13 @@ class McpCompletionsServer {
 
     @Mcp.Completion("prompt3")
     McpCompletionContent completionPromptParametersFeatures(McpParameters parameters, McpFeatures features) {
-        String argument = parameters.get("value").asString().orElse(null);
+        String argument = parameters.get("argument").get("value").asString().orElse(null);
         return McpCompletionContents.completion(argument);
     }
 
     @Mcp.Completion("prompt4")
     McpCompletionContent completionPromptFeaturesParameters(McpFeatures features, McpParameters parameters) {
-        String argument = parameters.get("value").asString().orElse(null);
+        String argument = parameters.get("argument").get("value").asString().orElse(null);
         return McpCompletionContents.completion(argument);
     }
 
@@ -69,7 +69,7 @@ class McpCompletionsServer {
 
     @Mcp.Completion(value = "resource/{path1}", type = McpCompletionType.RESOURCE)
     McpCompletionContent completionResource(McpParameters parameters) {
-        String argument = parameters.get("value").asString().orElse(null);
+        String argument = parameters.get("argument").get("value").asString().orElse(null);
         return McpCompletionContents.completion(argument);
     }
 
@@ -91,7 +91,7 @@ class McpCompletionsServer {
 
     @Mcp.Completion("prompt8")
     List<String> completionPromptList(McpParameters parameters) {
-        String argument = parameters.get("value").asString().orElse(null);
+        String argument = parameters.get("argument").get("value").asString().orElse(null);
         return List.of(argument);
     }
 
@@ -102,13 +102,13 @@ class McpCompletionsServer {
 
     @Mcp.Completion("prompt10")
     List<String> completionPromptListParametersFeatures(McpParameters parameters, McpFeatures features) {
-        String argument = parameters.get("value").asString().orElse(null);
+        String argument = parameters.get("argument").get("value").asString().orElse(null);
         return List.of(argument);
     }
 
     @Mcp.Completion("prompt11")
     List<String> completionPromptListFeaturesParameters(McpFeatures features, McpParameters parameters) {
-        String argument = parameters.get("value").asString().orElse(null);
+        String argument = parameters.get("argument").get("value").asString().orElse(null);
         return List.of(argument);
     }
 
@@ -139,13 +139,13 @@ class McpCompletionsServer {
 
     @Mcp.Completion(value = "resource/{path5}", type = McpCompletionType.RESOURCE)
     List<String> completionResourceListParametersFeatures(McpParameters parameters, McpFeatures features) {
-        String argument = parameters.get("value").asString().orElse(null);
+        String argument = parameters.get("argument").get("value").asString().orElse(null);
         return List.of(argument);
     }
 
     @Mcp.Completion(value = "resource/{path6}", type = McpCompletionType.RESOURCE)
     List<String> completionResourceListParameters(McpParameters parameters) {
-        String argument = parameters.get("value").asString().orElse(null);
+        String argument = parameters.get("argument").get("value").asString().orElse(null);
         return List.of(argument);
     }
 
@@ -154,9 +154,9 @@ class McpCompletionsServer {
         return List.of("path7");
     }
 
-    @Mcp.Completion(value = "resource/{path9}", type = McpCompletionType.RESOURCE)
+    @Mcp.Completion(value = "resource/{path8}", type = McpCompletionType.RESOURCE)
     List<String> completion1McpRequest(McpRequest request) {
-        String argument = request.parameters().get("value").asString().orElse(null);
+        String argument = request.parameters().get("argument").get("value").asString().orElse(null);
         return List.of(argument);
     }
 

--- a/tests/2025-06-18/mcp/src/main/java/io/helidon/extensions/mcp/tests/McpExceptionServer.java
+++ b/tests/2025-06-18/mcp/src/main/java/io/helidon/extensions/mcp/tests/McpExceptionServer.java
@@ -23,6 +23,7 @@ import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.extensions.mcp.server.McpCompletion;
 import io.helidon.extensions.mcp.server.McpCompletionContent;
+import io.helidon.extensions.mcp.server.McpCompletionRequest;
 import io.helidon.extensions.mcp.server.McpException;
 import io.helidon.extensions.mcp.server.McpPrompt;
 import io.helidon.extensions.mcp.server.McpPromptArgument;
@@ -196,7 +197,7 @@ class McpExceptionServer {
         }
 
         @Override
-        public Function<McpRequest, McpCompletionContent> completion() {
+        public Function<McpCompletionRequest, McpCompletionContent> completion() {
             return request -> {
                 throw new McpException(INTERNAL_ERROR, MESSAGE);
             };
@@ -210,7 +211,7 @@ class McpExceptionServer {
         }
 
         @Override
-        public Function<McpRequest, McpCompletionContent> completion() {
+        public Function<McpCompletionRequest, McpCompletionContent> completion() {
             return request -> {
                 request.features().logger().info("Switching to the SSE channel");
                 throw new McpException(INTERNAL_ERROR, MESSAGE);

--- a/tests/2025-06-18/mcp/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableCompletionTest.java
+++ b/tests/2025-06-18/mcp/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableCompletionTest.java
@@ -16,6 +16,8 @@
 
 package io.helidon.extensions.mcp.tests;
 
+import java.util.Map;
+
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.testing.junit5.ServerTest;
@@ -75,5 +77,20 @@ class McpSdkStreamableCompletionTest extends AbstractMcpSdkTest {
                                       () -> client().completeCompletion(request).completion());
         assertThat(error.getJsonRpcError().code(), is(INVALID_PARAMS));
         assertThat(error.getJsonRpcError().message(), is("No prompt completion found"));
+    }
+
+    @Test
+    void testMcpSdkCompletionContext() {
+        McpSchema.CompleteRequest request = new McpSchema.CompleteRequest(
+                new McpSchema.PromptReference("context"),
+                new McpSchema.CompleteRequest.CompleteArgument("hello", "world"),
+                new McpSchema.CompleteRequest.CompleteContext(Map.of("foo", "bar")));
+        McpSchema.CompleteResult.CompleteCompletion result = client().completeCompletion(request).completion();
+        assertThat(result.total(), is(1));
+        assertThat(result.hasMore(), is(false));
+
+        var list = result.values();
+        assertThat(list.size(), is(1));
+        assertThat(list.getFirst(), is("foo,bar"));
     }
 }

--- a/tests/2025-06-18/mcp/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableErrorServerTest.java
+++ b/tests/2025-06-18/mcp/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableErrorServerTest.java
@@ -109,7 +109,8 @@ class McpSdkStreamableErrorServerTest extends AbstractMcpSdkTest {
     void testErrorCompletion(String name) {
         try {
             var reference = new McpSchema.PromptReference(name);
-            var request = new McpSchema.CompleteRequest(reference, null);
+            var argument = new McpSchema.CompleteRequest.CompleteArgument("foo", "bar");
+            var request = new McpSchema.CompleteRequest(reference, argument);
             client().completeCompletion(request);
             assertThat("Completion execution must throw an exception", true, is(false));
         } catch (McpError e) {

--- a/tests/codegen/src/test/java/io/helidon/extensions/mcp/codegen/McpTypesTest.java
+++ b/tests/codegen/src/test/java/io/helidon/extensions/mcp/codegen/McpTypesTest.java
@@ -36,6 +36,7 @@ import io.helidon.extensions.mcp.server.McpCancellation;
 import io.helidon.extensions.mcp.server.McpCompletion;
 import io.helidon.extensions.mcp.server.McpCompletionContent;
 import io.helidon.extensions.mcp.server.McpCompletionContents;
+import io.helidon.extensions.mcp.server.McpCompletionRequest;
 import io.helidon.extensions.mcp.server.McpCompletionType;
 import io.helidon.extensions.mcp.server.McpFeatures;
 import io.helidon.extensions.mcp.server.McpLogger;
@@ -148,6 +149,7 @@ class McpTypesTest {
         checkField(toCheck, checked, fields, "HELIDON_MEDIA_TYPES", MediaTypes.class);
         checkField(toCheck, checked, fields, "HTTP_ROUTING_BUILDER", HttpRouting.Builder.class);
         checkField(toCheck, checked, fields, "MCP_TOOL_ANNOTATIONS", McpToolAnnotations.class);
+        checkField(toCheck, checked, fields, "MCP_COMPLETION_REQUEST", McpCompletionRequest.class);
         checkField(toCheck, checked, fields, "MCP_RESOURCE_SUBSCRIBER", Mcp.ResourceSubscriber.class);
         checkField(toCheck, checked, fields, "MCP_RESOURCE_UNSUBSCRIBER", Mcp.ResourceUnsubscriber.class);
         checkField(toCheck, checked, fields, "MCP_RESOURCE_SUBSCRIBER_INTERFACE", McpResourceSubscriber.class);
@@ -167,9 +169,9 @@ class McpTypesTest {
         checkField(toCheck, checked, fields, "MCP_PROMPT_CONTENT", McpPromptContent.class);
         checkField(toCheck, checked, fields, "MCP_TOOL_CONTENT", McpToolContent.class);
         checkField(toCheck, checked, fields, "FUNCTION_REQUEST_TOOL_RESULT", Function.class);
-        checkField(toCheck, checked, fields, "FUNCTION_REQUEST_COMPLETION_CONTENT", Function.class);
         checkField(toCheck, checked, fields, "FUNCTION_REQUEST_LIST_RESOURCE_CONTENT", Function.class);
         checkField(toCheck, checked, fields, "FUNCTION_REQUEST_LIST_PROMPT_CONTENT", Function.class);
+        checkField(toCheck, checked, fields, "FUNCTION_COMPLETION_REQUEST_COMPLETION_CONTENT", Function.class);
 
         assertThat("All the types from McpTypes must be tested.", toCheck, IsEmptyCollection.empty());
     }


### PR DESCRIPTION
Fixes #107

---

**Backward Incompatible Changes**

- The completions now accept an `McpCompletionRequest` instead of `McpRequest`. Thanks to this, it easier to access argument `name` and `value`, along with the introduction of optional context. 

Before:
```java
McpCompletionContent complete(McpRequest request) {
        String value = request.parameters().get("value").asString().get();
        String name = request.parameters().get("name").asString().get();
}
```

Now:
```java

McpCompletionContent complete(McpCompletionRequest request) {
        String value = request.value();
        String name = request.name();
        Optional<McpCompletionContext> context = request.context();
}
```

NOTE: The `McpCompletionRequest` extends `McpRequest` but the following change has to be made to get `name` and `value` from parameter if not willing the direct method:

Before:
```java
String value = request.parameters().get("value").asString().get();
String name = request.parameters().get("name").asString().get();
```
After:
```java
String value = request.parameters().get("argument").get("value").asString().get();
String name = request.parameters().get("argument").get("name").asString().get();
```

---

**Notable Change**

- Additional `asMap` method added to `McpParameter` to get a `Map<String, McpParameter>` where the `String` are the keys of a `JsonObject`.

Example:
```java
JsonObject object = JSON_PROVIDER.createObjectBuilder()
        .add("foo", "foo")
        .add("bar", "bar")
        .build();
McpParameters parameters = new McpParameters(JsonRpcParams.create(object), object);

Map<String, McpParameters> map = parameters.asMap().orElseGet(HashMap::new);
```

- Update `referenceType` method from `McpCompletion` so it can be set in its builder. Before this change, the `referenceType` could be overridden only when implementing the interface, not when creating an instance from a builder. Now the builder and interface are consistent.