### PR TITLE
Return proper JSON-RPC error for invalid session ID

### DIFF
--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
@@ -854,7 +854,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         var session = findSession(req);
         if (session.isEmpty()) {
             res.status(Status.NOT_FOUND_404)
-                    .error(INTERNAL_ERROR, "Session not found");
+                    .error(INVALID_REQUEST, "Session not found");
         }
         return session;
     }


### PR DESCRIPTION
## Problem

When a client sends a request with a stale `Mcp-Session-Id` (e.g. after server restart), the server returns HTTP 404 with a **malformed JSON-RPC response**:

```json
{"jsonrpc":"2.0","id":1}
```

This violates the [JSON-RPC 2.0 spec](https://www.jsonrpc.org/specification) which requires every response to contain either a `"result"` or `"error"` field. MCP clients cannot parse this as a session error and fail to re-initialize the session, leaving the connection permanently broken until the client is restarted.

For comparison, other MCP server implementations (Node.js SDK, Python SDK) return:

```json
{"jsonrpc":"2.0","error":{"code":-32001,"message":"Session not found"},"id":null}
```

This issue is the server-side counterpart to [anthropics/claude-code#27142](https://github.com/anthropics/claude-code/issues/27142), which tracks the client-side failure to re-initialize on session errors. The malformed response from Helidon makes the client-side recovery harder since there's no error message to key on.

## Root Cause

In `McpServerFeature.findSession(ServerRequest, ServerResponse)`, when a session is not found:

```java
res.status(Status.NOT_FOUND_404).send();
```

This calls `send()` on what is actually a `JsonRpcSingleResponse` (via the `ServerResponse` interface). The `send()` method serializes `asJsonObject()`, which builds the JSON-RPC envelope with the request `id` but without `result` or `error` (neither was set). This produces the malformed `{"jsonrpc":"2.0","id":N}` body.

Additionally, this causes a **double-send**: `findSession()` sends the response, then the caller (e.g., `toolsListRpc`) checks the status and calls `res.send()` again.

## Fix

- Narrow the method signature to `JsonRpcRequest`/`JsonRpcResponse` (callers already pass these types)
- Replace `res.status(404).send()` with `res.status(404).error(INTERNAL_ERROR, "Session not found")`
- The caller's existing status-check pattern handles the actual `send()`, which now produces:

```json
{"jsonrpc":"2.0","error":{"code":-32603,"message":"Session not found"},"id":1}
```

This is a 3-line change with no new dependencies.