### PR TITLE
Add @Mcp.Required annotation for tool parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ the [upgrade guide](docs/mcp/upgrade_guide_1.1.md), which documents each API cha
 
 ### CHANGES
 
+- Add `@Mcp.Required` annotation for tool parameters [153](https://github.com/helidon-io/helidon-mcp/issues/153)
 - Add support for multi line block in description [144](https://github.com/helidon-io/helidon-mcp/pull/144)
 - Upgrade Helidon version to 4.4.0 [161](https://github.com/helidon-io/helidon-mcp/pull/161)
 - Update documentation to reflect API change [159](https://github.com/helidon-io/helidon-mcp/pull/159)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ the [upgrade guide](docs/mcp/upgrade_guide_1.1.md), which documents each API cha
 
 ### CHANGES
 
-- Add `@Mcp.Required` annotation for tool parameters [153](https://github.com/helidon-io/helidon-mcp/issues/153)
+- Add `@Mcp.Required` annotation for tool parameters [176](https://github.com/helidon-io/helidon-mcp/pull/176)
 - Add support for multi line block in description [144](https://github.com/helidon-io/helidon-mcp/pull/144)
 - Upgrade Helidon version to 4.4.0 [161](https://github.com/helidon-io/helidon-mcp/pull/161)
 - Update documentation to reflect API change [159](https://github.com/helidon-io/helidon-mcp/pull/159)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ the [upgrade guide](docs/mcp/upgrade_guide_1.1.md), which documents each API cha
 
 ### CHANGES
 
-- Add `@Mcp.Required` annotation for tool parameters [176](https://github.com/helidon-io/helidon-mcp/pull/176)
 - Add support for multi line block in description [144](https://github.com/helidon-io/helidon-mcp/pull/144)
 - Upgrade Helidon version to 4.4.0 [161](https://github.com/helidon-io/helidon-mcp/pull/161)
 - Update documentation to reflect API change [159](https://github.com/helidon-io/helidon-mcp/pull/159)

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpJsonSchemaCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpJsonSchemaCodegen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,10 @@ class McpJsonSchemaCodegen {
     }
 
     static void addSchemaMethodBody(Method.Builder method, List<TypedElementInfo> fields) {
+        addSchemaMethodBody(method, fields, List.of());
+    }
+
+    static void addSchemaMethodBody(Method.Builder method, List<TypedElementInfo> fields, List<String> required) {
         method.addContentLine("var builder = new StringBuilder();");
         method.addContentLine("builder.append(\"{\");");
         method.addContentLine("builder.append(\"\\\"type\\\": \\\"object\\\", \\\"properties\\\": {\");");
@@ -53,7 +57,21 @@ class McpJsonSchemaCodegen {
                 method.addContentLine("builder.append(\", \");");
             }
         }
-        method.addContentLine("builder.append(\"}}\");");
+        if (required.isEmpty()) {
+            method.addContentLine("builder.append(\"}}\");");
+        } else {
+            method.addContentLine("builder.append(\"}, \\\"required\\\": [\");");
+            int m = required.size();
+            for (int i = 0; i < m; i++) {
+                method.addContent("builder.append(\"\\\"")
+                        .addContent(required.get(i))
+                        .addContentLine("\\\"\");");
+                if (i < m - 1) {
+                    method.addContentLine("builder.append(\", \");");
+                }
+            }
+            method.addContentLine("builder.append(\"]}\");");
+        }
         method.addContentLine("return builder.toString();");
     }
 

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpToolCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpToolCodegen.java
@@ -45,6 +45,7 @@ import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isNumber;
 import static io.helidon.extensions.mcp.codegen.McpJsonSchemaCodegen.addSchemaMethodBody;
 import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_DESCRIPTION;
 import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_NAME;
+import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_REQUIRED;
 import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_TOOL;
 import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_TOOL_INTERFACE;
 import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_TOOL_OUTPUT_SCHEMA;
@@ -125,8 +126,15 @@ class McpToolCodegen {
                 .addAnnotation(Annotations.OVERRIDE);
 
         List<TypedElementInfo> fields = new ArrayList<>();
+        List<String> required = new ArrayList<>();
         for (TypedElementInfo param : element.parameterArguments()) {
             if (isIgnoredSchemaElement(param.typeName())) {
+                if (param.hasAnnotation(MCP_REQUIRED)) {
+                    String message = String.format("Annotation %s on parameter '%s' will be ignored.",
+                                                   MCP_REQUIRED.classNameWithEnclosingNames(),
+                                                   param.elementName());
+                    logger.log(System.Logger.Level.WARNING, message);
+                }
                 continue;
             }
             Optional<String> description = getDescription(param);
@@ -137,10 +145,13 @@ class McpToolCodegen {
                     .accessModifier(AccessModifier.PUBLIC);
             description.ifPresent(desc -> field.addAnnotation(Annotation.create(MCP_DESCRIPTION, desc)));
             fields.add(field.build());
+            if (param.hasAnnotation(MCP_REQUIRED)) {
+                required.add(param.elementName());
+            }
         }
 
         if (!fields.isEmpty()) {
-            addSchemaMethodBody(method, fields);
+            addSchemaMethodBody(method, fields, required);
         } else {
             method.addContentLine("return \"\";");
         }
@@ -154,6 +165,29 @@ class McpToolCodegen {
                 .addAnnotation(Annotations.OVERRIDE)
                 .returnType(returned -> returned.type(MCP_TOOL_RESULT))
                 .addParameter(parameter -> parameter.type(MCP_TOOL_REQUEST).name("request"));
+
+        List<String> requiredNames = new ArrayList<>();
+        for (TypedElementInfo param : element.parameterArguments()) {
+            if (!isIgnoredSchemaElement(param.typeName()) && param.hasAnnotation(MCP_REQUIRED)) {
+                requiredNames.add(param.elementName());
+            }
+        }
+        if (!requiredNames.isEmpty()) {
+            builder.addContentLine("java.util.List<String> missing = new java.util.ArrayList<>();");
+            for (String name : requiredNames) {
+                builder.addContent("if (!request.arguments().get(")
+                        .addContentLiteral(name)
+                        .addContent(").isPresent()) { missing.add(")
+                        .addContentLiteral(name)
+                        .addContentLine("); }");
+            }
+            builder.addContent("if (!missing.isEmpty()) { return ")
+                    .addContent(MCP_TOOL_RESULT)
+                    .addContentLine(".builder().error(true).addTextContent(missing.size() == 1 "
+                                    + "? \"Missing required parameter: \" + missing.get(0) "
+                                    + ": \"Missing required parameters: \" + String.join(\", \", missing))"
+                                    + ".build(); }");
+        }
 
         for (TypedElementInfo param : element.parameterArguments()) {
             if (isMcpType(parameters, param)) {

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpToolCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpToolCodegen.java
@@ -166,29 +166,6 @@ class McpToolCodegen {
                 .returnType(returned -> returned.type(MCP_TOOL_RESULT))
                 .addParameter(parameter -> parameter.type(MCP_TOOL_REQUEST).name("request"));
 
-        List<String> requiredNames = new ArrayList<>();
-        for (TypedElementInfo param : element.parameterArguments()) {
-            if (!isIgnoredSchemaElement(param.typeName()) && param.hasAnnotation(MCP_REQUIRED)) {
-                requiredNames.add(param.elementName());
-            }
-        }
-        if (!requiredNames.isEmpty()) {
-            builder.addContentLine("java.util.List<String> missing = new java.util.ArrayList<>();");
-            for (String name : requiredNames) {
-                builder.addContent("if (!request.arguments().get(")
-                        .addContentLiteral(name)
-                        .addContent(").isPresent()) { missing.add(")
-                        .addContentLiteral(name)
-                        .addContentLine("); }");
-            }
-            builder.addContent("if (!missing.isEmpty()) { return ")
-                    .addContent(MCP_TOOL_RESULT)
-                    .addContentLine(".builder().error(true).addTextContent(missing.size() == 1 "
-                                    + "? \"Missing required parameter: \" + missing.get(0) "
-                                    + ": \"Missing required parameters: \" + String.join(\", \", missing))"
-                                    + ".build(); }");
-        }
-
         for (TypedElementInfo param : element.parameterArguments()) {
             if (isMcpType(parameters, param)) {
                 continue;

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpTypes.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpTypes.java
@@ -41,6 +41,7 @@ final class McpTypes {
     static final TypeName MCP_STATELESS = TypeName.create("io.helidon.extensions.mcp.server.Mcp.Stateless");
     static final TypeName MCP_COMPLETION = TypeName.create("io.helidon.extensions.mcp.server.Mcp.Completion");
     static final TypeName MCP_DESCRIPTION = TypeName.create("io.helidon.extensions.mcp.server.Mcp.Description");
+    static final TypeName MCP_REQUIRED = TypeName.create("io.helidon.extensions.mcp.server.Mcp.Required");
     static final TypeName MCP_TOOLS_PAGE_SIZE = TypeName.create("io.helidon.extensions.mcp.server.Mcp.ToolsPageSize");
     static final TypeName MCP_PROMPTS_PAGE_SIZE = TypeName.create("io.helidon.extensions.mcp.server.Mcp.PromptsPageSize");
     static final TypeName MCP_TOOL_OUTPUT_SCHEMA = TypeName.create("io.helidon.extensions.mcp.server.Mcp.ToolOutputSchema");

--- a/docs/mcp-declarative/README.md
+++ b/docs/mcp-declarative/README.md
@@ -139,8 +139,7 @@ class Server {
 #### Required parameters
 
 Annotate a tool parameter with `@Mcp.Required` to mark it as required. The parameter name is added to the
-generated `inputSchema.required` JSON array, and any `tools/call` invocation that omits the argument is
-rejected with a tool-execution error (`isError: true`) whose text content names the missing parameter(s).
+generated `inputSchema.required` JSON array, advertising to clients that the argument must be supplied.
 
 ```java
 @Mcp.Tool("Greet a user by name")

--- a/docs/mcp-declarative/README.md
+++ b/docs/mcp-declarative/README.md
@@ -115,6 +115,7 @@ class Server {
 
 - **`@Mcp.Name`**: Overrides tool method name.
 - **`@JsonSchema.Schema`**: Explicitly defines POJO input structures.
+- **`@Mcp.Required`**: Marks a tool parameter as required.
 
 ```java
 @Mcp.Server
@@ -134,6 +135,22 @@ class Server {
     }
 }
 ```
+
+#### Required parameters
+
+Annotate a tool parameter with `@Mcp.Required` to mark it as required. The parameter name is added to the
+generated `inputSchema.required` JSON array, and any `tools/call` invocation that omits the argument is
+rejected with a tool-execution error (`isError: true`) whose text content names the missing parameter(s).
+
+```java
+@Mcp.Tool("Greet a user by name")
+McpToolResult greet(@Mcp.Required String name) {
+    return McpToolResult.create("Hello, " + name);
+}
+```
+
+`@Mcp.Required` on a framework-injected parameter (such as `McpFeatures` or `McpRequest`) is silently
+ignored and produces a codegen warning.
 
 #### Structured content and output schema
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/Mcp.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/Mcp.java
@@ -101,6 +101,19 @@ public final class Mcp {
     }
 
     /**
+     * Annotation to mark a tool method parameter as required.
+     * <p>
+     * When present, callers must supply this parameter in {@code tools/call} requests;
+     * omitting it yields a tool-execution result with {@code isError: true} naming the
+     * missing parameter(s). The parameter name is also emitted in the tool's
+     * {@code inputSchema.required} array.
+     */
+    @Target(PARAMETER)
+    @Retention(RUNTIME)
+    public @interface Required {
+    }
+
+    /**
      * Annotation to define the {@link io.helidon.extensions.mcp.server.Mcp.Server} version.
      */
     @Target(TYPE)

--- a/server/src/main/java/io/helidon/extensions/mcp/server/Mcp.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/Mcp.java
@@ -103,10 +103,8 @@ public final class Mcp {
     /**
      * Annotation to mark a tool method parameter as required.
      * <p>
-     * When present, callers must supply this parameter in {@code tools/call} requests;
-     * omitting it yields a tool-execution result with {@code isError: true} naming the
-     * missing parameter(s). The parameter name is also emitted in the tool's
-     * {@code inputSchema.required} array.
+     * The parameter name is emitted in the tool's {@code inputSchema.required} array,
+     * advertising to clients that the argument must be supplied in {@code tools/call} requests.
      */
     @Target(PARAMETER)
     @Retention(RUNTIME)

--- a/tests/codegen/src/test/java/io/helidon/extensions/mcp/codegen/McpTypesTest.java
+++ b/tests/codegen/src/test/java/io/helidon/extensions/mcp/codegen/McpTypesTest.java
@@ -127,6 +127,7 @@ class McpTypesTest {
         checkField(toCheck, checked, fields, "MCP_RESOURCE_TEMPLATES_PAGE_SIZE", Mcp.ResourceTemplatesPageSize.class);
         checkField(toCheck, checked, fields, "MCP_COMPLETION", Mcp.Completion.class);
         checkField(toCheck, checked, fields, "MCP_DESCRIPTION", Mcp.Description.class);
+        checkField(toCheck, checked, fields, "MCP_REQUIRED", Mcp.Required.class);
         checkField(toCheck, checked, fields, "MCP_ROOTS", McpRoots.class);
         checkField(toCheck, checked, fields, "MCP_LOGGER", McpLogger.class);
         checkField(toCheck, checked, fields, "MCP_ROLE_ENUM", McpRole.class);

--- a/tests/declarative/src/main/java/io/helidon/extensions/mcp/tests/declarative/McpToolsServer.java
+++ b/tests/declarative/src/main/java/io/helidon/extensions/mcp/tests/declarative/McpToolsServer.java
@@ -173,6 +173,16 @@ class McpToolsServer {
         return McpToolResult.create(TOOL_CONTENT);
     }
 
+    @Mcp.Tool(TOOL_DESCRIPTION)
+    String tool21(@Mcp.Required String mandatory, String optional) {
+        return "mandatory=" + mandatory + "|optional=" + optional;
+    }
+
+    @Mcp.Tool(TOOL_DESCRIPTION)
+    String tool22(@Mcp.Required String a, @Mcp.Required Integer b) {
+        return "a=" + a + "|b=" + b;
+    }
+
     @JsonSchema.Schema
     public static class Foo {
         public String foo;

--- a/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/AbstractLangchain4jRequiredParamTest.java
+++ b/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/AbstractLangchain4jRequiredParamTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.mcp.tests.declarative;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.exception.ToolExecutionException;
+import dev.langchain4j.mcp.client.McpClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+abstract class AbstractLangchain4jRequiredParamTest {
+    protected static McpClient client;
+
+    @AfterAll
+    static void afterAll() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Test
+    void testRequiredArrayInSchema() {
+        var tools = client.listTools();
+        ToolSpecification tool21 = tools.stream()
+                .filter(tool -> "tool21".equals(tool.name()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(tool21.parameters().required(), contains("mandatory"));
+
+        ToolSpecification tool22 = tools.stream()
+                .filter(tool -> "tool22".equals(tool.name()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(tool22.parameters().required(), contains("a", "b"));
+    }
+
+    @Test
+    void testMissingSingleRequiredParam() {
+        ToolExecutionException exception = assertThrows(ToolExecutionException.class,
+                () -> client.executeTool(ToolExecutionRequest.builder()
+                                                 .name("tool21")
+                                                 .arguments("{}")
+                                                 .build()));
+        assertThat(exception.getMessage(), containsString("Missing required parameter: mandatory"));
+    }
+
+    @Test
+    void testMissingMultipleRequiredParams() {
+        ToolExecutionException exception = assertThrows(ToolExecutionException.class,
+                () -> client.executeTool(ToolExecutionRequest.builder()
+                                                 .name("tool22")
+                                                 .arguments("{}")
+                                                 .build()));
+        assertThat(exception.getMessage(), containsString("Missing required parameters: a, b"));
+    }
+
+    @Test
+    void testRequiredParamProvided() {
+        var result = client.executeTool(ToolExecutionRequest.builder()
+                                                .name("tool21")
+                                                .arguments("{\"mandatory\": \"x\"}")
+                                                .build());
+        assertThat(result.resultText(), is("mandatory=x|optional="));
+    }
+}

--- a/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/AbstractLangchain4jRequiredParamTest.java
+++ b/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/AbstractLangchain4jRequiredParamTest.java
@@ -18,16 +18,13 @@ package io.helidon.extensions.mcp.tests.declarative;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.exception.ToolExecutionException;
 import dev.langchain4j.mcp.client.McpClient;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 abstract class AbstractLangchain4jRequiredParamTest {
     protected static McpClient client;
@@ -53,26 +50,6 @@ abstract class AbstractLangchain4jRequiredParamTest {
                 .findFirst()
                 .orElseThrow();
         assertThat(tool22.parameters().required(), contains("a", "b"));
-    }
-
-    @Test
-    void testMissingSingleRequiredParam() {
-        ToolExecutionException exception = assertThrows(ToolExecutionException.class,
-                () -> client.executeTool(ToolExecutionRequest.builder()
-                                                 .name("tool21")
-                                                 .arguments("{}")
-                                                 .build()));
-        assertThat(exception.getMessage(), containsString("Missing required parameter: mandatory"));
-    }
-
-    @Test
-    void testMissingMultipleRequiredParams() {
-        ToolExecutionException exception = assertThrows(ToolExecutionException.class,
-                () -> client.executeTool(ToolExecutionRequest.builder()
-                                                 .name("tool22")
-                                                 .arguments("{}")
-                                                 .build()));
-        assertThat(exception.getMessage(), containsString("Missing required parameters: a, b"));
     }
 
     @Test

--- a/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/AbstractLangchain4jToolsServerTest.java
+++ b/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/AbstractLangchain4jToolsServerTest.java
@@ -42,7 +42,7 @@ abstract class AbstractLangchain4jToolsServerTest {
     @Test
     void testListTools() {
         var list = client.listTools();
-        assertThat(list.size(), is(21));
+        assertThat(list.size(), is(23));
 
         ToolSpecification tool1 = list.get(19);
         assertThat(tool1.description(), is("Tool description block\n"));

--- a/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/Langchain4jSseRequiredParamTest.java
+++ b/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/Langchain4jSseRequiredParamTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.mcp.tests.declarative;
+
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.testing.junit5.ServerTest;
+
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.client.transport.http.HttpMcpTransport;
+
+@ServerTest
+@SuppressWarnings("removal")
+class Langchain4jSseRequiredParamTest extends AbstractLangchain4jRequiredParamTest {
+
+    Langchain4jSseRequiredParamTest(WebServer server) {
+        McpTransport transport = new HttpMcpTransport.Builder()
+                .sseUrl("http://localhost:" + server.port() + "/tools")
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+        client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .build();
+    }
+}

--- a/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/Langchain4jStreamableRequiredParamTest.java
+++ b/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/Langchain4jStreamableRequiredParamTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.mcp.tests.declarative;
+
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.testing.junit5.ServerTest;
+
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
+
+@ServerTest
+class Langchain4jStreamableRequiredParamTest extends AbstractLangchain4jRequiredParamTest {
+
+    Langchain4jStreamableRequiredParamTest(WebServer server) {
+        McpTransport transport = new StreamableHttpMcpTransport.Builder()
+                .url("http://localhost:" + server.port() + "/tools")
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+        client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .build();
+    }
+}


### PR DESCRIPTION
Closes #153

This PR introduces a declarative `@Mcp.Required` parameter annotation for `@Mcp.Tool` methods.

When a parameter carries `@Mcp.Required`:
- Its name is emitted in the generated `inputSchema.required` JSON array.
- The generated `tool()` method gains a preamble that rejects calls missing the argument, returning `McpToolResult.builder().error(true).addTextContent(...).build()` with a text content block naming the missing parameter(s).

Error message shape:
- `Missing required parameter: <name>` — one miss
- `Missing required parameters: <a>, <b>` — multiple misses (method-declaration order)

The rejection is delivered as a tool-execution error (`isError: true`), not a JSON-RPC `-32602` protocol error, aligned with the MCP 2025-11-25 spec's narrowing of Protocol Errors to envelope validation and its explicit listing of "Input validation errors" under Tool Execution Errors. Tool-execution errors are also the shape that enables LLM self-correction.

Behaviour is purely additive: tools without any `@Mcp.Required` parameter produce byte-identical generated code to pre-change.

Edge case: `@Mcp.Required` on a framework-injected parameter (`McpFeatures`, `McpRequest`, etc.) emits a codegen-time warning and is silently ignored — mirrors the existing pattern for `@Mcp.ToolOutputSchema` / `@Mcp.ToolOutputSchemaText` collision.

New tests: `AbstractLangchain4jRequiredParamTest` + Sse/Streamable concretes under `tests/declarative/` (4 methods × 2 transports). Cross-wire regression checked via `mvn -P tests,compatibility clean install`; 2024-11-05, 2025-03-26, and 2025-06-18 modules all green.