### PR TITLE
Emit required array in tool schema based on @Nullable

### DIFF
--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegenUtil.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegenUtil.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import io.helidon.codegen.classmodel.ClassModel;
 import io.helidon.codegen.classmodel.Method;
@@ -58,6 +59,11 @@ class McpCodegenUtil {
                                                   MCP_PARAMETERS.classNameWithEnclosingNames());
 
     private McpCodegenUtil() {
+    }
+
+    static boolean isNullable(TypedElementInfo param) {
+        return Stream.concat(param.annotations().stream(), param.elementTypeAnnotations().stream())
+                .anyMatch(a -> a.typeName().className().equals("Nullable"));
     }
 
     static boolean isBoolean(TypeName type) {

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpJsonSchemaCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpJsonSchemaCodegen.java
@@ -19,6 +19,7 @@ package io.helidon.extensions.mcp.codegen;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import io.helidon.codegen.classmodel.Method;
 import io.helidon.common.types.TypeName;
@@ -41,6 +42,10 @@ class McpJsonSchemaCodegen {
     }
 
     static void addSchemaMethodBody(Method.Builder method, List<TypedElementInfo> fields) {
+        addSchemaMethodBody(method, fields, List.of());
+    }
+
+    static void addSchemaMethodBody(Method.Builder method, List<TypedElementInfo> fields, List<String> requiredFields) {
         method.addContentLine("var builder = new StringBuilder();");
         method.addContentLine("builder.append(\"{\");");
         method.addContentLine("builder.append(\"\\\"type\\\": \\\"object\\\", \\\"properties\\\": {\");");
@@ -53,7 +58,18 @@ class McpJsonSchemaCodegen {
                 method.addContentLine("builder.append(\", \");");
             }
         }
-        method.addContentLine("builder.append(\"}}\");");
+        method.addContentLine("builder.append(\"}\");");
+
+        if (!requiredFields.isEmpty()) {
+            String requiredJson = requiredFields.stream()
+                    .map(f -> "\\\"" + f + "\\\"")
+                    .collect(Collectors.joining(", "));
+            method.addContent("builder.append(\", \\\"required\\\": [")
+                    .addContent(requiredJson)
+                    .addContentLine("]\");");
+        }
+
+        method.addContentLine("builder.append(\"}\");");
         method.addContentLine("return builder.toString();");
     }
 

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpToolCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpToolCodegen.java
@@ -39,6 +39,7 @@ import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isBoolean;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isIgnoredSchemaElement;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isList;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isMcpType;
+import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isNullable;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isNumber;
 import static io.helidon.extensions.mcp.codegen.McpJsonSchemaCodegen.addSchemaMethodBody;
 import static io.helidon.extensions.mcp.codegen.McpTypes.FUNCTION_REQUEST_TOOL_RESULT;
@@ -101,6 +102,7 @@ class McpToolCodegen {
                 .addAnnotation(Annotations.OVERRIDE);
 
         List<TypedElementInfo> fields = new ArrayList<>();
+        List<String> requiredFields = new ArrayList<>();
         for (TypedElementInfo param : element.parameterArguments()) {
             if (isIgnoredSchemaElement(param.typeName())) {
                 continue;
@@ -113,10 +115,14 @@ class McpToolCodegen {
                     .accessModifier(AccessModifier.PUBLIC);
             description.ifPresent(desc -> field.addAnnotation(Annotation.create(MCP_DESCRIPTION, desc)));
             fields.add(field.build());
+
+            if (!isNullable(param)) {
+                requiredFields.add(param.elementName());
+            }
         }
 
         if (!fields.isEmpty()) {
-            addSchemaMethodBody(method, fields);
+            addSchemaMethodBody(method, fields, requiredFields);
         } else {
             method.addContentLine("return \"\";");
         }

--- a/tests/codegen/src/test/java/io/helidon/extensions/mcp/codegen/McpCodegenUtilTest.java
+++ b/tests/codegen/src/test/java/io/helidon/extensions/mcp/codegen/McpCodegenUtilTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.mcp.codegen;
+
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ElementKind;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypedElementInfo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class McpCodegenUtilTest {
+
+    private static final TypeName NULLABLE = TypeName.create("javax.annotation.Nullable");
+
+    @Test
+    void whenNoAnnotationsThenNotNullable() {
+        TypedElementInfo myParam = TypedElementInfo.builder()
+                .elementName("param")
+                .kind(ElementKind.PARAMETER)
+                .typeName(TypeName.create(String.class))
+                .build();
+
+        assertThat(McpCodegenUtil.isNullable(myParam), is(false));
+    }
+
+    @Test
+    void whenNullableInParameterAnnotationsThenNullable() {
+        TypedElementInfo myParam = TypedElementInfo.builder()
+                .elementName("param")
+                .kind(ElementKind.PARAMETER)
+                .typeName(TypeName.create(String.class))
+                .addAnnotation(Annotation.create(NULLABLE))
+                .build();
+
+        assertThat(McpCodegenUtil.isNullable(myParam), is(true));
+    }
+}


### PR DESCRIPTION
## Summary

- Tool annotation processor now checks `@Nullable` on parameters (both element and TYPE_USE annotations) and emits a `"required"` array in the generated JSON schema for non-nullable parameters
- MCP clients can now distinguish mandatory from optional tool inputs

Fixes #146

## Changes

- **`McpCodegenUtil`** — add `isNullable` helper that checks both `annotations()` and `elementTypeAnnotations()` for any annotation named `Nullable`
- **`McpJsonSchemaCodegen`** — add overload of `addSchemaMethodBody` that accepts required field names and emits `"required": [...]` between the properties close and root object close
- **`McpToolCodegen`** — collect non-nullable parameter names during schema generation and pass them through

## Example

Given:
```java
@Mcp.Tool("Abandon a change")
public List<McpToolContent> abandonChange(
        @Mcp.Description("Change ID") String changeId,
        @Mcp.Description("Reason") @Nullable String message) { ... }
```

Before:
```json
{"type": "object", "properties": {"changeId": {...}, "message": {...}}}
```

After:
```json
{"type": "object", "properties": {"changeId": {...}, "message": {...}}, "required": ["changeId"]}
```