### PR TITLE
Detect TYPE_USE @Nullable in tool schema codegen

### DIFF
--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegenUtil.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegenUtil.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import io.helidon.codegen.classmodel.ClassModel;
 import io.helidon.codegen.classmodel.Method;
@@ -58,6 +59,11 @@ class McpCodegenUtil {
                                                   MCP_PARAMETERS.classNameWithEnclosingNames());
 
     private McpCodegenUtil() {
+    }
+
+    static boolean isNullable(TypedElementInfo param) {
+        return Stream.concat(param.annotations().stream(), param.elementTypeAnnotations().stream())
+                .anyMatch(a -> a.typeName().className().equals("Nullable"));
     }
 
     static boolean isBoolean(TypeName type) {

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegenUtil.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegenUtil.java
@@ -62,7 +62,8 @@ class McpCodegenUtil {
     }
 
     static boolean isNullable(TypedElementInfo param) {
-        return Stream.concat(param.annotations().stream(), param.elementTypeAnnotations().stream())
+        return Stream.of(param.annotations(), param.elementTypeAnnotations(), param.typeName().annotations())
+                .flatMap(List::stream)
                 .anyMatch(a -> a.typeName().className().equals("Nullable"));
     }
 

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpJsonSchemaCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpJsonSchemaCodegen.java
@@ -19,6 +19,7 @@ package io.helidon.extensions.mcp.codegen;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import io.helidon.codegen.classmodel.Method;
 import io.helidon.common.types.TypeName;
@@ -41,6 +42,10 @@ class McpJsonSchemaCodegen {
     }
 
     static void addSchemaMethodBody(Method.Builder method, List<TypedElementInfo> fields) {
+        addSchemaMethodBody(method, fields, List.of());
+    }
+
+    static void addSchemaMethodBody(Method.Builder method, List<TypedElementInfo> fields, List<String> requiredFields) {
         method.addContentLine("var builder = new StringBuilder();");
         method.addContentLine("builder.append(\"{\");");
         method.addContentLine("builder.append(\"\\\"type\\\": \\\"object\\\", \\\"properties\\\": {\");");
@@ -53,7 +58,18 @@ class McpJsonSchemaCodegen {
                 method.addContentLine("builder.append(\", \");");
             }
         }
-        method.addContentLine("builder.append(\"}}\");");
+        method.addContentLine("builder.append(\"}\");");
+
+        if (!requiredFields.isEmpty()) {
+            String requiredJson = requiredFields.stream()
+                    .map(f -> "\\\"" + f + "\\\"")
+                    .collect(Collectors.joining(", "));
+            method.addContent("builder.append(\", \\\"required\\\": [")
+                    .addContent(requiredJson)
+                    .addContentLine("]\");");
+        }
+
+        method.addContentLine("builder.append(\"}\");");
         method.addContentLine("return builder.toString();");
     }
 

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpToolCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpToolCodegen.java
@@ -39,6 +39,7 @@ import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isBoolean;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isIgnoredSchemaElement;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isList;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isMcpType;
+import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isNullable;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isNumber;
 import static io.helidon.extensions.mcp.codegen.McpJsonSchemaCodegen.addSchemaMethodBody;
 import static io.helidon.extensions.mcp.codegen.McpTypes.FUNCTION_REQUEST_TOOL_RESULT;
@@ -101,6 +102,7 @@ class McpToolCodegen {
                 .addAnnotation(Annotations.OVERRIDE);
 
         List<TypedElementInfo> fields = new ArrayList<>();
+        List<String> requiredFields = new ArrayList<>();
         for (TypedElementInfo param : element.parameterArguments()) {
             if (isIgnoredSchemaElement(param.typeName())) {
                 continue;
@@ -113,10 +115,14 @@ class McpToolCodegen {
                     .accessModifier(AccessModifier.PUBLIC);
             description.ifPresent(desc -> field.addAnnotation(Annotation.create(MCP_DESCRIPTION, desc)));
             fields.add(field.build());
+
+            if (!isNullable(param)) {
+                requiredFields.add(param.elementName());
+            }
         }
 
         if (!fields.isEmpty()) {
-            addSchemaMethodBody(method, fields);
+            addSchemaMethodBody(method, fields, requiredFields);
         } else {
             method.addContentLine("return \"\";");
         }

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 
     <properties>
         <version.java>21</version.java>
-        <helidon.version>4.3.1</helidon.version>
+        <helidon.version>4.4.0-SNAPSHOT</helidon.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/tests/codegen/src/test/java/io/helidon/extensions/mcp/codegen/McpCodegenUtilTest.java
+++ b/tests/codegen/src/test/java/io/helidon/extensions/mcp/codegen/McpCodegenUtilTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.mcp.codegen;
+
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ElementKind;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypedElementInfo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class McpCodegenUtilTest {
+
+    private static final TypeName NULLABLE = TypeName.create("javax.annotation.Nullable");
+
+    @Test
+    void whenNoAnnotationsThenNotNullable() {
+        TypedElementInfo myParam = TypedElementInfo.builder()
+                .elementName("param")
+                .kind(ElementKind.PARAMETER)
+                .typeName(TypeName.create(String.class))
+                .build();
+
+        assertThat(McpCodegenUtil.isNullable(myParam), is(false));
+    }
+
+    @Test
+    void whenNullableInParameterAnnotationsThenNullable() {
+        TypedElementInfo myParam = TypedElementInfo.builder()
+                .elementName("param")
+                .kind(ElementKind.PARAMETER)
+                .typeName(TypeName.create(String.class))
+                .addAnnotation(Annotation.create(NULLABLE))
+                .build();
+
+        assertThat(McpCodegenUtil.isNullable(myParam), is(true));
+    }
+
+    @Test
+    void whenNullableInTypeNameAnnotationsThenNullable() {
+        TypeName myAnnotatedType = TypeName.builder(TypeName.create(String.class))
+                .addAnnotation(Annotation.create(NULLABLE))
+                .build();
+        TypedElementInfo myParam = TypedElementInfo.builder()
+                .elementName("param")
+                .kind(ElementKind.PARAMETER)
+                .typeName(myAnnotatedType)
+                .build();
+
+        assertThat(McpCodegenUtil.isNullable(myParam), is(true));
+    }
+}


### PR DESCRIPTION
## Summary
- Extends `isNullable()` to also check `param.typeName().annotations()`, where Helidon's APT bridge stores TYPE_USE annotations (e.g. `org.jspecify.annotations.Nullable`)
- Upgrades Helidon dependency to 4.4.0-SNAPSHOT (required for `TypeName extends Annotated`)
- Adds unit tests for all three annotation source paths

## Blocked on
Helidon 4.4.0 release — `TypeNameBlueprint extends Annotated` was added in [helidon#10755](https://github.com/helidon-io/helidon/pull/10755) and is not yet in any released version. Once 4.4.0 is released, swap the SNAPSHOT version and this is ready to merge.

## Builds on
#148

## Test plan
- [x] `mvn clean install -Ptests` — 149 tests pass, 0 failures