### PR TITLE
Enforce required tool parameters in the server runtime

### DIFF
--- a/docs/mcp-declarative/README.md
+++ b/docs/mcp-declarative/README.md
@@ -139,7 +139,8 @@ class Server {
 #### Required parameters
 
 Annotate a tool parameter with `@Mcp.Required` to mark it as required. The parameter name is added to the
-generated `inputSchema.required` JSON array, advertising to clients that the argument must be supplied.
+generated `inputSchema.required` JSON array, and any `tools/call` invocation that omits the argument is
+rejected with a tool execution error (`isError: true`) whose text content names the missing parameter(s).
 
 ```java
 @Mcp.Tool("Greet a user by name")

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -85,7 +85,9 @@ McpServerFeature.builder()
 computations. To define a tool, provide a name, description, input schema, and business logic. Use the `addTool` method 
 from the `McpServerFeature` builder to register it with the server. The name and description help LLMs understand its purpose. 
 The schema, written according to [JSON Schema Specification](https://json-schema.org/specification), defines the expected input 
-format. The business logic is implemented in the `tool` method and uses `McpToolRequest` to access inputs. The `McpToolRequest` 
+format. Properties listed in the schema `required` array are enforced by the server: a `tools/call` request omitting any of 
+them is rejected with a tool execution error (`isError: true`) whose text content names the missing parameter(s). 
+The business logic is implemented in the `tool` method and uses `McpToolRequest` to access inputs. The `McpToolRequest` 
 extends `McpRequest` and provides access to the `McpTool` instance via the `tool()` method.
 
 #### Tool Interface

--- a/server/src/main/java/io/helidon/extensions/mcp/server/Mcp.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/Mcp.java
@@ -103,8 +103,9 @@ public final class Mcp {
     /**
      * Annotation to mark a tool method parameter as required.
      * <p>
-     * The parameter name is emitted in the tool's {@code inputSchema.required} array,
-     * advertising to clients that the argument must be supplied in {@code tools/call} requests.
+     * The parameter name is emitted in the tool's {@code inputSchema.required} array. The server
+     * rejects {@code tools/call} requests omitting the argument with a tool execution result with
+     * {@code isError: true} naming the missing parameter(s).
      */
     @Target(PARAMETER)
     @Retention(RUNTIME)

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
@@ -17,6 +17,7 @@
 package io.helidon.extensions.mcp.server;
 
 import java.lang.System.Logger.Level;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +50,7 @@ import io.helidon.webserver.jsonrpc.JsonRpcRequest;
 import io.helidon.webserver.jsonrpc.JsonRpcResponse;
 import io.helidon.webserver.jsonrpc.JsonRpcRouting;
 
+import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
@@ -85,6 +87,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
     private static final int RESOURCE_NOT_FOUND_CODE = -32002;
     private static final String DEFAULT_OIDC_METADATA_URI = "/.well-known/openid-configuration";
     private static final System.Logger LOGGER = System.getLogger(McpServerFeature.class.getName());
+    private static final Map<String, JsonObject> INPUT_SCHEMA = new McpSchemaHashMap();
 
     private final String endpoint;
     private final McpSessions sessions;
@@ -397,7 +400,6 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             res.send();
             return;
         }
-        boolean error = false;
         McpSession session = foundSession.get();
         McpParameters parameters = new McpParameters(req.params(), req.params().asJsonObject());
 
@@ -408,6 +410,17 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
 
         if (tool.isEmpty()) {
             res.error(INVALID_PARAMS, "Tool with name %s is not available".formatted(name));
+            session.send(requestId, res);
+            return;
+        }
+
+        List<String> missing = missingRequiredParameters(tool.get(), parameters.get("arguments"));
+        if (!missing.isEmpty()) {
+            McpToolResult result = McpToolResult.builder()
+                    .error(true)
+                    .addTextContent(missingParametersMessage(missing))
+                    .build();
+            res.result(session.serializer().toolCall(tool.get(), result));
             session.send(requestId, res);
             return;
         }
@@ -428,6 +441,26 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         var toolCall = session.serializer().toolCall(tool.get(), result);
         res.result(toolCall);
         session.send(requestId, res);
+    }
+
+    private static List<String> missingRequiredParameters(McpTool tool, McpParameters arguments) {
+        JsonValue required = INPUT_SCHEMA.get(tool.schema()).get("required");
+        if (!(required instanceof JsonArray requiredNames)) {
+            return List.of();
+        }
+        List<String> missing = new ArrayList<>();
+        for (JsonValue requiredName : requiredNames) {
+            if (requiredName instanceof JsonString parameter && arguments.get(parameter.getString()).isEmpty()) {
+                missing.add(parameter.getString());
+            }
+        }
+        return missing;
+    }
+
+    private static String missingParametersMessage(List<String> missing) {
+        return missing.size() == 1
+                ? "Missing required parameter: " + missing.getFirst()
+                : "Missing required parameters: " + String.join(", ", missing);
     }
 
     private void resourcesListRpc(JsonRpcRequest req, JsonRpcResponse res) {

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpTool.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpTool.java
@@ -39,6 +39,10 @@ public interface McpTool {
      * JSON schema describing tool inputs. String must be compliant with
      * <a href="https://json-schema.org/draft/2020-12">JSON Schema Version 2020-12</a>.
      * An empty string is mapped to a schema of type object without any properties.
+     * <p>
+     * Properties listed in the schema {@code required} array are enforced by the server:
+     * a {@code tools/call} request omitting any of them is rejected with a tool execution
+     * result with {@code isError: true} naming the missing parameter(s).
      *
      * @return JSON schema as a string
      */

--- a/tests/2024-11-05/src/test/java/io/helidon/extensions/mcp/tests/McpSdkSseRequiredParamTest.java
+++ b/tests/2024-11-05/src/test/java/io/helidon/extensions/mcp/tests/McpSdkSseRequiredParamTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.mcp.tests;
+
+import java.util.Map;
+
+import io.helidon.extensions.mcp.tests.common.RequiredParamServer;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+@ServerTest
+class McpSdkSseRequiredParamTest extends AbstractMcpSdkTest {
+    private final McpSyncClient client;
+
+    McpSdkSseRequiredParamTest(WebServer server) {
+        client = McpClient.sync(sse(server.port())).build();
+        client.initialize();
+    }
+
+    @Override
+    McpSyncClient client() {
+        return client;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder builder) {
+        RequiredParamServer.setUpRoute(builder);
+    }
+
+    @Test
+    void testMissingSingleRequiredParam() {
+        var request = new McpSchema.CallToolRequest("single-required-param-tool", Map.of());
+        var result = client().callTool(request);
+        assertThat(result.isError(), is(true));
+
+        var content = result.content().getFirst();
+        assertThat(content, instanceOf(McpSchema.TextContent.class));
+
+        McpSchema.TextContent text = (McpSchema.TextContent) content;
+        assertThat(text.text(), is("Missing required parameter: mandatory"));
+    }
+
+    @Test
+    void testMissingMultipleRequiredParams() {
+        var request = new McpSchema.CallToolRequest("multiple-required-params-tool", Map.of());
+        var result = client().callTool(request);
+        assertThat(result.isError(), is(true));
+
+        var content = result.content().getFirst();
+        assertThat(content, instanceOf(McpSchema.TextContent.class));
+
+        McpSchema.TextContent text = (McpSchema.TextContent) content;
+        assertThat(text.text(), is("Missing required parameters: a, b"));
+    }
+
+    @Test
+    void testRequiredParamsProvided() {
+        var request = new McpSchema.CallToolRequest("multiple-required-params-tool", Map.<String, Object>of("a", "x", "b", 42));
+        var result = client().callTool(request);
+        assertThat(result.isError(), is(false));
+
+        var content = result.content().getFirst();
+        assertThat(content, instanceOf(McpSchema.TextContent.class));
+
+        McpSchema.TextContent text = (McpSchema.TextContent) content;
+        assertThat(text.text(), is("a=x|b=42"));
+    }
+}

--- a/tests/2025-06-18/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableRequiredParamTest.java
+++ b/tests/2025-06-18/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableRequiredParamTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.mcp.tests;
+
+import java.util.Map;
+
+import io.helidon.extensions.mcp.tests.common.RequiredParamServer;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+@ServerTest
+class McpSdkStreamableRequiredParamTest extends AbstractMcpSdkTest {
+    private final McpSyncClient client;
+
+    McpSdkStreamableRequiredParamTest(WebServer server) {
+        client = McpClient.sync(streamable(server.port())).build();
+        client.initialize();
+    }
+
+    @Override
+    McpSyncClient client() {
+        return client;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder builder) {
+        RequiredParamServer.setUpRoute(builder);
+    }
+
+    @Test
+    void testMissingSingleRequiredParam() {
+        var result = client().callTool(McpSchema.CallToolRequest.builder()
+                                               .name("single-required-param-tool")
+                                               .build());
+        assertThat(result.isError(), is(true));
+
+        var content = result.content().getFirst();
+        assertThat(content, instanceOf(McpSchema.TextContent.class));
+
+        McpSchema.TextContent text = (McpSchema.TextContent) content;
+        assertThat(text.text(), is("Missing required parameter: mandatory"));
+    }
+
+    @Test
+    void testMissingMultipleRequiredParams() {
+        var result = client().callTool(McpSchema.CallToolRequest.builder()
+                                               .name("multiple-required-params-tool")
+                                               .build());
+        assertThat(result.isError(), is(true));
+
+        var content = result.content().getFirst();
+        assertThat(content, instanceOf(McpSchema.TextContent.class));
+
+        McpSchema.TextContent text = (McpSchema.TextContent) content;
+        assertThat(text.text(), is("Missing required parameters: a, b"));
+    }
+
+    @Test
+    void testRequiredParamsProvided() {
+        var result = client().callTool(McpSchema.CallToolRequest.builder()
+                                               .name("multiple-required-params-tool")
+                                               .arguments(Map.<String, Object>of("a", "x", "b", 42))
+                                               .build());
+        assertThat(result.isError(), is(false));
+
+        var content = result.content().getFirst();
+        assertThat(content, instanceOf(McpSchema.TextContent.class));
+
+        McpSchema.TextContent text = (McpSchema.TextContent) content;
+        assertThat(text.text(), is("a=x|b=42"));
+    }
+}

--- a/tests/common/src/main/java/io/helidon/extensions/mcp/tests/common/RequiredParamServer.java
+++ b/tests/common/src/main/java/io/helidon/extensions/mcp/tests/common/RequiredParamServer.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.tests.common;
+
+import io.helidon.extensions.mcp.server.McpServerFeature;
+import io.helidon.extensions.mcp.server.McpTool;
+import io.helidon.extensions.mcp.server.McpToolRequest;
+import io.helidon.extensions.mcp.server.McpToolResult;
+import io.helidon.webserver.http.HttpRouting;
+
+/**
+ * Server with tools declaring required parameters in their input schema.
+ */
+public class RequiredParamServer {
+    private RequiredParamServer() {
+    }
+
+    /**
+     * Setup webserver routing.
+     *
+     * @param builder routing builder
+     */
+    public static void setUpRoute(HttpRouting.Builder builder) {
+        builder.addFeature(McpServerFeature.builder()
+                                   .path("/")
+                                   .addTool(new SingleRequiredParamTool())
+                                   .addTool(new MultipleRequiredParamsTool()));
+    }
+
+    private static class SingleRequiredParamTool implements McpTool {
+        @Override
+        public String name() {
+            return "single-required-param-tool";
+        }
+
+        @Override
+        public String description() {
+            return "Tool with one required parameter";
+        }
+
+        @Override
+        public String schema() {
+            return """
+                    {
+                      "type": "object",
+                      "properties": {
+                        "mandatory": {"type": "string"},
+                        "optional": {"type": "string"}
+                      },
+                      "required": ["mandatory"]
+                    }
+                    """;
+        }
+
+        @Override
+        public McpToolResult tool(McpToolRequest request) {
+            String mandatory = request.arguments().get("mandatory").asString().orElse("");
+            return McpToolResult.create("mandatory=" + mandatory);
+        }
+    }
+
+    private static class MultipleRequiredParamsTool implements McpTool {
+        @Override
+        public String name() {
+            return "multiple-required-params-tool";
+        }
+
+        @Override
+        public String description() {
+            return "Tool with multiple required parameters";
+        }
+
+        @Override
+        public String schema() {
+            return """
+                    {
+                      "type": "object",
+                      "properties": {
+                        "a": {"type": "string"},
+                        "b": {"type": "integer"}
+                      },
+                      "required": ["a", "b"]
+                    }
+                    """;
+        }
+
+        @Override
+        public McpToolResult tool(McpToolRequest request) {
+            String a = request.arguments().get("a").asString().orElse("");
+            int b = request.arguments().get("b").asInteger().orElse(0);
+            return McpToolResult.create("a=" + a + "|b=" + b);
+        }
+    }
+}

--- a/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/AbstractLangchain4jRequiredParamTest.java
+++ b/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/AbstractLangchain4jRequiredParamTest.java
@@ -18,13 +18,16 @@ package io.helidon.extensions.mcp.tests.declarative;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.exception.ToolExecutionException;
 import dev.langchain4j.mcp.client.McpClient;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 abstract class AbstractLangchain4jRequiredParamTest {
     protected static McpClient client;
@@ -68,6 +71,26 @@ abstract class AbstractLangchain4jRequiredParamTest {
                 .findFirst()
                 .orElseThrow();
         assertThat(tool25.parameters().required(), contains("values"));
+    }
+
+    @Test
+    void testMissingSingleRequiredParam() {
+        ToolExecutionException exception = assertThrows(ToolExecutionException.class,
+                () -> client.executeTool(ToolExecutionRequest.builder()
+                                                 .name("tool21")
+                                                 .arguments("{}")
+                                                 .build()));
+        assertThat(exception.getMessage(), containsString("Missing required parameter: mandatory"));
+    }
+
+    @Test
+    void testMissingMultipleRequiredParams() {
+        ToolExecutionException exception = assertThrows(ToolExecutionException.class,
+                () -> client.executeTool(ToolExecutionRequest.builder()
+                                                 .name("tool22")
+                                                 .arguments("{}")
+                                                 .build()));
+        assertThat(exception.getMessage(), containsString("Missing required parameters: a, b"));
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #176, relates to #119.

In #176, runtime rejection of missing `@Mcp.Required` arguments was removed from the generated tool preamble per review: it created a behaviour gap between the declarative and SE APIs, and it was undecided where such validation should live. This PR reintroduces the enforcement in the server runtime instead — `McpServerFeature.toolsCallRpc`, the dispatch point both APIs converge on — so the gap no longer exists.

### What changed

- `toolsCallRpc` validates the request's `arguments` against the tool's `inputSchema.required` array before invoking the tool. Missing arguments produce a tool execution result (`isError: true`) with a text content block naming them:
  - `Missing required parameter: <name>` (single)
  - `Missing required parameters: <a>, <b>` (multiple, schema order)
- Enforcement is driven by the schema, not the annotation, so it applies uniformly: declarative tools (whose generated schema carries `required` from `@Mcp.Required`) and SE tools whose hand-written schema declares `required` behave identically.
- The error shape follows the MCP specification's tool-execution-error guidance for input validation (see #119), enabling LLM self-correction. Protocol errors (`-32602`) remain reserved for envelope issues such as unknown tool names.
- Schema parsing reuses the existing `McpSchemaHashMap` cache; dispatch stays protocol-version agnostic.
- Docs and javadoc updated: `docs/mcp/README.md`, `docs/mcp-declarative/README.md`, `@Mcp.Required`, `McpTool.schema()`.

### Tests

- Restores `testMissingSingleRequiredParam` / `testMissingMultipleRequiredParams` in `AbstractLangchain4jRequiredParamTest` (SSE + Streamable), dropped from #176.
- New SE coverage: `RequiredParamServer` in `tests/common`, exercised by `McpSdkSseRequiredParamTest` (2024-11-05, V1 serializer) and `McpSdkStreamableRequiredParamTest` (2025-06-18, V3 serializer) — missing single, missing multiple, and happy path.
- `mvn -P tests,compatibility clean install`: all modules green except the pre-existing `*SamplingTest` failures, which reproduce identically at b309ffb on a clean checkout (`Schema$Builder` error from `io.helidon.json.schema`, unrelated to this change).

### Note on #119 scope

This implements the tool-execution-error shape for missing required parameters. Argument *type* errors raised from tool code (e.g. `McpParameters` conversion failures throwing `McpException`) still surface as protocol errors — happy to extend here or in a follow-up if that is considered in scope for #119.