### PR TITLE
Emit required array in tool schema based on @Nullable

### DIFF
--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegenUtil.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegenUtil.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import io.helidon.codegen.classmodel.ClassModel;
 import io.helidon.codegen.classmodel.Method;
@@ -58,6 +59,11 @@ class McpCodegenUtil {
                                                   MCP_PARAMETERS.classNameWithEnclosingNames());
 
     private McpCodegenUtil() {
+    }
+
+    static boolean isNullable(TypedElementInfo param) {
+        return Stream.concat(param.annotations().stream(), param.elementTypeAnnotations().stream())
+                .anyMatch(a -> a.typeName().className().equals("Nullable"));
     }
 
     static boolean isBoolean(TypeName type) {

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpJsonSchemaCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpJsonSchemaCodegen.java
@@ -19,6 +19,7 @@ package io.helidon.extensions.mcp.codegen;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import io.helidon.codegen.classmodel.Method;
 import io.helidon.common.types.TypeName;
@@ -41,6 +42,10 @@ class McpJsonSchemaCodegen {
     }
 
     static void addSchemaMethodBody(Method.Builder method, List<TypedElementInfo> fields) {
+        addSchemaMethodBody(method, fields, List.of());
+    }
+
+    static void addSchemaMethodBody(Method.Builder method, List<TypedElementInfo> fields, List<String> requiredFields) {
         method.addContentLine("var builder = new StringBuilder();");
         method.addContentLine("builder.append(\"{\");");
         method.addContentLine("builder.append(\"\\\"type\\\": \\\"object\\\", \\\"properties\\\": {\");");
@@ -53,7 +58,18 @@ class McpJsonSchemaCodegen {
                 method.addContentLine("builder.append(\", \");");
             }
         }
-        method.addContentLine("builder.append(\"}}\");");
+        method.addContentLine("builder.append(\"}\");");
+
+        if (!requiredFields.isEmpty()) {
+            String requiredJson = requiredFields.stream()
+                    .map(f -> "\\\"" + f + "\\\"")
+                    .collect(Collectors.joining(", "));
+            method.addContent("builder.append(\", \\\"required\\\": [")
+                    .addContent(requiredJson)
+                    .addContentLine("]\");");
+        }
+
+        method.addContentLine("builder.append(\"}\");");
         method.addContentLine("return builder.toString();");
     }
 

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpToolCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpToolCodegen.java
@@ -39,6 +39,7 @@ import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isBoolean;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isIgnoredSchemaElement;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isList;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isMcpType;
+import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isNullable;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isNumber;
 import static io.helidon.extensions.mcp.codegen.McpJsonSchemaCodegen.addSchemaMethodBody;
 import static io.helidon.extensions.mcp.codegen.McpTypes.FUNCTION_REQUEST_TOOL_RESULT;
@@ -101,6 +102,7 @@ class McpToolCodegen {
                 .addAnnotation(Annotations.OVERRIDE);
 
         List<TypedElementInfo> fields = new ArrayList<>();
+        List<String> requiredFields = new ArrayList<>();
         for (TypedElementInfo param : element.parameterArguments()) {
             if (isIgnoredSchemaElement(param.typeName())) {
                 continue;
@@ -113,10 +115,14 @@ class McpToolCodegen {
                     .accessModifier(AccessModifier.PUBLIC);
             description.ifPresent(desc -> field.addAnnotation(Annotation.create(MCP_DESCRIPTION, desc)));
             fields.add(field.build());
+
+            if (!isNullable(param)) {
+                requiredFields.add(param.elementName());
+            }
         }
 
         if (!fields.isEmpty()) {
-            addSchemaMethodBody(method, fields);
+            addSchemaMethodBody(method, fields, requiredFields);
         } else {
             method.addContentLine("return \"\";");
         }


### PR DESCRIPTION
## Summary

- Tool annotation processor now checks `@Nullable` on parameters (both element and TYPE_USE annotations) and emits a `"required"` array in the generated JSON schema for non-nullable parameters
- MCP clients can now distinguish mandatory from optional tool inputs

Fixes #146

## Changes

- **`McpCodegenUtil`** — add `isNullable` helper that checks both `annotations()` and `elementTypeAnnotations()` for any annotation named `Nullable`
- **`McpJsonSchemaCodegen`** — add overload of `addSchemaMethodBody` that accepts required field names and emits `"required": [...]` between the properties close and root object close
- **`McpToolCodegen`** — collect non-nullable parameter names during schema generation and pass them through

## Example

Given:
```java
@Mcp.Tool("Abandon a change")
public List<McpToolContent> abandonChange(
        @Mcp.Description("Change ID") String changeId,
        @Mcp.Description("Reason") @Nullable String message) { ... }
```

Before:
```json
{"type": "object", "properties": {"changeId": {...}, "message": {...}}}
```

After:
```json
{"type": "object", "properties": {"changeId": {...}, "message": {...}}, "required": ["changeId"]}
```