### PR TITLE
Add Configurable Instructions Field to MCP Server Initialization Response

### DIFF
--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV1.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV1.java
@@ -69,7 +69,7 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
                 .add("serverInfo", JSON_BUILDER_FACTORY.createObjectBuilder()
                         .add("name", config.name())
                         .add("version", config.version()))
-                .add("instructions", "");
+                .add("instructions", config.instructions().orElse(""));
     }
 
     @Override

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpServerConfigBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpServerConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.extensions.mcp.server;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
@@ -174,4 +175,12 @@ interface McpServerConfigBlueprint extends Prototype.Factory<McpServerFeature> {
     @Option.Configured
     @Option.Default("PT5S")
     Duration rootListTimeout();
+
+    /**
+     * Instructions describing how to use the server and its features.
+     *
+     * @return instructions
+     */
+    @Option.Configured
+    Optional<String> instructions();
 }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/ConfigurationTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/ConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,8 @@ class ConfigurationTest {
 
     @Test
     void testConfiguration() {
-        var config = McpServerConfig.create(Config.just(ConfigSources.classpath("application-server.yaml"))
-                                                             .get(McpServerConfigBlueprint.CONFIG_ROOT));
+        McpServerConfig config = McpServerConfig.create(Config.just(ConfigSources.classpath("application-server.yaml"))
+                                                                .get(McpServerConfigBlueprint.CONFIG_ROOT));
 
         assertThat(config.path(), is("/path"));
         assertThat(config.version(), is("1.0.0"));
@@ -46,17 +46,19 @@ class ConfigurationTest {
         assertThat(config.resourcesPageSize(), is(10));
         assertThat(config.resourceTemplatesPageSize(), is(10));
         assertThat(config.rootListTimeout(), is(Duration.ofSeconds(1)));
+        assertThat(config.instructions().orElse(""), is("instructions"));
         assertThat(config.subscriptionTimeout(), is(Duration.ofSeconds(1)));
     }
 
     @Test
     void testConfigurationDefaultValues() {
-        var config = McpServerConfig.create(Config.just(ConfigSources.classpath("application-empty.yaml"))
-                                                             .get(McpServerConfigBlueprint.CONFIG_ROOT));
+        McpServerConfig config = McpServerConfig.create(Config.just(ConfigSources.classpath("application-empty.yaml"))
+                                                                .get(McpServerConfigBlueprint.CONFIG_ROOT));
 
         assertThat(config.path(), is("/mcp"));
         assertThat(config.version(), is("0.0.1"));
         assertThat(config.name(), is("mcp-server"));
+        assertThat(config.instructions().isEmpty(), is(true));
         assertThat(config.toolsPageSize(), is(DEFAULT_PAGE_SIZE));
         assertThat(config.promptsPageSize(), is(DEFAULT_PAGE_SIZE));
         assertThat(config.resourcesPageSize(), is(DEFAULT_PAGE_SIZE));

--- a/server/src/test/resources/application-server.yaml
+++ b/server/src/test/resources/application-server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Oracle and/or its affiliates.
+# Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,3 +25,4 @@ mcp:
     resource-templates-page-size: 10
     subscription-timeout: "PT1S"
     root-list-timeout: "PT1S"
+    instructions: "instructions"

--- a/tests/2025-06-18/mcp/src/main/java/io/helidon/extensions/mcp/tests/ConfigurationServer.java
+++ b/tests/2025-06-18/mcp/src/main/java/io/helidon/extensions/mcp/tests/ConfigurationServer.java
@@ -28,6 +28,7 @@ class ConfigurationServer {
     static void setUpRoute(HttpRouting.Builder builder) {
         Config mcpServerConfig = Config.just(ConfigSources.classpath("application-mcp-server.yaml"));
         builder.addFeature(McpServerFeature.builder()
-                                   .config(mcpServerConfig.get("mcp.server")));
+                                   .config(mcpServerConfig.get("mcp.server"))
+                                   .instructions("instructions"));
     }
 }

--- a/tests/2025-06-18/mcp/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableClientTest.java
+++ b/tests/2025-06-18/mcp/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableClientTest.java
@@ -75,6 +75,7 @@ class McpSdkStreamableClientTest extends AbstractMcpSdkTest {
     @Test
     void testClientInitialize() {
         McpSchema.InitializeResult result = client().initialize();
+        assertThat(result.instructions(), is(""));
 
         var implementation = result.serverInfo();
         assertThat(implementation.name(), is(SERVER_NAME));

--- a/tests/2025-06-18/mcp/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableConfigurationTest.java
+++ b/tests/2025-06-18/mcp/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableConfigurationTest.java
@@ -51,8 +51,10 @@ class McpSdkStreamableConfigurationTest extends AbstractMcpSdkTest {
     void toolAnnotationConfig() {
         var result = client().initialize();
         var infos = result.serverInfo();
-
-        assertThat(infos.version(), is("1.0.0-CONFIG"));
         assertThat(infos.name(), is("Config Named"));
+        assertThat(infos.version(), is("1.0.0-CONFIG"));
+
+        var instructions = result.instructions();
+        assertThat(instructions, is("instructions"));
     }
 }


### PR DESCRIPTION
Fixes #135

---

Instructions can be configured with config files:
```yaml
mcp:
  server:
    instructions: "foo"
```
or directly on the builder
```java
McpServerConfig.builder()
               .instructions("foo")
```