### PR TITLE
Update title to Optional field and add convenient method to McpParameters

### DIFF
--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV1.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV1.java
@@ -42,6 +42,9 @@ import jakarta.json.JsonValue;
 
 import static io.helidon.jsonrpc.core.JsonRpcError.INTERNAL_ERROR;
 
+/**
+ * JSON serializer for {@code 2024-11-05} MCP specification.
+ */
 class McpJsonSerializerV1 implements McpJsonSerializer {
     private static final Map<String, JsonObject> CACHE = new HashMap<>();
     private static final JsonReaderFactory JSON_READER_FACTORY = Json.createReaderFactory(Map.of());
@@ -255,9 +258,6 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
         if (content instanceof McpPromptResourceContent resource) {
             return toJson(resource);
         }
-        if (content instanceof McpPromptAudioContent resource) {
-            return toJson(resource);
-        }
         throw new IllegalArgumentException("Unsupported content type: " + content.getClass().getName());
     }
 
@@ -271,9 +271,6 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
         }
         if (content instanceof McpResourceContent resource) {
             return toJson(resource);
-        }
-        if (content instanceof McpAudioContent audio) {
-            return toJson(audio);
         }
         throw new IllegalArgumentException("Unsupported content type: " + content.getClass().getName());
     }
@@ -380,10 +377,7 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
 
     @Override
     public JsonObjectBuilder toJson(McpAudioContent content) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("type", content.type().text())
-                .add("data", content.base64Data())
-                .add("mimeType", content.mediaType().text());
+        throw new UnsupportedOperationException("Specification 2024-11-05 does not support audio content");
     }
 
     @Override

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV2.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV2.java
@@ -22,6 +22,9 @@ import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObjectBuilder;
 
+/**
+ * JSON serializer for {@code 2025-03-26} MCP specification.
+ */
 class McpJsonSerializerV2 extends McpJsonSerializerV1 {
     private static final JsonBuilderFactory JSON_BUILDER_FACTORY = Json.createBuilderFactory(Map.of());
 
@@ -29,6 +32,30 @@ class McpJsonSerializerV2 extends McpJsonSerializerV1 {
     public JsonObjectBuilder toJson(Set<McpCapability> capabilities, McpServerConfig config) {
         return super.toJson(capabilities, config)
                 .add("protocolVersion", McpProtocolVersion.VERSION_2025_03_26.text());
+    }
+
+    @Override
+    public JsonObjectBuilder toJson(McpContent content) {
+        if (content instanceof McpAudioContent audio) {
+            return toJson(audio);
+        }
+        return super.toJson(content);
+    }
+
+    @Override
+    public JsonObjectBuilder toJson(McpPromptContent content) {
+        if (content instanceof McpPromptAudioContent resource) {
+            return toJson(resource);
+        }
+        return super.toJson(content);
+    }
+
+    @Override
+    public JsonObjectBuilder toJson(McpAudioContent content) {
+        return JSON_BUILDER_FACTORY.createObjectBuilder()
+                .add("type", content.type().text())
+                .add("data", content.base64Data())
+                .add("mimeType", content.mediaType().text());
     }
 
     @Override

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3.java
@@ -29,6 +29,9 @@ import jakarta.json.JsonReaderFactory;
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
 
+/**
+ * JSON serializer for {@code 2025-06-18} MCP specification.
+ */
 class McpJsonSerializerV3 extends McpJsonSerializerV2 {
     private static final Jsonb JSON_B = JsonbBuilder.create();
     private static final Map<String, JsonObject> CACHE = new HashMap<>();
@@ -78,10 +81,7 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
     @Override
     public JsonObjectBuilder toJson(McpTool tool) {
         var builder = super.toJson(tool);
-
-        if (!tool.title().isBlank()) {
-            builder.add("title", tool.title());
-        }
+        tool.title().ifPresent(title -> builder.add("title", title));
         tool.outputSchema().ifPresent(outputSchema -> {
             JsonObject jsonSchema = CACHE.get(outputSchema);
             if (jsonSchema == null) {
@@ -114,27 +114,21 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
     @Override
     public JsonObjectBuilder toJson(McpResource resource) {
         var builder = super.toJson(resource);
-        if (!resource.title().isBlank()) {
-            builder.add("title", resource.title());
-        }
+        resource.title().ifPresent(title -> builder.add("title", title));
         return builder;
     }
 
     @Override
     public JsonObjectBuilder toJson(McpPrompt prompt) {
         var builder = super.toJson(prompt);
-        if (!prompt.title().isBlank()) {
-            builder.add("title", prompt.title());
-        }
+        prompt.title().ifPresent(title -> builder.add("title", title));
         return builder;
     }
 
     @Override
     public JsonObjectBuilder toJson(McpPromptArgument argument) {
         var builder = super.toJson(argument);
-        if (!argument.title().isBlank()) {
-            builder.add("title", argument.title());
-        }
+        argument.title().ifPresent(title -> builder.add("title", title));
         return builder;
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpPromptArgumentBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpPromptArgumentBlueprint.java
@@ -16,6 +16,8 @@
 
 package io.helidon.extensions.mcp.server;
 
+import java.util.Optional;
+
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 
@@ -38,9 +40,8 @@ interface McpPromptArgumentBlueprint {
      *
      * @return the prompt argument title
      */
-    @Option.Default("")
-    default String title() {
-        return "";
+    default Optional<String> title() {
+        return Optional.empty();
     }
 
     /**

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpPromptBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpPromptBlueprint.java
@@ -17,6 +17,7 @@
 package io.helidon.extensions.mcp.server;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 import io.helidon.builder.api.Option;
@@ -41,9 +42,8 @@ interface McpPromptBlueprint {
      *
      * @return the prompt title
      */
-    @Option.Default("")
-    default String title() {
-        return "";
+    default Optional<String> title() {
+        return Optional.empty();
     }
 
     /**

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceBlueprint.java
@@ -17,6 +17,7 @@
 package io.helidon.extensions.mcp.server;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 import io.helidon.builder.api.Option;
@@ -49,9 +50,8 @@ interface McpResourceBlueprint {
      *
      * @return the resource title
      */
-    @Option.Default("")
-    default String title() {
-        return "";
+    default Optional<String> title() {
+        return Optional.empty();
     }
 
     /**

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpToolBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpToolBlueprint.java
@@ -40,9 +40,8 @@ interface McpToolBlueprint {
      *
      * @return the tool title
      */
-    @Option.Default("")
-    default String title() {
-        return "";
+    default Optional<String> title() {
+        return Optional.empty();
     }
 
     /**

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpParametersTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpParametersTest.java
@@ -25,10 +25,12 @@ import java.util.stream.Collectors;
 import io.helidon.common.mapper.OptionalValue;
 import io.helidon.jsonrpc.core.JsonRpcParams;
 
+import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonStructure;
 import jakarta.json.spi.JsonProvider;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.JUnitException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -141,6 +143,216 @@ class McpParametersTest {
                 .map(OptionalValue::get)
                 .toList();
         assertThat(foo, is(List.of("foo1", "foo2")));
+    }
+
+    @Test
+    void testStringList() {
+        JsonObject object = JSON_PROVIDER.createObjectBuilder()
+                .add("foo", JSON_PROVIDER.createArrayBuilder()
+                        .add("foo1")
+                        .add("foo2"))
+                .build();
+        JsonRpcParams rpcParams = JsonRpcParams.create(object);
+        McpParameters parameters = new McpParameters(rpcParams, object);
+        List<String> foo = parameters.get("foo")
+                .asList(String.class)
+                .orElse(List.of());
+        assertThat(foo, is(List.of("foo1", "foo2")));
+    }
+
+    @Test
+    void testBooleanList() {
+        JsonArray array = JSON_PROVIDER.createArrayBuilder()
+                .add(true)
+                .add(false)
+                .build();
+        JsonRpcParams rpcParams = JsonRpcParams.create(array);
+        McpParameters parameters = new McpParameters(rpcParams, array);
+        List<Boolean> booleans = parameters.asList(Boolean.class).orElse(List.of());
+        assertThat(booleans.size(), is(2));
+        assertThat(booleans, is(List.of(true, false)));
+    }
+
+    @Test
+    void testIntegerList() {
+        JsonArray array = JSON_PROVIDER.createArrayBuilder()
+                .add(1)
+                .add(2)
+                .build();
+        JsonRpcParams rpcParams = JsonRpcParams.create(array);
+        McpParameters parameters = new McpParameters(rpcParams, array);
+        List<Integer> booleans = parameters.asList(Integer.class).orElse(List.of());
+        assertThat(booleans.size(), is(2));
+        assertThat(booleans, is(List.of(1, 2)));
+    }
+
+    @Test
+    void testLongList() {
+        JsonArray array = JSON_PROVIDER.createArrayBuilder()
+                .add(1L)
+                .add(2L)
+                .build();
+        JsonRpcParams rpcParams = JsonRpcParams.create(array);
+        McpParameters parameters = new McpParameters(rpcParams, array);
+        List<Long> booleans = parameters.asList(Long.class).orElse(List.of());
+        assertThat(booleans.size(), is(2));
+        assertThat(booleans, is(List.of(1L, 2L)));
+    }
+
+    @Test
+    void testDoubleList() {
+        JsonArray array = JSON_PROVIDER.createArrayBuilder()
+                .add(1D)
+                .add(2D)
+                .build();
+        JsonRpcParams rpcParams = JsonRpcParams.create(array);
+        McpParameters parameters = new McpParameters(rpcParams, array);
+        List<Double> booleans = parameters.asList(Double.class).orElse(List.of());
+        assertThat(booleans.size(), is(2));
+        assertThat(booleans, is(List.of(1D, 2D)));
+    }
+
+    @Test
+    void testFloatList() {
+        JsonArray array = JSON_PROVIDER.createArrayBuilder()
+                .add(1.0F)
+                .add(2.0F)
+                .build();
+        JsonRpcParams rpcParams = JsonRpcParams.create(array);
+        McpParameters parameters = new McpParameters(rpcParams, array);
+        List<Float> booleans = parameters.asList(Float.class).orElse(List.of());
+        assertThat(booleans.size(), is(2));
+        assertThat(booleans, is(List.of(1.0F, 2.0F)));
+    }
+
+    @Test
+    void testShortList() {
+        JsonArray array = JSON_PROVIDER.createArrayBuilder()
+                .add(1)
+                .add(2)
+                .build();
+        JsonRpcParams rpcParams = JsonRpcParams.create(array);
+        McpParameters parameters = new McpParameters(rpcParams, array);
+        List<Short> booleans = parameters.asList(Short.class).orElse(List.of());
+        assertThat(booleans.size(), is(2));
+        assertThat(booleans, is(List.of((short) 1, (short) 2)));
+    }
+
+    @Test
+    void testByteList() {
+        JsonArray array = JSON_PROVIDER.createArrayBuilder()
+                .add(1)
+                .add(2)
+                .build();
+        JsonRpcParams rpcParams = JsonRpcParams.create(array);
+        McpParameters parameters = new McpParameters(rpcParams, array);
+        List<Byte> booleans = parameters.asList(Byte.class).orElse(List.of());
+        assertThat(booleans.size(), is(2));
+        assertThat(booleans, is(List.of((byte) 1, (byte) 2)));
+    }
+
+    @Test
+    void testPojoList() {
+        JsonArray array = JSON_PROVIDER.createArrayBuilder()
+                .add(JSON_PROVIDER.createObjectBuilder()
+                             .add("foo", "foo1")
+                             .add("bar", "bar1"))
+                .add(JSON_PROVIDER.createObjectBuilder()
+                             .add("foo", "foo2")
+                             .add("bar", "bar2"))
+                .build();
+        JsonRpcParams rpcParams = JsonRpcParams.create(array);
+        McpParameters parameters = new McpParameters(rpcParams, array);
+        List<Foo> foos = parameters
+                .asList(Foo.class)
+                .orElse(List.of());
+        assertThat(foos.size(), is(2));
+
+        Foo foo1 = foos.getFirst();
+        assertThat(foo1.foo, is("foo1"));
+        assertThat(foo1.bar, is("bar1"));
+
+        Foo foo2 = foos.getLast();
+        assertThat(foo2.foo, is("foo2"));
+        assertThat(foo2.bar, is("bar2"));
+    }
+
+    @Test
+    void testListOfMap() {
+        JsonArray array = JSON_PROVIDER.createArrayBuilder()
+                .add(JSON_PROVIDER.createObjectBuilder()
+                             .add("value1", JSON_PROVIDER.createObjectBuilder()
+                                     .add("foo", "foo1")
+                                     .add("bar", "bar1")))
+                .add(JSON_PROVIDER.createObjectBuilder()
+                             .add("value2", JSON_PROVIDER.createObjectBuilder()
+                                     .add("foo", "foo2")
+                                     .add("bar", "bar2")))
+                .build();
+        JsonRpcParams rpcParams = JsonRpcParams.create(array);
+        McpParameters parameters = new McpParameters(rpcParams, array);
+        List<Map<String, McpParameters>> listMap = parameters.asList()
+                .map(list -> list.stream()
+                        .map(McpParameters::asMap)
+                        .filter(OptionalValue::isPresent)
+                        .map(OptionalValue::get)
+                        .toList())
+                .orElse(List.of());
+        assertThat(listMap.size(), is(2));
+
+        Map<String, McpParameters> map = listMap.getFirst();
+        assertThat(map.size(), is(1));
+        assertThat(map.containsKey("value1"), is(true));
+
+        Foo value1 = map.get("value1")
+                .as(Foo.class)
+                .orElseThrow(() -> new JUnitException("Cannot convert value1 to Foo.class"));
+        assertThat(value1.foo, is("foo1"));
+        assertThat(value1.bar, is("bar1"));
+
+        map = listMap.getLast();
+        assertThat(map.size(), is(1));
+        assertThat(map.containsKey("value2"), is(true));
+
+        Foo value2 = map.get("value2")
+                .as(Foo.class)
+                .orElseThrow(() -> new JUnitException("Cannot convert value2 to Foo.class"));
+        assertThat(value2.foo, is("foo2"));
+        assertThat(value2.bar, is("bar2"));
+    }
+
+    @Test
+    void testMapOfList() {
+        JsonObject object = JSON_PROVIDER.createObjectBuilder()
+                .add("value1", JSON_PROVIDER.createArrayBuilder()
+                        .add(JSON_PROVIDER.createObjectBuilder()
+                                     .add("foo", "foo1")
+                                     .add("bar", "bar1")))
+                .add("value2", JSON_PROVIDER.createArrayBuilder()
+                        .add(JSON_PROVIDER.createObjectBuilder()
+                                     .add("foo", "foo2")
+                                     .add("bar", "bar2")))
+                .build();
+        JsonRpcParams rpcParams = JsonRpcParams.create(object);
+        McpParameters parameters = new McpParameters(rpcParams, object);
+        Map<String, McpParameters> map = parameters.asMap().orElse(Map.of());
+        assertThat(map.size(), is(2));
+        assertThat(map.containsKey("value1"), is(true));
+        assertThat(map.containsKey("value2"), is(true));
+
+        List<Foo> value1 = map.get("value1").asList(Foo.class).orElse(List.of());
+        assertThat(value1.size(), is(1));
+
+        Foo foo1 = value1.getFirst();
+        assertThat(foo1.foo, is("foo1"));
+        assertThat(foo1.bar, is("bar1"));
+
+        List<Foo> value2 = map.get("value2").asList(Foo.class).orElse(List.of());
+        assertThat(value2.size(), is(1));
+
+        Foo foo2 = value2.getFirst();
+        assertThat(foo2.foo, is("foo2"));
+        assertThat(foo2.bar, is("bar2"));
     }
 
     @Test

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpToolTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpToolTest.java
@@ -35,8 +35,8 @@ class McpToolTest {
                 .tool((request) -> null)
                 .build();
         assertThat(tool.name(), is("name"));
-        assertThat(tool.title(), is("title"));
         assertThat(tool.schema(), is("schema"));
+        assertThat(tool.title().orElse(""), is("title"));
         assertThat(tool.description(), is("description"));
         assertThat(tool.outputSchema().orElse(""), is("outputSchema"));
     }
@@ -49,9 +49,9 @@ class McpToolTest {
                 .description("description")
                 .tool((request) -> null)
                 .build();
-        assertThat(tool.title(), is(""));
         assertThat(tool.name(), is("name"));
         assertThat(tool.schema(), is("schema"));
+        assertThat(tool.title().isEmpty(), is(true));
         assertThat(tool.description(), is("description"));
         assertThat(tool.outputSchema().isPresent(), is(false));
     }
@@ -59,9 +59,9 @@ class McpToolTest {
     @Test
     void testMcpToolImplementation() {
         Foo foo = new Foo();
-        assertThat(foo.title(), is(""));
         assertThat(foo.name(), is("name"));
         assertThat(foo.schema(), is("schema"));
+        assertThat(foo.title().isEmpty(), is(true));
         assertThat(foo.description(), is("description"));
         assertThat(foo.outputSchema().isPresent(), is(false));
     }

--- a/tests/2024-11-05/mcp/src/main/java/io/helidon/extensions/mcp/tests/MultipleTool.java
+++ b/tests/2024-11-05/mcp/src/main/java/io/helidon/extensions/mcp/tests/MultipleTool.java
@@ -17,6 +17,7 @@
 package io.helidon.extensions.mcp.tests;
 
 import java.net.URI;
+import java.util.Optional;
 import java.util.function.Function;
 
 import io.helidon.extensions.mcp.server.McpParameters;
@@ -101,8 +102,8 @@ class MultipleTool {
         }
 
         @Override
-        public String title() {
-            return "Tool 4 Title";
+        public Optional<String> title() {
+            return Optional.of("Tool 4 Title");
         }
 
         @Override

--- a/tests/2025-03-26/mcp/src/main/java/io/helidon/extensions/mcp/tests/MultipleTool.java
+++ b/tests/2025-03-26/mcp/src/main/java/io/helidon/extensions/mcp/tests/MultipleTool.java
@@ -17,6 +17,7 @@
 package io.helidon.extensions.mcp.tests;
 
 import java.net.URI;
+import java.util.Optional;
 import java.util.function.Function;
 
 import io.helidon.extensions.mcp.server.McpParameters;
@@ -104,8 +105,8 @@ class MultipleTool {
         }
 
         @Override
-        public String title() {
-            return "Tool 4 Title";
+        public Optional<String> title() {
+            return Optional.of("Tool 4 Title");
         }
 
         @Override

--- a/tests/2025-06-18/mcp/src/main/java/io/helidon/extensions/mcp/tests/MultipleResource.java
+++ b/tests/2025-06-18/mcp/src/main/java/io/helidon/extensions/mcp/tests/MultipleResource.java
@@ -18,6 +18,7 @@ package io.helidon.extensions.mcp.tests;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -99,8 +100,8 @@ class MultipleResource {
         }
 
         @Override
-        public String title() {
-            return "Resource 3 Title";
+        public Optional<String> title() {
+            return Optional.of("Resource 3 Title");
         }
 
         @Override

--- a/tests/2025-06-18/mcp/src/main/java/io/helidon/extensions/mcp/tests/MultipleTool.java
+++ b/tests/2025-06-18/mcp/src/main/java/io/helidon/extensions/mcp/tests/MultipleTool.java
@@ -17,6 +17,7 @@
 package io.helidon.extensions.mcp.tests;
 
 import java.net.URI;
+import java.util.Optional;
 import java.util.function.Function;
 
 import io.helidon.common.media.type.MediaTypes;
@@ -119,8 +120,8 @@ class MultipleTool {
         }
 
         @Override
-        public String title() {
-            return "Tool 4 Title";
+        public Optional<String> title() {
+            return Optional.of("Tool 4 Title");
         }
 
         @Override


### PR DESCRIPTION
Fixes #94

Fixes bugs in McpParameters where when binding the parameter to a class, the delegate Json-RPC parameter was pointing to a different node. New test added.

Fixes bug in the Json serializer where content from newer version was processed in former one. This bug was not caught by test as client simply ignored this content instead of reporting an error. 