### PR TITLE
Update Helidon version to 4.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,9 @@ node/
 # Helidon CLI
 .helidon
 
+# Codex workspace
+.ai/
+
 # Helidon examples repository
 helidon-examples
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Helidon support for [Model Context Protocol](https://modelcontextprotocol.io/).
 
 To get started, read the documentation that explains what is Helidon MCP support related to. Then the
 examples are a good starting point to run your first Helidon MCP server whether you use SE or Declarative.
-Helidon MCP supports MCP version 2024-11-05, and planning to support latest version.
+Helidon MCP supports MCP version 2025-06-18 and earlier, and planning to support latest version.
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,5 +4,6 @@ This documentation set covers both imperative and declarative APIs for building 
 
 - [MCP for Helidon SE](mcp/README.md)
 - [MCP for Helidon SE Declarative](mcp-declarative/README.md)
+- [MCP Upgrade Guide 1.2](mcp/upgrade_guide_1.2.md)
 - [MCP Upgrade Guide 1.1](mcp/upgrade_guide_1.1.md)
 - [MCP Declarative Upgrade Guide 1.1](mcp-declarative/upgrade_guide_1.1.md)

--- a/docs/mcp-declarative/README.md
+++ b/docs/mcp-declarative/README.md
@@ -158,6 +158,9 @@ a tool that returns structured content SHOULD also return the serialized JSON in
 added to the `McpToolResult` builder, Helidon will serialize the structured content and add it by itself.
 Tools have to provide an output schema for validation of structured results if it is using structured content.
 
+Structured content is serialized using Helidon JSON binding. Custom classes must be annotated with `@Json.Entity` and
+compiled with the Helidon JSON annotation processor. JSON-B annotations and unregistered POJOs are not supported.
+
 To add an output schema to the tool, use the `@Mcp.ToolOutputSchema` or `@Mcp.ToolOutputSchemaText` annotations:
 
 - **`@Mcp.ToolOutputSchema`**: Defines the output schema using a class (POJO). Helidon will generate the JSON schema from the class.
@@ -180,6 +183,7 @@ McpToolResult toolWithTextSchema(McpToolRequest request) {
             .build();
 }
 
+@Json.Entity
 @JsonSchema.Schema
 public record Foo(String bar) {
 }
@@ -495,6 +499,15 @@ void process(McpToolRequest request) {
 
     // Convert to a custom POJO
     Address homeAddress = address.as(Address.class).orElseThrow();
+}
+```
+
+Custom parameter types are deserialized using Helidon JSON binding. Annotate them with `@Json.Entity` and enable the
+Helidon JSON annotation processor so a converter is generated:
+
+```java
+@Json.Entity
+record Address(String street, String city) {
 }
 ```
 

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -178,6 +178,9 @@ a tool that returns structured content SHOULD also return the serialized JSON in
 added to the `McpToolResult` builder, Helidon will serialize the structured content and add it by itself.
 Tools have to provide an output schema for validation of structured results if it is using structured content.
 
+Structured content is serialized using Helidon JSON binding. Custom classes must be annotated with `@Json.Entity` and
+compiled with the Helidon JSON annotation processor. JSON-B annotations and unregistered POJOs are not supported.
+
 To add an output schema to the tool, implement the `outputSchema` method:
 ```java
 @Override
@@ -795,6 +798,15 @@ void process(McpRequest request) {
 }
 ```
 
+Custom parameter types are deserialized using Helidon JSON binding. Annotate them with `@Json.Entity` and enable the
+Helidon JSON annotation processor so a converter is generated:
+
+```java
+@Json.Entity
+record Address(String street, String city) {
+}
+```
+
 ### Checking for Presence
 
 You can check if a parameter is present or empty.
@@ -1097,7 +1109,7 @@ McpSamplingRequest request = McpSamplingRequest.builder()
                 .costPriority(0.1)
                 .speedPriority(0.1)
                 .hints(List.of("hint1"))
-                .metadata(JsonValue.TRUE)
+                .metadata(Map.of("requestId", "example-request"))
                 .intelligencePriority(0.1)
                 .systemPrompt("system prompt")
                 .timeout(Duration.ofSeconds(10))
@@ -1109,6 +1121,11 @@ McpSamplingRequest request = McpSamplingRequest.builder()
                                                      .build())
                 .build();
 ```
+
+Sampling metadata is serialized using Helidon JSON binding. The metadata option accepts `Object`; maps, collections,
+arrays, primitives, and converter-backed custom classes are supported. See
+[Migrate from JSON-B to Helidon JSON Binding](upgrade_guide_1.2.md#migrate-from-json-b-to-helidon-json-binding) for the
+compatibility impact and migration steps.
 
 Once your request is built, send it using the sampling feature.
 

--- a/docs/mcp/upgrade_guide_1.2.md
+++ b/docs/mcp/upgrade_guide_1.2.md
@@ -1,0 +1,157 @@
+# Upgrade Guide for Version 1.2.0
+
+Helidon MCP `1.2.0` upgrades the Helidon baseline to `4.5.0` and replaces the server's JSON-B and JSON-P integration
+with Helidon JSON Binding. This document summarizes the key changes and explains how to migrate existing code to
+`1.2.0`.
+
+## Overview of Changes
+
+- The Helidon version is upgraded to `4.5.0`.
+- Helidon MCP now uses Helidon JSON Binding for MCP parameter conversion, structured tool content, and sampling
+  metadata.
+- Yasson and the JSON-B, JSON-P, and Parsson dependencies are no longer provided by Helidon MCP.
+- Custom classes used for MCP JSON serialization or deserialization must have a discoverable Helidon JSON converter.
+- `McpSamplingRequest.metadata()` now returns `Optional<Object>`, and its builder accepts `Object` instead of
+  `jakarta.json.JsonValue`.
+
+The sections below describe how to migrate applications to version `1.2.0`.
+
+## Migrate from JSON-B to Helidon JSON Binding
+
+Helidon MCP now uses Helidon JSON Binding for parameter conversion, structured tool content, and sampling metadata.
+Yasson and the JSON-B, JSON-P, and Parsson dependencies are no longer used or provided by Helidon MCP.
+
+### Application impact
+
+Maps, collections, arrays, primitives, and enums continue to work without additional configuration. Applications that
+use custom classes with MCP parameter conversion, structured content, or sampling metadata must provide a Helidon JSON
+converter. JSON-B annotations and unregistered POJOs are no longer supported by Helidon MCP.
+
+Applications can continue to use JSON-B independently for their own serialization, but they must declare and configure
+those dependencies themselves.
+
+### Providing a converter
+
+Helidon MCP creates its own default `JsonBinding` instance, so converters must be discoverable through the Helidon
+Service Registry. Registering a converter only with a separate, application-owned `JsonBinding` instance does not make
+that converter available to Helidon MCP.
+
+Parameter conversion through `McpParameters.as(...)` requires a deserializer. Structured tool content and sampling
+metadata require a serializer. A `JsonConverter` provides both directions.
+
+#### Generate a converter
+
+The recommended approach for application-owned classes is to let Helidon generate and register the converter. Declare
+the JSON binding dependency directly:
+
+```xml
+<dependency>
+    <groupId>io.helidon.json</groupId>
+    <artifactId>helidon-json-binding</artifactId>
+</dependency>
+```
+
+Annotate each custom class with `@Json.Entity`:
+
+```java
+import io.helidon.json.binding.Json;
+
+@Json.Entity
+record Result(String value) {
+}
+```
+
+Enable the Helidon annotation processors in the application build. The APT bundle contains both the JSON converter and
+Service Registry processors:
+
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <annotationProcessorPaths>
+                    <path>
+                        <groupId>io.helidon.bundles</groupId>
+                        <artifactId>helidon-bundles-apt</artifactId>
+                        <version>${helidon.version}</version>
+                    </path>
+                </annotationProcessorPaths>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+```
+
+Use the same Helidon version as the application. During compilation, Helidon generates a `JsonConverter` and its
+Service Registry descriptor. Helidon MCP then discovers the converter automatically at runtime; no MCP-specific
+registration is required.
+
+#### Provide a handwritten converter
+
+For a third-party type that cannot be annotated, or when its JSON representation requires custom logic, implement
+`JsonConverter` and register the implementation as a Helidon service:
+
+```java
+import io.helidon.common.GenericType;
+import io.helidon.json.JsonGenerator;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonParser;
+import io.helidon.json.binding.JsonConverter;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+final class ExternalResultConverter implements JsonConverter<ExternalResult> {
+    private static final GenericType<ExternalResult> TYPE = GenericType.create(ExternalResult.class);
+
+    @Override
+    public void serialize(JsonGenerator generator, ExternalResult result, boolean writeNulls) {
+        generator.writeObjectStart();
+        generator.write("value", result.value());
+        generator.writeObjectEnd();
+    }
+
+    @Override
+    public ExternalResult deserialize(JsonParser parser) {
+        JsonObject object = parser.readJsonObject();
+        return new ExternalResult(object.stringValue("value").orElseThrow());
+    }
+
+    @Override
+    public GenericType<ExternalResult> type() {
+        return TYPE;
+    }
+}
+```
+
+The `helidon-bundles-apt` configuration shown above generates the Service Registry descriptor that makes the
+handwritten converter discoverable. If only one direction is required, an application may instead implement
+`JsonSerializer` or `JsonDeserializer` and register it in the same way.
+
+See the [Helidon JSON Processing documentation](https://helidon.io/docs/v4/se/json#json-binding) for converter
+generation, annotation processor alternatives, custom serializers and deserializers, and binding factories.
+
+### Sampling metadata incompatibility
+
+`McpSamplingRequest.metadata()` now returns `Optional<Object>`, and the builder accepts `Object` instead of
+`jakarta.json.JsonValue`. This is a backward-incompatible API change. Recompile existing applications and replace JSON-P
+metadata values with regular Java values or Helidon JSON-bound classes.
+
+Previous usage:
+
+```java
+McpSamplingRequest request = McpSamplingRequest.builder()
+        .metadata(JsonValue.TRUE)
+        .build();
+```
+
+Updated usage:
+
+```java
+McpSamplingRequest request = McpSamplingRequest.builder()
+        .metadata(Map.of("requestId", "example-request"))
+        .build();
+```
+
+Code compiled against the previous builder signature must be rebuilt to avoid a `NoSuchMethodError` at runtime.

--- a/examples/calendar-application/calendar-declarative/pom.xml
+++ b/examples/calendar-application/calendar-declarative/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.4.0</version>
+        <version>4.5.0</version>
         <relativePath/>
     </parent>
 
@@ -48,20 +48,16 @@
             <artifactId>helidon-webclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.http.media</groupId>
-            <artifactId>helidon-http-media-jsonb</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.json.schema</groupId>
             <artifactId>helidon-json-schema</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json-binding</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.logging</groupId>

--- a/examples/calendar-application/calendar-declarative/src/main/java/io/helidon/extensions/mcp/examples/calendar/declarative/CalendarEvent.java
+++ b/examples/calendar-application/calendar-declarative/src/main/java/io/helidon/extensions/mcp/examples/calendar/declarative/CalendarEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,13 @@ package io.helidon.extensions.mcp.examples.calendar.declarative;
 
 import java.util.List;
 
+import io.helidon.json.binding.Json;
 import io.helidon.json.schema.JsonSchema;
 
 /**
  * Calendar Event.
  */
+@Json.Entity
 @JsonSchema.Schema
 @JsonSchema.Title("Calendar Event")
 public class CalendarEvent {

--- a/examples/calendar-application/calendar-microprofile/pom.xml
+++ b/examples/calendar-application/calendar-microprofile/pom.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-mp</artifactId>
+        <version>4.5.0</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>io.helidon.extensions.mcp.examples</groupId>
+    <artifactId>helidon4-extensions-mcp-calendar-microprofile</artifactId>
+    <version>1.1.0-SNAPSHOT</version>
+
+    <name>Helidon extensions MCP Calendar Microprofile</name>
+
+    <properties>
+        <version.lib.mcp-sdk>0.11.3</version.lib.mcp-sdk>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.extensions.mcp</groupId>
+            <artifactId>helidon4-extensions-mcp-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.json.schema</groupId>
+            <artifactId>helidon-json-schema</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json-binding</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>jandex</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-mcp</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <artifactId>mcp</artifactId>
+            <version>${version.lib.mcp-sdk}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.testing</groupId>
+            <artifactId>helidon-microprofile-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.bundles</groupId>
+                            <artifactId>helidon-bundles-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.extensions.mcp</groupId>
+                            <artifactId>helidon4-extensions-mcp-codegen</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!-- Maven plugin that generates the application binding -->
+                <groupId>io.helidon.service</groupId>
+                <artifactId>helidon-service-maven-plugin</artifactId>
+                <version>${helidon.version}</version>
+                <executions>
+                    <execution>
+                        <id>create-application</id>
+                        <goals>
+                            <goal>create-application</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/examples/calendar-application/calendar-microprofile/src/main/java/io/helidon/extensions/mcp/examples/calendar/microprofile/Calendar.java
+++ b/examples/calendar-application/calendar-microprofile/src/main/java/io/helidon/extensions/mcp/examples/calendar/microprofile/Calendar.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.mcp.examples.calendar.microprofile;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import io.helidon.extensions.mcp.server.McpException;
+import io.helidon.service.registry.Service;
+
+/**
+ * The calendar is a temporary file containing a list of created events.
+ */
+@Service.Singleton
+final class Calendar {
+
+    private final Path file;
+
+    Calendar() {
+        try {
+            this.file = Files.createTempFile("calendar", "-calendar");
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+    }
+
+    String readContent() {
+        try {
+            return Files.readString(file);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    String readContentMatchesLine(Predicate<String> lineMatcher) {
+        try {
+            return Files.readAllLines(file)
+                    .stream()
+                    .filter(lineMatcher)
+                    .collect(Collectors.joining("\n"));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    List<String> readEventNames() {
+        String prefix = "name: ";
+        List<String> values = new ArrayList<>();
+        String contents = readContent();
+        for (int i = 0; i < contents.length();) {
+            int k = contents.indexOf(prefix, i);
+            if (k == -1) {
+                break;
+            }
+            int j = contents.indexOf(", ", k);
+            values.add(contents.substring(k + prefix.length(), j));
+            i = j + 1;
+        }
+        return values;
+    }
+
+    void createNewEvent(String name, String date, List<String> attendees) {
+        try {
+            String content = String.format("Event: { name: %s, date: %s, attendees: %s }\n", name, date, attendees);
+            Files.writeString(file, content, StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            throw new McpException("Error happened when writing to event registry", e);
+        }
+    }
+}

--- a/examples/calendar-application/calendar-microprofile/src/main/java/io/helidon/extensions/mcp/examples/calendar/microprofile/CalendarEvent.java
+++ b/examples/calendar-application/calendar-microprofile/src/main/java/io/helidon/extensions/mcp/examples/calendar/microprofile/CalendarEvent.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.mcp.examples.calendar.microprofile;
+
+import java.util.List;
+
+import io.helidon.json.binding.Json;
+import io.helidon.json.schema.JsonSchema;
+
+/**
+ * Calendar Event.
+ */
+@Json.Entity
+@JsonSchema.Schema
+@JsonSchema.Title("Calendar Event")
+public class CalendarEvent {
+
+    @JsonSchema.Required
+    @JsonSchema.Description("Calendar event name")
+    private String name;
+
+    @JsonSchema.Required
+    @JsonSchema.Description("Calendar event date")
+    private String date;
+
+    @JsonSchema.Required
+    @JsonSchema.Description("Calendar event attendees")
+    private List<String> attendees;
+
+    /**
+     * Create a new instance of {@code CalendarEvent}.
+     */
+    public CalendarEvent() {
+    }
+
+    /**
+     * Get event name.
+     *
+     * @return name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Get event date.
+     *
+     * @return date
+     */
+    public String getDate() {
+        return date;
+    }
+
+    /**
+     * Get event attendees.
+     *
+     * @return attendees
+     */
+    public List<String> getAttendees() {
+        return attendees;
+    }
+
+    /**
+     * Set event name.
+     *
+     * @param name the event name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Set event date.
+     *
+     * @param date the event date
+     */
+    public void setDate(String date) {
+        this.date = date;
+    }
+
+    /**
+     * Set event attendees.
+     *
+     * @param attendees the event attendees
+     */
+    public void setAttendees(List<String> attendees) {
+        this.attendees = attendees;
+    }
+}

--- a/examples/calendar-application/calendar-microprofile/src/main/java/io/helidon/extensions/mcp/examples/calendar/microprofile/McpCalendarServer.java
+++ b/examples/calendar-application/calendar-microprofile/src/main/java/io/helidon/extensions/mcp/examples/calendar/microprofile/McpCalendarServer.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.mcp.examples.calendar.microprofile;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.extensions.mcp.server.Mcp;
+import io.helidon.extensions.mcp.server.McpCompletionResult;
+import io.helidon.extensions.mcp.server.McpCompletionType;
+import io.helidon.extensions.mcp.server.McpException;
+import io.helidon.extensions.mcp.server.McpFeatures;
+import io.helidon.extensions.mcp.server.McpLogger;
+import io.helidon.extensions.mcp.server.McpParameters;
+import io.helidon.extensions.mcp.server.McpProgress;
+import io.helidon.extensions.mcp.server.McpPromptResult;
+import io.helidon.extensions.mcp.server.McpResourceResult;
+import io.helidon.extensions.mcp.server.McpRole;
+import io.helidon.extensions.mcp.server.McpToolResult;
+import io.helidon.service.registry.Service;
+
+@Mcp.Path("/calendar")
+@Mcp.Server("helidon-mcp-calendar-manager")
+class McpCalendarServer {
+    private final Calendar calendar;
+    static final String[] FRIENDS = new String[] {
+            "Frank, Tweety", "Frank, Daffy", "Frank, Tweety, Daffy"
+    };
+    static final String EVENTS_URI = "file://events";
+    static final String EVENTS_URI_TEMPLATE = EVENTS_URI + "/{name}";
+    static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    @Service.Inject
+    McpCalendarServer(Calendar calendar) {
+        this.calendar = calendar;
+    }
+
+    // -- Tools ---------------------------------------------------------------
+
+    /**
+     * Tool that returns all calendar events on a certain date or all events
+     * if no date is provided.
+     *
+     * @param date the date or {@code ""} if not provided
+     * @return list of calendar events
+     */
+    @Mcp.Tool("List calendar events")
+    McpToolResult listCalendarEvents(String date) {
+        String entries = calendar.readContentMatchesLine(
+                line -> date.isEmpty() || line.contains("date: " + date));
+        return McpToolResult.create(entries);
+    }
+
+    /**
+     * Tool that adds a new calendar event with a name, date and list of
+     * attendees.
+     *
+     * @param features the MCP features
+     * @param event    the event
+     * @return text confirming event being created
+     */
+    @Mcp.Tool("Adds a new event to the calendar")
+    McpToolResult addCalendarEvent(McpFeatures features, CalendarEvent event) {
+        if (event.getName().isEmpty() || event.getDate().isEmpty() || event.getAttendees().isEmpty()) {
+            throw new McpException("Missing required arguments name, date or attendees");
+        }
+
+        McpLogger logger = features.logger();
+        McpProgress progress = features.progress();
+        progress.total(100);
+        logger.info("Request to add new event");
+        progress.send(0);
+        calendar.createNewEvent(event.getName(), event.getDate(), event.getAttendees());
+        progress.send(50);
+        features.subscriptions().sendUpdate(EVENTS_URI);
+        progress.send(100);
+
+        return McpToolResult.create("New event added to the calendar");
+    }
+
+    // -- Resources -----------------------------------------------------------
+
+    /**
+     * Resource whose representation is a list of all calendar events created.
+     *
+     * @param logger the MCP logger
+     * @return text with a list of calendar events
+     */
+    @Mcp.Resource(uri = EVENTS_URI,
+                  mediaType = MediaTypes.TEXT_PLAIN_VALUE,
+                  description = "List of calendar events created")
+    McpResourceResult eventsResource(McpLogger logger) {
+        logger.debug("Reading calendar events from registry...");
+        String content = calendar.readContent();
+        return McpResourceResult.create(content);
+    }
+
+    /**
+     * Resource whose representation is a single calendar event given its name.
+     *
+     * @param logger the MCP logger
+     * @param name   the event's name
+     * @return text with calendar event lines or empty line if not found
+     */
+    @Mcp.Resource(uri = EVENTS_URI_TEMPLATE,
+                  mediaType = MediaTypes.TEXT_PLAIN_VALUE,
+                  description = "List single calendar event by name")
+    McpResourceResult eventResourceTemplate(McpLogger logger, String name) {
+        logger.debug("Reading calendar events from registry...");
+        String content = calendar.readContentMatchesLine(line -> line.contains("name: " + name));
+        return McpResourceResult.builder().addTextContent(content).build();
+    }
+
+    /**
+     * Completion for event resource template that returns possible event names
+     * containing {@code nameValue} as a substring.
+     *
+     * @param nameValue the value for the name template argument
+     * @return list of possible values or empty
+     */
+    @Mcp.Completion(value = EVENTS_URI_TEMPLATE,
+                    type = McpCompletionType.RESOURCE)
+    McpCompletionResult eventResourceTemplateCompletion(String nameValue) {
+        List<String> values = calendar.readEventNames()
+                .stream()
+                .filter(name -> name.contains(nameValue))
+                .toList();
+        return McpCompletionResult.create(values);
+    }
+
+    // -- Prompts -------------------------------------------------------------
+
+    /**
+     * Prompt to create a new event given a name, date and attendees.
+     *
+     * @param logger    the MCP logger
+     * @param name      the event's name
+     * @param date      the event's date
+     * @param attendees the list of attendees
+     * @return text with prompt
+     */
+    @Mcp.Prompt("Prompt to create a new event given a name, date and attendees")
+    McpPromptResult createEventPrompt(McpLogger logger,
+                                      @Mcp.Description("event's name") String name,
+                                      @Mcp.Description("event's date") String date,
+                                      @Mcp.Description("event's attendees") String attendees) {
+        logger.debug("Creating calendar event prompt...");
+        return McpPromptResult.builder()
+                .addTextContent(t -> t
+                        .text("""
+                                  Create a new calendar event with name %s, on %s with attendees %s. Make
+                                  sure all attendees are free to attend the event.
+                                  """.formatted(name, date, attendees))
+                        .role(McpRole.USER))
+                .build();
+    }
+
+    /**
+     * Completion for prompt.
+     *
+     * @param parameters the MCP parameters
+     * @return list of possible values or empty
+     */
+    @Mcp.Completion(value = "createEventPrompt",
+                    type = McpCompletionType.PROMPT)
+    McpCompletionResult createEventPromptCompletion(McpParameters parameters) {
+        String promptName = parameters.get("argument").get("name").asString().orElse(null);
+        if ("name".equals(promptName)) {
+            return McpCompletionResult.create("Frank & Friends");
+        }
+        if ("date".equals(promptName)) {
+            LocalDate today = LocalDate.now();
+            String[] dates = new String[3];
+            for (int i = 0; i < dates.length; i++) {
+                dates[i] = today.plusDays(i).format(FORMATTER);
+            }
+            return McpCompletionResult.create(dates);
+        }
+        if ("attendees".equals(promptName)) {
+            return McpCompletionResult.create(FRIENDS);
+        }
+        // no completion
+        return McpCompletionResult.create();
+    }
+}

--- a/examples/calendar-application/calendar-microprofile/src/main/java/io/helidon/extensions/mcp/examples/calendar/microprofile/package-info.java
+++ b/examples/calendar-application/calendar-microprofile/src/main/java/io/helidon/extensions/mcp/examples/calendar/microprofile/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Helidon MCP Calendar application MicroProfile example.
+ */
+package io.helidon.extensions.mcp.examples.calendar.microprofile;

--- a/examples/calendar-application/calendar-microprofile/src/main/resources/META-INF/beans.xml
+++ b/examples/calendar-application/calendar-microprofile/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                           https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/examples/calendar-application/calendar-microprofile/src/main/resources/application.yaml
+++ b/examples/calendar-application/calendar-microprofile/src/main/resources/application.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server:
+  port: 8080
+  host: 0.0.0.0

--- a/examples/calendar-application/calendar-microprofile/src/test/java/io/helidon/extensions/mcp/examples/calendar/microprofile/CompletionTest.java
+++ b/examples/calendar-application/calendar-microprofile/src/test/java/io/helidon/extensions/mcp/examples/calendar/microprofile/CompletionTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.examples.calendar.microprofile;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import io.helidon.microprofile.testing.Socket;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@HelidonTest
+class CompletionTest {
+    private final URI uri;
+
+    @Inject
+    CompletionTest(@Socket("@default") URI uri) {
+        this.uri = uri;
+    }
+
+    @Test
+    void testPromptCompletion() {
+        try (McpSyncClient client = McpClient.sync(
+                HttpClientStreamableHttpTransport.builder(uri.toASCIIString())
+                        .endpoint("/calendar")
+                        .build()).build()) {
+            client.initialize();
+            McpSchema.CompleteRequest request = new McpSchema.CompleteRequest(
+                    new McpSchema.PromptReference("createEventPrompt"),
+                    new McpSchema.CompleteRequest.CompleteArgument("name", "Frank"));
+            McpSchema.CompleteResult.CompleteCompletion completion = client.completeCompletion(request).completion();
+
+            assertThat(completion.hasMore(), is(false));
+            assertThat(completion.total(), is(1));
+            assertThat(completion.values(), is(List.of("Frank & Friends")));
+        }
+    }
+
+    @Test
+    void testResourceCompletion() {
+        try (McpSyncClient client = McpClient.sync(
+                HttpClientStreamableHttpTransport.builder(uri.toASCIIString())
+                        .endpoint("/calendar")
+                        .build()).build()) {
+            client.initialize();
+            Map<String, Object> arguments = Map.of(
+                    "event", Map.of(
+                            "name", "Frank-birthday",
+                            "date", "2021-04-20",
+                            "attendees", List.of("Frank")));
+            McpSchema.CallToolRequest callToolRequest = new McpSchema.CallToolRequest("addCalendarEvent", arguments);
+            McpSchema.CallToolResult callToolResult = client.callTool(callToolRequest);
+            assertThat(callToolResult.isError(), is(false));
+
+            McpSchema.CompleteRequest request = new McpSchema.CompleteRequest(
+                    new McpSchema.ResourceReference(McpCalendarServer.EVENTS_URI_TEMPLATE),
+                    new McpSchema.CompleteRequest.CompleteArgument("name", "Frank"));
+            McpSchema.CompleteResult.CompleteCompletion completion = client.completeCompletion(request).completion();
+
+            assertThat(completion.hasMore(), is(false));
+            assertThat(completion.total(), is(1));
+            assertThat(completion.values(), is(List.of("Frank-birthday")));
+        }
+    }
+}

--- a/examples/calendar-application/calendar-microprofile/src/test/java/io/helidon/extensions/mcp/examples/calendar/microprofile/MainTest.java
+++ b/examples/calendar-application/calendar-microprofile/src/test/java/io/helidon/extensions/mcp/examples/calendar/microprofile/MainTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.examples.calendar.microprofile;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.microprofile.testing.Socket;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.McpGetPromptResult;
+import dev.langchain4j.mcp.client.McpPrompt;
+import dev.langchain4j.mcp.client.McpPromptArgument;
+import dev.langchain4j.mcp.client.McpPromptMessage;
+import dev.langchain4j.mcp.client.McpResource;
+import dev.langchain4j.mcp.client.McpResourceContents;
+import dev.langchain4j.mcp.client.McpResourceTemplate;
+import dev.langchain4j.mcp.client.McpRole;
+import dev.langchain4j.mcp.client.McpTextContent;
+import dev.langchain4j.mcp.client.McpTextResourceContents;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+
+@HelidonTest
+@TestMethodOrder(OrderAnnotation.class)
+public class MainTest {
+    private final McpClient client;
+
+    @Inject
+    MainTest(@Socket("@default") URI uri) {
+        McpTransport transport = new StreamableHttpMcpTransport.Builder()
+                .url(uri.toASCIIString() + "/calendar")
+                .logRequests(true)
+                .logResponses(true)
+                .timeout(Duration.ofSeconds(1))
+                .build();
+        client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .initializationTimeout(Duration.ofSeconds(1))
+                .build();
+    }
+
+    @Test
+    @Order(1)
+    void testToolList() {
+        List<ToolSpecification> tools = client.listTools();
+        assertThat(tools.size(), is(2));
+
+        ToolSpecification tool1 = tools.stream()
+                .filter(it -> it.name().equals("listCalendarEvents"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(tool1.name(), is("listCalendarEvents"));
+        assertThat(tool1.description(), is("List calendar events"));
+
+        assertThat(tool1.parameters().properties().keySet(), hasItems("date"));
+
+        ToolSpecification tool2 = tools.stream()
+                .filter(it -> it.name().equals("addCalendarEvent"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(tool2.name(), is("addCalendarEvent"));
+        assertThat(tool2.description(), is("Adds a new event to the calendar"));
+
+        assertThat(tool2.parameters().properties().keySet(), hasItems("event"));
+    }
+
+    @Test
+    @Order(2)
+    void testAddToolCall() {
+        var result = client.executeTool(ToolExecutionRequest.builder()
+                .name("addCalendarEvent")
+                .arguments("""
+                        {
+                          "event": {
+                            "name": "Frank-birthday",
+                            "date": "2021-04-20",
+                            "attendees": ["Frank"]
+                          }
+                        }
+                        """)
+                .build());
+
+        assertThat(result.resultText(), is("New event added to the calendar"));
+    }
+
+    @Test
+    @Order(3)
+    void testListToolCall() {
+        var result = client.executeTool(ToolExecutionRequest.builder()
+                .name("listCalendarEvents")
+                .arguments("{\"date\":\"2021-04-20\"}")
+                .build());
+
+        assertThat(result.resultText(), containsString("Frank-birthday"));
+    }
+
+    @Test
+    @Order(4)
+    void testPromptList() {
+        List<McpPrompt> prompts = client.listPrompts();
+        assertThat(prompts.size(), is(1));
+
+        McpPrompt prompt = prompts.getFirst();
+        assertThat(prompt.name(), is("createEventPrompt"));
+        assertThat(prompt.description(), is("Prompt to create a new event given a name, date and attendees"));
+
+        List<McpPromptArgument> arguments = prompt.arguments();
+        arguments.sort(this::sortArguments);
+        assertThat(arguments.size(), is(3));
+
+        McpPromptArgument attendees = arguments.getFirst();
+        assertThat(attendees.name(), is("attendees"));
+        assertThat(attendees.description(), is("event's attendees"));
+        assertThat(attendees.required(), is(true));
+
+        McpPromptArgument date = arguments.get(1);
+        assertThat(date.name(), is("date"));
+        assertThat(date.description(), is("event's date"));
+        assertThat(date.required(), is(true));
+
+        McpPromptArgument name = arguments.getLast();
+        assertThat(name.name(), is("name"));
+        assertThat(name.description(), is("event's name"));
+        assertThat(name.required(), is(true));
+    }
+
+    @Test
+    @Order(5)
+    void testPromptCall() {
+        Map<String, Object> arguments = Map.of("name", "Frank-birthday", "date", "2021-04-20", "attendees", "Frank");
+        McpGetPromptResult promptResult = client.getPrompt("createEventPrompt", arguments);
+        assertThat(promptResult.description(), is(nullValue()));
+
+        List<McpPromptMessage> messages = promptResult.messages();
+        assertThat(messages.size(), is(1));
+
+        McpPromptMessage message = messages.getFirst();
+        assertThat(message.role(), is(McpRole.USER));
+        assertThat(message.content(), instanceOf(McpTextContent.class));
+
+        McpTextContent textContent = (McpTextContent) message.content();
+        assertThat(textContent.text(), containsString("Create a new calendar event with name Frank-birthday"));
+        assertThat(textContent.text(), containsString("on 2021-04-20"));
+        assertThat(textContent.text(), containsString("attendees Frank"));
+    }
+
+    @Test
+    @Order(6)
+    void testResourceList() {
+        List<McpResource> resources = client.listResources();
+        assertThat(resources.size(), is(1));
+
+        McpResource resource = resources.getFirst();
+        assertThat(resource.name(), is("eventsResource"));
+        assertThat(resource.uri(), startsWith("file://"));
+        assertThat(resource.mimeType(), is(MediaTypes.TEXT_PLAIN_VALUE));
+        assertThat(resource.description(), is("List of calendar events created"));
+    }
+
+    @Test
+    @Order(7)
+    void testResourceCall() {
+        String uri = client.listResources().getFirst().uri();
+        var result = client.readResource(uri);
+
+        List<McpResourceContents> contents = result.contents();
+        assertThat(contents.size(), is(1));
+
+        McpResourceContents content = contents.getFirst();
+        assertThat(content, instanceOf(McpTextResourceContents.class));
+
+        McpTextResourceContents textContent = (McpTextResourceContents) content;
+        assertThat(textContent.uri(), is(uri));
+        assertThat(textContent.mimeType(), is(MediaTypes.TEXT_PLAIN_VALUE));
+        assertThat(textContent.text(), is("Event: { name: Frank-birthday, date: 2021-04-20, attendees: [Frank] }\n"));
+    }
+
+    @Test
+    @Order(8)
+    void testResourceTemplateList() {
+        List<McpResourceTemplate> templates = client.listResourceTemplates();
+        assertThat(templates.size(), is(1));
+
+        McpResourceTemplate template = templates.getFirst();
+        assertThat(template.uriTemplate(), containsString("{name}"));
+        assertThat(template.mimeType(), is(MediaTypes.TEXT_PLAIN_VALUE));
+        assertThat(template.name(), is("eventResourceTemplate"));
+        assertThat(template.description(), is("List single calendar event by name"));
+    }
+
+    @Test
+    @Order(9)
+    void testResourceTemplateCall() {
+        var result = client.readResource("file://events/Frank-birthday");
+        var contents = result.contents();
+        assertThat(contents.size(), is(1));
+
+        McpResourceContents content = contents.getFirst();
+        assertThat(content, instanceOf(McpTextResourceContents.class));
+
+        McpTextResourceContents text = (McpTextResourceContents) content;
+        assertThat(text.uri(), is("file://events/Frank-birthday"));
+        assertThat(text.mimeType(), is(MediaTypes.TEXT_PLAIN_VALUE));
+        assertThat(text.text(), is("Event: { name: Frank-birthday, date: 2021-04-20, attendees: [Frank] }"));
+    }
+
+    private int sortArguments(McpPromptArgument first, McpPromptArgument second) {
+        return first.name().compareTo(second.name());
+    }
+}

--- a/examples/calendar-application/calendar-stateless/pom.xml
+++ b/examples/calendar-application/calendar-stateless/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.4.0</version>
+        <version>4.5.0</version>
         <relativePath/>
     </parent>
 
@@ -47,16 +47,8 @@
             <artifactId>helidon-webclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.http.media</groupId>
-            <artifactId>helidon-http-media-jsonb</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-yaml</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.logging</groupId>
@@ -71,6 +63,11 @@
         <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient-jsonrpc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/calendar-application/calendar-stateless/src/main/java/io/helidon/extensions/mcp/examples/calendar/AddCalendarEventTool.java
+++ b/examples/calendar-application/calendar-stateless/src/main/java/io/helidon/extensions/mcp/examples/calendar/AddCalendarEventTool.java
@@ -89,11 +89,11 @@ final class AddCalendarEventTool implements McpTool {
                 .orElseThrow(() -> requiredArgument("date"));
         List<String> attendees = mcpParameters.get("attendees")
                 .asList()
-                .orElseThrow(() -> requiredArgument("attendees"))
-                .stream()
-                .map(McpParameters::asString)
-                .map(OptionalValue::get)
-                .toList();
+                .map(values -> values.stream()
+                        .map(McpParameters::asString)
+                        .map(OptionalValue::get)
+                        .toList())
+                .orElseThrow(() -> requiredArgument("attendees"));
 
         calendar.createNewEvent(name, date, attendees);
 

--- a/examples/calendar-application/calendar-stateless/src/test/java/io/helidon/extensions/mcp/examples/calendar/StatelessClientTest.java
+++ b/examples/calendar-application/calendar-stateless/src/test/java/io/helidon/extensions/mcp/examples/calendar/StatelessClientTest.java
@@ -19,6 +19,10 @@ package io.helidon.extensions.mcp.examples.calendar;
 import java.util.List;
 
 import io.helidon.common.media.type.MediaTypes;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
+import io.helidon.jsonrpc.core.JsonRpcResult;
 import io.helidon.webclient.jsonrpc.JsonRpcClient;
 import io.helidon.webclient.jsonrpc.JsonRpcClientResponse;
 import io.helidon.webserver.WebServer;
@@ -26,9 +30,6 @@ import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.json.spi.JsonProvider;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -43,11 +44,13 @@ import static org.hamcrest.Matchers.startsWith;
 @ServerTest
 @TestMethodOrder(OrderAnnotation.class)
 class StatelessClientTest {
-    private static final JsonProvider JSON_PROVIDER = JsonProvider.provider();
     private final JsonRpcClient client;
 
     StatelessClientTest(WebServer server) {
-        this.client = JsonRpcClient.create(builder -> builder.baseUri("http://localhost:" + server.port() + "/calendar"));
+        this.client = JsonRpcClient.create(builder ->
+                                                   builder.baseUri("http://localhost:"
+                                                                           + server.port()
+                                                                           + "/calendar"));
     }
 
     @SetUpRoute
@@ -61,32 +64,42 @@ class StatelessClientTest {
         try (var response = client.rpcMethod("tools/list")
                 .rpcId(1)
                 .submit()) {
-            JsonArray tools = result(response).getJsonArray("tools");
+            JsonArray tools = result(response).arrayValue("tools").orElseThrow();
             assertThat(tools.size(), is(2));
 
-            JsonObject addTool = tools.getJsonObject(0);
-            assertThat(addTool.getString("name"), is("add-calendar-event"));
-            assertThat(addTool.getString("description"), is("Adds a new event to the calendar"));
-            JsonObject addSchema = addTool.getJsonObject("inputSchema");
-            assertThat(addSchema.getString("type"), is("object"));
-            assertThat(addSchema.getJsonObject("properties").keySet(), hasItems("name", "date", "attendees"));
+            JsonObject addTool = tools.get(0)
+                    .map(JsonValue::asObject)
+                    .orElseThrow();
+            assertThat(addTool.stringValue("name").orElseThrow(), is("add-calendar-event"));
+            assertThat(addTool.stringValue("description").orElseThrow(), is("Adds a new event to the calendar"));
+            JsonObject addSchema = addTool.objectValue("inputSchema").orElseThrow();
+            assertThat(addSchema.stringValue("type").orElseThrow(), is("object"));
+            var addProperties = addSchema.objectValue("properties")
+                    .map(JsonObject::keysAsStrings)
+                    .orElseThrow();
+            assertThat(addProperties, hasItems("name", "date", "attendees"));
 
-            JsonObject listTool = tools.getJsonObject(1);
-            assertThat(listTool.getString("name"), is("list-calendar-events"));
-            assertThat(listTool.getString("description"), is("List calendar events"));
-            JsonObject listSchema = listTool.getJsonObject("inputSchema");
-            assertThat(listSchema.getString("type"), is("object"));
-            assertThat(listSchema.getJsonObject("properties").keySet(), hasItems("date"));
+            JsonObject listTool = tools.get(1)
+                    .map(JsonValue::asObject)
+                    .orElseThrow();
+            assertThat(listTool.stringValue("name").orElseThrow(), is("list-calendar-events"));
+            assertThat(listTool.stringValue("description").orElseThrow(), is("List calendar events"));
+            JsonObject listSchema = listTool.objectValue("inputSchema").orElseThrow();
+            assertThat(listSchema.stringValue("type").orElseThrow(), is("object"));
+            var listProperties = listSchema.objectValue("properties")
+                    .map(JsonObject::keysAsStrings)
+                    .orElseThrow();
+            assertThat(listProperties, hasItems("date"));
         }
     }
 
     @Test
     @Order(2)
     void testAddToolCall() {
-        JsonObject arguments = JSON_PROVIDER.createObjectBuilder()
-                .add("name", "Frank-birthday")
-                .add("date", "2021-04-20")
-                .add("attendees", JSON_PROVIDER.createArrayBuilder(List.of("Frank")))
+        JsonObject arguments = JsonObject.builder()
+                .set("name", "Frank-birthday")
+                .set("date", "2021-04-20")
+                .setStrings("attendees", List.of("Frank"))
                 .build();
 
         try (var response = client.rpcMethod("tools/call")
@@ -95,18 +108,21 @@ class StatelessClientTest {
                 .param("arguments", arguments)
                 .submit()) {
             JsonObject result = result(response);
-            assertThat(result.getBoolean("isError"), is(false));
-            JsonObject content = result.getJsonArray("content").getJsonObject(0);
-            assertThat(content.getString("type"), is("text"));
-            assertThat(content.getString("text"), is("New event added to the calendar"));
+            assertThat(result.booleanValue("isError").orElseThrow(), is(false));
+            JsonObject content = result.arrayValue("content")
+                    .flatMap(array -> array.get(0))
+                    .map(JsonValue::asObject)
+                    .orElseThrow();
+            assertThat(content.stringValue("type").orElseThrow(), is("text"));
+            assertThat(content.stringValue("text").orElseThrow(), is("New event added to the calendar"));
         }
     }
 
     @Test
     @Order(3)
     void testListToolCall() {
-        JsonObject arguments = JSON_PROVIDER.createObjectBuilder()
-                .add("date", "2021-04-20")
+        JsonObject arguments = JsonObject.builder()
+                .set("date", "2021-04-20")
                 .build();
 
         try (var response = client.rpcMethod("tools/call")
@@ -115,10 +131,13 @@ class StatelessClientTest {
                 .param("arguments", arguments)
                 .submit()) {
             JsonObject result = result(response);
-            assertThat(result.getBoolean("isError"), is(false));
-            JsonObject content = result.getJsonArray("content").getJsonObject(0);
-            assertThat(content.getString("type"), is("text"));
-            assertThat(content.getString("text"), containsString("Frank-birthday"));
+            assertThat(result.booleanValue("isError").orElseThrow(), is(false));
+            JsonObject content = result.arrayValue("content")
+                    .flatMap(array -> array.get(0))
+                    .map(JsonValue::asObject)
+                    .orElseThrow();
+            assertThat(content.stringValue("type").orElseThrow(), is("text"));
+            assertThat(content.stringValue("text").orElseThrow(), containsString("Frank-birthday"));
         }
     }
 
@@ -128,28 +147,50 @@ class StatelessClientTest {
         try (var response = client.rpcMethod("prompts/list")
                 .rpcId(4)
                 .submit()) {
-            JsonArray prompts = result(response).getJsonArray("prompts");
+            JsonArray prompts = result(response).arrayValue("prompts").orElseThrow();
             assertThat(prompts.size(), is(1));
 
-            JsonObject prompt = prompts.getJsonObject(0);
-            assertThat(prompt.getString("name"), is("create-event"));
-            assertThat(prompt.getString("description"), is("Create a new event and add it to the calendar"));
+            JsonObject prompt = prompts.get(0)
+                    .map(JsonValue::asObject)
+                    .orElseThrow();
+            assertThat(prompt.stringValue("name").orElseThrow(), is("create-event"));
+            assertThat(prompt.stringValue("description").orElseThrow(),
+                       is("Create a new event and add it to the calendar"));
 
-            JsonArray arguments = prompt.getJsonArray("arguments");
+            JsonArray arguments = prompt.arrayValue("arguments").orElseThrow();
             assertThat(arguments.size(), is(3));
-            assertPromptArgument(arguments.getJsonObject(0), "name", "Event name");
-            assertPromptArgument(arguments.getJsonObject(1), "date", "Event date in the following format YYYY-MM-DD");
-            assertPromptArgument(arguments.getJsonObject(2), "attendees", "Event attendees names separated by commas");
+            JsonObject nameArgument = arguments.get(0)
+                    .map(JsonValue::asObject)
+                    .orElseThrow();
+            assertThat(nameArgument.stringValue("name").orElseThrow(), is("name"));
+            assertThat(nameArgument.stringValue("description").orElseThrow(), is("Event name"));
+            assertThat(nameArgument.booleanValue("required").orElseThrow(), is(true));
+
+            JsonObject dateArgument = arguments.get(1)
+                    .map(JsonValue::asObject)
+                    .orElseThrow();
+            assertThat(dateArgument.stringValue("name").orElseThrow(), is("date"));
+            assertThat(dateArgument.stringValue("description").orElseThrow(),
+                       is("Event date in the following format YYYY-MM-DD"));
+            assertThat(dateArgument.booleanValue("required").orElseThrow(), is(true));
+
+            JsonObject attendeesArgument = arguments.get(2)
+                    .map(JsonValue::asObject)
+                    .orElseThrow();
+            assertThat(attendeesArgument.stringValue("name").orElseThrow(), is("attendees"));
+            assertThat(attendeesArgument.stringValue("description").orElseThrow(),
+                       is("Event attendees names separated by commas"));
+            assertThat(attendeesArgument.booleanValue("required").orElseThrow(), is(true));
         }
     }
 
     @Test
     @Order(5)
     void testPromptCall() {
-        JsonObject arguments = JSON_PROVIDER.createObjectBuilder()
-                .add("name", "Frank-birthday")
-                .add("date", "2021-04-20")
-                .add("attendees", "Frank")
+        JsonObject arguments = JsonObject.builder()
+                .set("name", "Frank-birthday")
+                .set("date", "2021-04-20")
+                .set("attendees", "Frank")
                 .build();
 
         try (var response = client.rpcMethod("prompts/get")
@@ -158,10 +199,16 @@ class StatelessClientTest {
                 .param("arguments", arguments)
                 .submit()) {
             JsonObject prompt = result(response);
-            assertThat(prompt.getString("description"), is("New event created"));
-            JsonObject message = prompt.getJsonArray("messages").getJsonObject(0);
-            assertThat(message.getString("role"), is("user"));
-            assertThat(message.getJsonObject("content").getString("text"), is("""
+            assertThat(prompt.stringValue("description").orElseThrow(), is("New event created"));
+            JsonObject message = prompt.arrayValue("messages")
+                    .flatMap(messages -> messages.get(0))
+                    .map(JsonValue::asObject)
+                    .orElseThrow();
+            assertThat(message.stringValue("role").orElseThrow(), is("user"));
+            String text = message.objectValue("content")
+                    .flatMap(content -> content.stringValue("text"))
+                    .orElseThrow();
+            assertThat(text, is("""
                     Create a new calendar event with name Frank-birthday, on 2021-04-20 with attendees Frank. Make
                     sure all attendees are free to attend the event.
                     """));
@@ -174,14 +221,16 @@ class StatelessClientTest {
         try (var response = client.rpcMethod("resources/list")
                 .rpcId(6)
                 .submit()) {
-            JsonArray resources = result(response).getJsonArray("resources");
+            JsonArray resources = result(response).arrayValue("resources").orElseThrow();
             assertThat(resources.size(), is(1));
 
-            JsonObject resource = resources.getJsonObject(0);
-            assertThat(resource.getString("name"), is("calendar-events"));
-            assertThat(resource.getString("uri"), startsWith("file://"));
-            assertThat(resource.getString("mimeType"), is(MediaTypes.TEXT_PLAIN_VALUE));
-            assertThat(resource.getString("description"), is("List of calendar events created"));
+            JsonObject resource = resources.get(0)
+                    .map(JsonValue::asObject)
+                    .orElseThrow();
+            assertThat(resource.stringValue("name").orElseThrow(), is("calendar-events"));
+            assertThat(resource.stringValue("uri").orElseThrow(), startsWith("file://"));
+            assertThat(resource.stringValue("mimeType").orElseThrow(), is(MediaTypes.TEXT_PLAIN_VALUE));
+            assertThat(resource.stringValue("description").orElseThrow(), is("List of calendar events created"));
         }
     }
 
@@ -193,10 +242,14 @@ class StatelessClientTest {
                 .rpcId(7)
                 .param("uri", uri)
                 .submit()) {
-            JsonObject content = result(response).getJsonArray("contents").getJsonObject(0);
-            assertThat(content.getString("uri"), is(uri));
-            assertThat(content.getString("mimeType"), is(MediaTypes.TEXT_PLAIN_VALUE));
-            assertThat(content.getString("text"), is("Event: { name: Frank-birthday, date: 2021-04-20, attendees: [Frank] }\n"));
+            JsonObject content = result(response).arrayValue("contents")
+                    .flatMap(contents -> contents.get(0))
+                    .map(JsonValue::asObject)
+                    .orElseThrow();
+            assertThat(content.stringValue("uri").orElseThrow(), is(uri));
+            assertThat(content.stringValue("mimeType").orElseThrow(), is(MediaTypes.TEXT_PLAIN_VALUE));
+            assertThat(content.stringValue("text").orElseThrow(),
+                       is("Event: { name: Frank-birthday, date: 2021-04-20, attendees: [Frank] }\n"));
         }
     }
 
@@ -206,14 +259,17 @@ class StatelessClientTest {
         try (var response = client.rpcMethod("resources/templates/list")
                 .rpcId(8)
                 .submit()) {
-            JsonArray templates = result(response).getJsonArray("resourceTemplates");
+            JsonArray templates = result(response).arrayValue("resourceTemplates").orElseThrow();
             assertThat(templates.size(), is(1));
 
-            JsonObject template = templates.getJsonObject(0);
-            assertThat(template.getString("uriTemplate"), containsString("{name}"));
-            assertThat(template.getString("mimeType"), is(MediaTypes.TEXT_PLAIN_VALUE));
-            assertThat(template.getString("name"), is("calendar-events-resource-template"));
-            assertThat(template.getString("description"), is("Resource Template to find calendar events with name"));
+            JsonObject template = templates.get(0)
+                    .map(JsonValue::asObject)
+                    .orElseThrow();
+            assertThat(template.stringValue("uriTemplate").orElseThrow(), containsString("{name}"));
+            assertThat(template.stringValue("mimeType").orElseThrow(), is(MediaTypes.TEXT_PLAIN_VALUE));
+            assertThat(template.stringValue("name").orElseThrow(), is("calendar-events-resource-template"));
+            assertThat(template.stringValue("description").orElseThrow(),
+                       is("Resource Template to find calendar events with name"));
         }
     }
 
@@ -224,49 +280,62 @@ class StatelessClientTest {
                 .rpcId(9)
                 .param("uri", "file://events/Frank-birthday")
                 .submit()) {
-            JsonObject content = result(response).getJsonArray("contents").getJsonObject(0);
-            assertThat(content.getString("uri"), is("file://events/Frank-birthday"));
-            assertThat(content.getString("mimeType"), is(MediaTypes.TEXT_PLAIN_VALUE));
-            assertThat(content.getString("text"), is("Event: { name: Frank-birthday, date: 2021-04-20, attendees: [Frank] }"));
+            JsonObject content = result(response).arrayValue("contents")
+                    .flatMap(contents -> contents.get(0))
+                    .map(JsonValue::asObject)
+                    .orElseThrow();
+            assertThat(content.stringValue("uri").orElseThrow(), is("file://events/Frank-birthday"));
+            assertThat(content.stringValue("mimeType").orElseThrow(), is(MediaTypes.TEXT_PLAIN_VALUE));
+            assertThat(content.stringValue("text").orElseThrow(),
+                       is("Event: { name: Frank-birthday, date: 2021-04-20, attendees: [Frank] }"));
         }
     }
 
     @Test
     @Order(10)
     void testCalendarEventPromptCompletion() {
-        JsonObject ref = JSON_PROVIDER.createObjectBuilder()
-                .add("type", "ref/prompt")
-                .add("name", "create-event")
+        JsonObject ref = JsonObject.builder()
+                .set("type", "ref/prompt")
+                .set("name", "create-event")
                 .build();
-        assertCompletion(10, ref, "name", 1);
-        assertCompletion(11, ref, "date", 3);
-        assertCompletion(12, ref, "attendees", 3);
+        JsonObject nameCompletion = complete(10, ref, "name").objectValue("completion").orElseThrow();
+        assertThat(nameCompletion.booleanValue("hasMore").orElseThrow(), is(false));
+        assertThat(nameCompletion.intValue("total").orElseThrow(), is(1));
+        assertThat(nameCompletion.arrayValue("values").map(JsonArray::size).orElseThrow(), is(1));
+
+        JsonObject dateCompletion = complete(11, ref, "date").objectValue("completion").orElseThrow();
+        assertThat(dateCompletion.booleanValue("hasMore").orElseThrow(), is(false));
+        assertThat(dateCompletion.intValue("total").orElseThrow(), is(3));
+        assertThat(dateCompletion.arrayValue("values").map(JsonArray::size).orElseThrow(), is(3));
+
+        JsonObject attendeesCompletion = complete(12, ref, "attendees").objectValue("completion").orElseThrow();
+        assertThat(attendeesCompletion.booleanValue("hasMore").orElseThrow(), is(false));
+        assertThat(attendeesCompletion.intValue("total").orElseThrow(), is(3));
+        assertThat(attendeesCompletion.arrayValue("values").map(JsonArray::size).orElseThrow(), is(3));
     }
 
     @Test
     @Order(11)
     void testCalendarEventResourceCompletion() {
-        JsonObject ref = JSON_PROVIDER.createObjectBuilder()
-                .add("type", "ref/resource")
-                .add("uri", Calendar.EVENTS_URI_TEMPLATE)
+        JsonObject ref = JsonObject.builder()
+                .set("type", "ref/resource")
+                .set("uri", Calendar.EVENTS_URI_TEMPLATE)
                 .build();
-        JsonObject completion = complete(13, ref, "name").getJsonObject("completion");
-        assertThat(completion.getBoolean("hasMore"), is(false));
-        assertThat(completion.getInt("total"), is(1));
-        assertThat(completion.getJsonArray("values").getString(0), is("Frank-birthday"));
-    }
-
-    private void assertCompletion(int rpcId, JsonObject ref, String argument, int total) {
-        JsonObject completion = complete(rpcId, ref, argument).getJsonObject("completion");
-        assertThat(completion.getBoolean("hasMore"), is(false));
-        assertThat(completion.getInt("total"), is(total));
-        assertThat(completion.getJsonArray("values").size(), is(total));
+        JsonObject completion = complete(13, ref, "name").objectValue("completion").orElseThrow();
+        assertThat(completion.booleanValue("hasMore").orElseThrow(), is(false));
+        assertThat(completion.intValue("total").orElseThrow(), is(1));
+        String value = completion.arrayValue("values")
+                .flatMap(values -> values.get(0))
+                .map(JsonValue::asString)
+                .map(jsonString -> jsonString.value())
+                .orElseThrow();
+        assertThat(value, is("Frank-birthday"));
     }
 
     private JsonObject complete(int rpcId, JsonObject ref, String argument) {
-        JsonObject completionArgument = JSON_PROVIDER.createObjectBuilder()
-                .add("name", argument)
-                .add("value", "")
+        JsonObject completionArgument = JsonObject.builder()
+                .set("name", argument)
+                .set("value", "")
                 .build();
 
         try (var response = client.rpcMethod("completion/complete")
@@ -282,19 +351,19 @@ class StatelessClientTest {
         try (var response = client.rpcMethod("resources/list")
                 .rpcId(20)
                 .submit()) {
-            return result(response).getJsonArray("resources").getJsonObject(0).getString("uri");
+            return result(response).arrayValue("resources")
+                    .flatMap(resources -> resources.get(0))
+                    .map(JsonValue::asObject)
+                    .flatMap(resource -> resource.stringValue("uri"))
+                    .orElseThrow();
         }
-    }
-
-    private void assertPromptArgument(JsonObject argument, String name, String description) {
-        assertThat(argument.getString("name"), is(name));
-        assertThat(argument.getString("description"), is(description));
-        assertThat(argument.getBoolean("required"), is(true));
     }
 
     private JsonObject result(JsonRpcClientResponse response) {
         assertThat(response.error().isEmpty(), is(true));
         assertThat(response.result().isEmpty(), is(false));
-        return response.result().orElseThrow().asJsonObject();
+        return response.result()
+                .map(JsonRpcResult::asJsonObject)
+                .orElseThrow();
     }
 }

--- a/examples/calendar-application/calendar/pom.xml
+++ b/examples/calendar-application/calendar/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.4.0</version>
+        <version>4.5.0</version>
         <relativePath/>
     </parent>
 
@@ -34,7 +34,7 @@
 
     <properties>
         <mainClass>io.helidon.extensions.mcp.examples.calendar.Main</mainClass>
-        <version.lib.mcp-sdk>0.11.3</version.lib.mcp-sdk>
+        <version.lib.mcp-sdk>1.0.0</version.lib.mcp-sdk>
     </properties>
 
     <dependencies>
@@ -48,16 +48,8 @@
             <artifactId>helidon-webclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.http.media</groupId>
-            <artifactId>helidon-http-media-jsonb</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-yaml</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.logging</groupId>

--- a/examples/calendar-application/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/AddCalendarEventTool.java
+++ b/examples/calendar-application/calendar/src/main/java/io/helidon/extensions/mcp/examples/calendar/AddCalendarEventTool.java
@@ -99,11 +99,11 @@ final class AddCalendarEventTool implements McpTool {
                 .orElseThrow(() -> requiredArgument("date"));
         List<String> attendees = mcpParameters.get("attendees")
                 .asList()
-                .orElseThrow(() -> requiredArgument("attendees"))
-                .stream()
-                .map(McpParameters::asString)
-                .map(OptionalValue::get)
-                .toList();
+                .map(values -> values.stream()
+                        .map(McpParameters::asString)
+                        .map(OptionalValue::get)
+                        .toList())
+                .orElseThrow(() -> requiredArgument("attendees"));
 
         progress.send(50);
         calendar.createNewEvent(name, date, attendees);

--- a/examples/calendar-application/calendar/src/main/resources/logging.properties
+++ b/examples/calendar-application/calendar/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Oracle and/or its affiliates.
+# Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,4 +19,4 @@ handlers=io.helidon.logging.jul.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
 .level=INFO
-io.helidon.extensions.mcp.server.level=FINE
+io.helidon.extensions.mcp.server.level=FINEST

--- a/examples/calendar-application/pom.xml
+++ b/examples/calendar-application/pom.xml
@@ -36,5 +36,6 @@
         <module>calendar</module>
         <module>calendar-stateless</module>
         <module>calendar-declarative</module>
+        <module>calendar-microprofile</module>
     </modules>
 </project>

--- a/examples/secured-server/README.md
+++ b/examples/secured-server/README.md
@@ -120,7 +120,7 @@ mvn clean package
 ### Run
 
 ```bash
-java -jar target/helidon-mcp-secured-server.java
+java -jar target/helidon-mcp-secured-server.jar
 ```
 
 ---

--- a/examples/secured-server/pom.xml
+++ b/examples/secured-server/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.4.0</version>
+        <version>4.5.0</version>
         <relativePath/>
     </parent>
 
@@ -34,7 +34,11 @@
 
     <properties>
         <mainClass>io.helidon.extensions.mcp.examples.secured.Main</mainClass>
+        <version.lib.langchain4j.mcp>1.10.0-beta18</version.lib.langchain4j.mcp>
+        <version.lib.langchain4j>1.10.0</version.lib.langchain4j>
         <version.lib.mcp-sdk>0.11.3</version.lib.mcp-sdk>
+        <version.lib.testcontainers>1.21.4</version.lib.testcontainers>
+        <version.lib.testcontainers-keycloak>3.4.0</version.lib.testcontainers-keycloak>
     </properties>
 
     <dependencies>
@@ -48,12 +52,12 @@
             <artifactId>helidon-webserver-security</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.security</groupId>
-            <artifactId>helidon-security</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver-cors</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.security</groupId>
+            <artifactId>helidon-security</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.security.providers</groupId>
@@ -64,16 +68,12 @@
             <artifactId>helidon-webclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.http.media</groupId>
-            <artifactId>helidon-http-media-jsonb</artifactId>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-yaml</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.logging</groupId>
@@ -104,6 +104,30 @@
             <groupId>io.modelcontextprotocol.sdk</groupId>
             <artifactId>mcp</artifactId>
             <version>${version.lib.mcp-sdk}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${version.lib.langchain4j}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-mcp</artifactId>
+            <version>${version.lib.langchain4j.mcp}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.dasniko</groupId>
+            <artifactId>testcontainers-keycloak</artifactId>
+            <version>${version.lib.testcontainers-keycloak}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${version.lib.testcontainers}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/secured-server/src/main/java/io/helidon/extensions/mcp/examples/secured/Main.java
+++ b/examples/secured-server/src/main/java/io/helidon/extensions/mcp/examples/secured/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import io.helidon.extensions.mcp.server.McpServerConfig;
 import io.helidon.security.providers.oidc.OidcFeature;
 import io.helidon.service.registry.Services;
 import io.helidon.webserver.WebServer;
+import io.helidon.webserver.cors.CorsFeature;
 import io.helidon.webserver.http.HttpRouting;
 
 /**
@@ -41,6 +42,7 @@ public class Main {
 
         WebServer.builder()
                 .config(config.get("server"))
+                .addFeature(CorsFeature.create(config.get("cors")))
                 .routing(Main::setUpRoute)
                 .build()
                 .start();

--- a/examples/secured-server/src/main/resources/application.yaml
+++ b/examples/secured-server/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Oracle and/or its affiliates.
+# Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/secured-server/src/test/java/io/helidon/extensions/mcp/examples/secured/Langchain4jKeycloakTest.java
+++ b/examples/secured-server/src/test/java/io/helidon/extensions/mcp/examples/secured/Langchain4jKeycloakTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.mcp.examples.secured;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.extensions.mcp.server.McpServerConfig;
+import io.helidon.json.JsonParser;
+import io.helidon.security.providers.oidc.OidcFeature;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@Testcontainers(disabledWithoutDocker = true)
+@ServerTest
+class Langchain4jKeycloakTest {
+    private static final String REALM = "mcp-realm";
+    private static final String CLIENT_ID = "mcp-client";
+    private static final String SCOPE = "openid mcp-scope";
+    private static final String USERNAME = "mcp-user";
+    private static final String PASSWORD = "mcp-password";
+    private static final String TOOL_NAME = "secured-tool";
+
+    private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
+    @Container
+    private static final KeycloakContainer KEYCLOAK = new KeycloakContainer("quay.io/keycloak/keycloak:24.0.5")
+            .withRealmImportFile("/mcp-test-realm.json")
+            .waitingFor(KeycloakContainer.LOG_WAIT_STRATEGY);
+    private static String accessToken;
+
+    private final int port;
+
+    Langchain4jKeycloakTest(WebServer server) {
+        this.port = server.port();
+    }
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        if (!KEYCLOAK.isRunning()) {
+            KEYCLOAK.start();
+        }
+        accessToken = accessToken();
+    }
+
+    @SetUpServer
+    static void server(WebServerConfig.Builder builder) {
+        Config config = Config.builder()
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .sources(ConfigSources.create(Map.of(
+                                 "security.providers.0.oidc.identity-uri",
+                                 KEYCLOAK.getAuthServerUrl() + "/realms/" + REALM)),
+                         ConfigSources.classpath("application.yaml"))
+                .build();
+        builder.config(config.get("server"))
+                .host("localhost")
+                .port(0)
+                .shutdownHook(false);
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder builder) {
+        Config config = Config.builder()
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .sources(ConfigSources.create(Map.of(
+                                 "security.providers.0.oidc.identity-uri",
+                                 KEYCLOAK.getAuthServerUrl() + "/realms/" + REALM)),
+                         ConfigSources.classpath("application.yaml"))
+                .build();
+        builder.addFeature(McpServerConfig.builder()
+                                   .config(config.get("mcp.server"))
+                                   .addTool(new SecuredTool()))
+                .addFeature(OidcFeature.create(config));
+    }
+
+    @Test
+    void callSecuredToolWithKeycloakToken() throws Exception {
+        try (McpClient client = langchain4jClient()) {
+            var tools = client.listTools();
+            assertThat(tools.size(), is(1));
+            assertThat(tools.getFirst().name(), is(TOOL_NAME));
+
+            var result = client.executeTool(ToolExecutionRequest.builder()
+                                                    .name(TOOL_NAME)
+                                                    .build());
+
+            assertThat(result.resultText(), is("Username: " + USERNAME));
+        }
+    }
+
+    private McpClient langchain4jClient() {
+        McpTransport transport = new StreamableHttpMcpTransport.Builder()
+                .url("http://localhost:" + port + "/secured")
+                .customHeaders(Map.of("Authorization", "Bearer " + accessToken))
+                .build();
+
+        return new DefaultMcpClient.Builder()
+                .protocolVersion("2025-06-18")
+                .transport(transport)
+                .build();
+    }
+
+    private static String accessToken() throws Exception {
+        String issuerUri = KEYCLOAK.getAuthServerUrl() + "/realms/" + REALM;
+        String form = Map.of(
+                        "grant_type", "password",
+                        "client_id", CLIENT_ID,
+                        "username", USERNAME,
+                        "password", PASSWORD,
+                        "scope", SCOPE)
+                .entrySet()
+                .stream()
+                .map(entry -> URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8)
+                        + "="
+                        + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8))
+                .collect(Collectors.joining("&"));
+        HttpRequest request = HttpRequest.newBuilder(URI.create(issuerUri + "/protocol/openid-connect/token"))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(form))
+                .build();
+
+        HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        assertThat(response.body(), response.statusCode(), is(200));
+
+        return JsonParser.create(response.body())
+                .readJsonObject()
+                .stringValue("access_token")
+                .orElseThrow();
+    }
+}

--- a/examples/secured-server/src/test/resources/mcp-test-realm.json
+++ b/examples/secured-server/src/test/resources/mcp-test-realm.json
@@ -1,0 +1,92 @@
+{
+  "realm": "mcp-realm",
+  "enabled": true,
+  "users": [
+    {
+      "username": "mcp-user",
+      "enabled": true,
+      "firstName": "MCP",
+      "lastName": "User",
+      "email": "mcp-user@example.com",
+      "emailVerified": true,
+      "requiredActions": [],
+      "credentials": [
+        {
+          "type": "password",
+          "value": "mcp-password",
+          "temporary": false
+        }
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "mcp-client",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "bearerOnly": false,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "*"
+      ],
+      "webOrigins": [
+        "*"
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "email",
+        "mcp-scope"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "name": "mcp-scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "mcp-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "mcp-scope",
+            "access.token.claim": "true",
+            "id.token.claim": "false",
+            "userinfo.token.claim": "false"
+          }
+        },
+        {
+          "name": "preferred-username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "username",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String",
+            "access.token.claim": "true",
+            "id.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/examples/weather-application/mcp-client/pom.xml
+++ b/examples/weather-application/mcp-client/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.4.0</version>
+        <version>4.5.0</version>
         <relativePath/>
     </parent>
 

--- a/examples/weather-application/mcp-server-declarative/pom.xml
+++ b/examples/weather-application/mcp-server-declarative/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.4.0</version>
+        <version>4.5.0</version>
         <relativePath/>
     </parent>
 
@@ -55,16 +55,12 @@
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.http.media</groupId>
-            <artifactId>helidon-http-media-jsonb</artifactId>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json-binding</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.logging</groupId>
@@ -100,6 +96,11 @@
                             <!-- Code generator for Helidon service registry -->
                             <groupId>io.helidon.service</groupId>
                             <artifactId>helidon-service-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.json</groupId>
+                            <artifactId>helidon-json-codegen</artifactId>
                             <version>${helidon.version}</version>
                         </path>
                         <path>

--- a/examples/weather-application/mcp-server-declarative/src/main/java/io/helidon/extensions/mcp/weather/server/declarative/McpServer.java
+++ b/examples/weather-application/mcp-server-declarative/src/main/java/io/helidon/extensions/mcp/weather/server/declarative/McpServer.java
@@ -21,16 +21,14 @@ import java.util.stream.Collectors;
 
 import io.helidon.extensions.mcp.server.Mcp;
 import io.helidon.extensions.mcp.server.McpToolResult;
+import io.helidon.json.binding.Json;
+import io.helidon.json.binding.JsonBinding;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.WebClient;
 
-import jakarta.json.bind.Jsonb;
-import jakarta.json.bind.annotation.JsonbProperty;
-import jakarta.json.bind.spi.JsonbProvider;
-
 @Mcp.Server("helidon-mcp-weather-server")
 class McpServer {
-    private static final Jsonb JSON = JsonbProvider.provider().create().build();
+    private static final JsonBinding JSON = JsonBinding.create();
     private static final WebClient WEBCLIENT = WebClient.builder()
                                                         .baseUri("https://api.weather.gov")
                                                         .addHeader("Accept", "application/geo+json")
@@ -43,7 +41,7 @@ class McpServer {
                 .path("/alerts/active/area/" + state)
                 .request()) {
 
-            Alert alert = JSON.fromJson(response.as(String.class), Alert.class);
+            Alert alert = JSON.deserialize(response.as(String.class), Alert.class);
             String content = alert.features()
                     .stream()
                     .map(f -> String.format("""
@@ -63,17 +61,20 @@ class McpServer {
         }
     }
 
-    public record Alert(@JsonbProperty("features") List<Feature> features) {
+    @Json.Entity
+    public record Alert(List<Feature> features) {
 
-        public record Feature(@JsonbProperty("properties") Properties properties) {
+        @Json.Entity
+        public record Feature(Properties properties) {
         }
 
-        public record Properties(@JsonbProperty("event") String event,
-                                 @JsonbProperty("id") String id,
-                                 @JsonbProperty("areaDesc") String areaDesc,
-                                 @JsonbProperty("severity") String severity,
-                                 @JsonbProperty("description") String description,
-                                 @JsonbProperty("instruction") String instruction) {
+        @Json.Entity
+        public record Properties(String event,
+                                 String id,
+                                 String areaDesc,
+                                 String severity,
+                                 String description,
+                                 String instruction) {
         }
     }
 }

--- a/examples/weather-application/mcp-server/pom.xml
+++ b/examples/weather-application/mcp-server/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>4.4.0</version>
+        <version>4.5.0</version>
         <relativePath/>
     </parent>
 
@@ -47,8 +47,8 @@
             <artifactId>helidon-webclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.http.media</groupId>
-            <artifactId>helidon-http-media-jsonb</artifactId>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json-binding</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.json.schema</groupId>
@@ -76,6 +76,19 @@
                         <id>copy-libs</id>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.bundles</groupId>
+                            <artifactId>helidon-bundles-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/examples/weather-application/mcp-server/src/main/java/io/helidon/extensions/mcp/weather/server/Main.java
+++ b/examples/weather-application/mcp-server/src/main/java/io/helidon/extensions/mcp/weather/server/Main.java
@@ -24,17 +24,15 @@ import io.helidon.extensions.mcp.server.McpParameters;
 import io.helidon.extensions.mcp.server.McpServerConfig;
 import io.helidon.extensions.mcp.server.McpToolRequest;
 import io.helidon.extensions.mcp.server.McpToolResult;
+import io.helidon.json.binding.Json;
+import io.helidon.json.binding.JsonBinding;
 import io.helidon.json.schema.Schema;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webserver.WebServer;
 
-import jakarta.json.bind.Jsonb;
-import jakarta.json.bind.annotation.JsonbProperty;
-import jakarta.json.bind.spi.JsonbProvider;
-
 public class Main {
-    private static final Jsonb JSON = JsonbProvider.provider().create().build();
+    private static final JsonBinding JSON = JsonBinding.create();
 
     private static final WebClient WEBCLIENT = WebClient.builder()
                                                         .baseUri("https://api.weather.gov")
@@ -81,7 +79,7 @@ public class Main {
                 .path("/alerts/active/area/" + state)
                 .request()) {
 
-            Alert alert = JSON.fromJson(response.as(String.class), Alert.class);
+            Alert alert = JSON.deserialize(response.as(String.class), Alert.class);
             String content = alert.features()
                     .stream()
                     .map(f -> String.format("""
@@ -101,17 +99,20 @@ public class Main {
         }
     }
 
-    public record Alert(@JsonbProperty("features") List<Feature> features) {
+    @Json.Entity
+    public record Alert(List<Feature> features) {
 
-        public record Feature(@JsonbProperty("properties") Properties properties) {
+        @Json.Entity
+        public record Feature(Properties properties) {
         }
 
-        public record Properties(@JsonbProperty("event") String event,
-                                 @JsonbProperty("id") String id,
-                                 @JsonbProperty("areaDesc") String areaDesc,
-                                 @JsonbProperty("severity") String severity,
-                                 @JsonbProperty("description") String description,
-                                 @JsonbProperty("instruction") String instruction) {
+        @Json.Entity
+        public record Properties(String event,
+                                 String id,
+                                 String areaDesc,
+                                 String severity,
+                                 String description,
+                                 String instruction) {
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 
     <properties>
         <version.java>21</version.java>
-        <helidon.version>4.4.0</helidon.version>
+        <helidon.version>4.5.0</helidon.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -75,7 +75,7 @@
         <version.lib.checkstyle>10.12.5</version.lib.checkstyle>
         <version.lib.langchain4j.mcp>1.10.0-beta18</version.lib.langchain4j.mcp>
         <version.lib.langchain4j>1.10.0</version.lib.langchain4j>
-        <version.lib.mcp-sdk>0.17.0</version.lib.mcp-sdk>
+        <version.lib.mcp-sdk>0.18.0</version.lib.mcp-sdk>
         <version.lib.mockito>5.22.0</version.lib.mockito>
 
         <version.plugin.buildnumber>3.1.0</version.plugin.buildnumber>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -36,12 +36,8 @@
             <artifactId>helidon-webserver-cors</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.cors</groupId>
-            <artifactId>helidon-cors</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver</groupId>
@@ -52,21 +48,20 @@
             <artifactId>helidon-jsonrpc-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json-binding</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver-jsonrpc</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver-sse</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.json</groupId>
-            <artifactId>jakarta.json-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.parsson</groupId>
-            <artifactId>parsson</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.common.features</groupId>
@@ -81,11 +76,6 @@
         <dependency>
             <groupId>io.helidon.json.schema</groupId>
             <artifactId>helidon-json-schema</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -145,6 +135,11 @@
                         <path>
                             <groupId>io.helidon.common.features</groupId>
                             <artifactId>helidon-common-features-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.json</groupId>
+                            <artifactId>helidon-json-codegen</artifactId>
                             <version>${helidon.version}</version>
                         </path>
                     </annotationProcessorPaths>

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpCancellation.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpCancellation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,7 @@ package io.helidon.extensions.mcp.server;
 import java.lang.System.Logger.Level;
 
 import io.helidon.common.LazyValue;
-
-import jakarta.json.JsonValue;
+import io.helidon.json.JsonValue;
 
 /**
  * The MCP Cancellation feature enables verification of whether a client

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionSupport.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionSupport.java
@@ -31,7 +31,7 @@ final class McpCompletionSupport {
      * @param values suggestions
      * @return completion result
      */
-    @Prototype.FactoryMethod
+    @Prototype.PrototypeFactoryMethod
     static McpCompletionResult create(List<String> values) {
         return McpCompletionResult.builder()
                 .values(values)
@@ -47,7 +47,7 @@ final class McpCompletionSupport {
      * @param values suggestions
      * @return completion result
      */
-    @Prototype.FactoryMethod
+    @Prototype.PrototypeFactoryMethod
     static McpCompletionResult create(String... values) {
         return McpCompletionResult.builder()
                 .values(Arrays.asList(values))

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpElicitation.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpElicitation.java
@@ -17,7 +17,7 @@ package io.helidon.extensions.mcp.server;
 
 import java.util.function.Consumer;
 
-import jakarta.json.JsonObject;
+import io.helidon.json.JsonObject;
 
 /**
  * Elicitation feature.

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpElicitationResponseImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpElicitationResponseImpl.java
@@ -17,9 +17,8 @@ package io.helidon.extensions.mcp.server;
 
 import java.util.Optional;
 
+import io.helidon.json.JsonObject;
 import io.helidon.jsonrpc.core.JsonRpcParams;
-
-import jakarta.json.JsonObject;
 
 final class McpElicitationResponseImpl implements McpElicitationResponse {
     private final McpParameters content;
@@ -28,7 +27,7 @@ final class McpElicitationResponseImpl implements McpElicitationResponse {
     McpElicitationResponseImpl(McpElicitationAction action, JsonObject content) {
         this.action = action;
         this.content = content != null
-                ? new McpParameters(JsonRpcParams.create(content), content)
+                ? new McpParameters(JsonRpcParams.create(content))
                 : null;
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonBinding.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonBinding.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.server;
+
+import io.helidon.common.GenericType;
+import io.helidon.common.LazyValue;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonParser;
+import io.helidon.json.JsonValue;
+import io.helidon.json.binding.JsonBinding;
+
+final class McpJsonBinding {
+    private static final LazyValue<JsonBinding> JSON_BINDING = LazyValue.create(JsonBinding::create);
+
+    private McpJsonBinding() {
+    }
+
+    static JsonValue serialize(Object value) {
+        byte[] json = JSON_BINDING.get().serializeToBytes(value);
+        return JsonParser.create(json).readJsonValue();
+    }
+
+    static JsonObject serializeObject(Object value) {
+        byte[] json = JSON_BINDING.get().serializeToBytes(value);
+        return JsonParser.create(json).readJsonObject();
+    }
+
+    static <T> T deserialize(JsonValue value, Class<T> type) {
+        return JSON_BINDING.get().deserialize(value.toString(), type);
+    }
+
+    static <T> T deserialize(JsonValue value, GenericType<T> type) {
+        // Collection binding requires a streaming parser in Helidon 4.5.0.
+        return JSON_BINDING.get().deserialize(value.toString(), type);
+    }
+}

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializer.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializer.java
@@ -18,27 +18,17 @@ package io.helidon.extensions.mcp.server;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.json.Json;
-import jakarta.json.JsonBuilderFactory;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
-import jakarta.json.JsonStructure;
-import jakarta.json.JsonValue;
-import jakarta.json.JsonWriter;
-import jakarta.json.JsonWriterFactory;
-import jakarta.json.stream.JsonGenerator;
+import io.helidon.json.JsonGenerator;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
 
 /**
  * Serialize MCP classes to JSON.
  */
 interface McpJsonSerializer {
-    JsonBuilderFactory JSON_BUILDER_FACTORY = Json.createBuilderFactory(Map.of());
-    JsonWriterFactory JSON_PP_WRITER_FACTORY = Json.createWriterFactory(Map.of(JsonGenerator.PRETTY_PRINTING, true));
-
     /**
      * JSON-RPC {@code initialize} method.
      */
@@ -139,7 +129,6 @@ interface McpJsonSerializer {
      * JSON-RPC {@code session/disconnect} method.
      */
     String METHOD_SESSION_DISCONNECT = "session/disconnect";
-
     /**
      * JSON-RPC {@code elicitation/create} method.
      */
@@ -153,10 +142,10 @@ interface McpJsonSerializer {
         };
     }
 
-    static String prettyPrint(JsonStructure json) {
+    static String prettyPrint(JsonValue json) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (JsonWriter writer = JSON_PP_WRITER_FACTORY.createWriter(baos)) {
-            writer.write(json);
+        try (JsonGenerator generator = JsonGenerator.create(baos, true)) {
+            generator.write(json);
         }
         return baos.toString(StandardCharsets.UTF_8);
     }
@@ -165,7 +154,7 @@ interface McpJsonSerializer {
         return !payload.containsKey("method") && payload.containsKey("id");
     }
 
-    JsonObjectBuilder createJsonInitializeResponse(Set<McpCapability> capabilities, McpServerConfig config);
+    JsonObject.Builder createJsonInitializeResponse(Set<McpCapability> capabilities, McpServerConfig config);
 
     // ---------- LIST RESPONSE ----------
 
@@ -179,15 +168,15 @@ interface McpJsonSerializer {
 
     // ---------- LIST RESPONSE COMPONENT MAPPING ----------
 
-    JsonObjectBuilder toJson(McpTool tool);
+    JsonObject.Builder toJson(McpTool tool);
 
-    JsonObjectBuilder toJson(McpPrompt prompt);
+    JsonObject.Builder toJson(McpPrompt prompt);
 
-    JsonObjectBuilder toJson(McpPromptArgument argument);
+    JsonObject.Builder toJson(McpPromptArgument argument);
 
-    JsonObjectBuilder toJson(McpResource resource);
+    JsonObject.Builder toJson(McpResource resource);
 
-    JsonObjectBuilder resourceTemplates(McpResource resource);
+    JsonObject.Builder resourceTemplates(McpResource resource);
 
     // ---------- COMPONENT EXECUTION RESULT ----------
 
@@ -201,51 +190,51 @@ interface McpJsonSerializer {
 
     // ---------- CONTENTS ----------
 
-    Optional<JsonObjectBuilder> toJson(McpContent content);
+    Optional<JsonObject.Builder> toJson(McpContent content);
 
-    JsonObjectBuilder toJson(McpTextContent content);
+    JsonObject.Builder toJson(McpTextContent content);
 
-    JsonObjectBuilder toJson(McpImageContent content);
+    JsonObject.Builder toJson(McpImageContent content);
 
-    JsonObjectBuilder toJson(McpEmbeddedTextResourceContent content);
+    JsonObject.Builder toJson(McpEmbeddedTextResourceContent content);
 
-    JsonObjectBuilder toJson(McpEmbeddedBinaryResourceContent content);
+    JsonObject.Builder toJson(McpEmbeddedBinaryResourceContent content);
 
-    Optional<JsonObjectBuilder> toJson(McpAudioContent content);
+    Optional<JsonObject.Builder> toJson(McpAudioContent content);
 
     // ---------- PROMPT CONTENTS ----------
 
-    Optional<JsonObjectBuilder> toJson(McpPromptContent content);
+    Optional<JsonObject.Builder> toJson(McpPromptContent content);
 
-    JsonObjectBuilder toJson(McpPromptImageContent image);
+    JsonObject.Builder toJson(McpPromptImageContent image);
 
-    JsonObjectBuilder toJson(McpPromptTextResourceContent text);
+    JsonObject.Builder toJson(McpPromptTextResourceContent text);
 
-    JsonObjectBuilder toJson(McpPromptBinaryResourceContent binary);
+    JsonObject.Builder toJson(McpPromptBinaryResourceContent binary);
 
-    Optional<JsonObjectBuilder> toJson(McpPromptAudioContent audio);
+    Optional<JsonObject.Builder> toJson(McpPromptAudioContent audio);
 
-    JsonObjectBuilder toJson(McpPromptTextContent content);
+    JsonObject.Builder toJson(McpPromptTextContent content);
 
     // ---------- RESOURCE CONTENTS ----------
 
-    Optional<JsonObjectBuilder> toJson(McpResourceContent content);
+    Optional<JsonObject.Builder> toJson(McpResourceContent content);
 
-    JsonObjectBuilder toJson(McpResourceBinaryContent content);
+    JsonObject.Builder toJson(McpResourceBinaryContent content);
 
-    JsonObjectBuilder toJson(McpResourceTextContent content);
+    JsonObject.Builder toJson(McpResourceTextContent content);
 
     // ---------- SAMPLING ----------
 
-    JsonObjectBuilder toJson(McpSamplingRequest request);
+    JsonObject.Builder toJson(McpSamplingRequest request);
 
-    JsonObjectBuilder toJson(McpSamplingMessage message);
+    JsonObject.Builder toJson(McpSamplingMessage message);
 
-    JsonObjectBuilder toJson(McpSamplingImageMessage image);
+    JsonObject.Builder toJson(McpSamplingImageMessage image);
 
-    JsonObjectBuilder toJson(McpSamplingTextMessage text);
+    JsonObject.Builder toJson(McpSamplingTextMessage text);
 
-    JsonObjectBuilder toJson(McpSamplingAudioMessage audio);
+    JsonObject.Builder toJson(McpSamplingAudioMessage audio);
 
     JsonObject createSamplingRequest(long id, McpSamplingRequest request);
 
@@ -261,13 +250,13 @@ interface McpJsonSerializer {
 
     // ---------- JSON-RPC ----------
 
-    JsonObject createJsonRpcNotification(String method, JsonObjectBuilder params);
+    JsonObject createJsonRpcNotification(String method, JsonObject.Builder params);
 
-    JsonObject createJsonRpcRequest(long id, String method, JsonObjectBuilder params);
+    JsonObject createJsonRpcRequest(long id, String method, JsonObject.Builder params);
 
-    JsonObjectBuilder createJsonRpcRequest(long id, String method);
+    JsonObject.Builder createJsonRpcRequest(long id, String method);
 
-    JsonObject createJsonRpcErrorResponse(long id, JsonObjectBuilder params);
+    JsonObject createJsonRpcErrorResponse(long id, JsonObject.Builder params);
 
     JsonObject createJsonRpcResultResponse(long id, JsonValue params);
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV1.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV1.java
@@ -17,26 +17,19 @@ package io.helidon.extensions.mcp.server;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.IntStream;
 
 import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonString;
+import io.helidon.json.JsonValue;
 import io.helidon.jsonrpc.core.JsonRpcError;
-
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonArrayBuilder;
-import jakarta.json.JsonBuilderFactory;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
-import jakarta.json.JsonReaderFactory;
-import jakarta.json.JsonString;
-import jakarta.json.JsonValue;
 
 import static io.helidon.jsonrpc.core.JsonRpcError.INTERNAL_ERROR;
 
@@ -45,194 +38,198 @@ import static io.helidon.jsonrpc.core.JsonRpcError.INTERNAL_ERROR;
  */
 class McpJsonSerializerV1 implements McpJsonSerializer {
     private static final Map<String, JsonObject> INPUT_SCHEMA = new McpSchemaHashMap();
-    private static final JsonReaderFactory JSON_READER_FACTORY = Json.createReaderFactory(Map.of());
-    private static final JsonBuilderFactory JSON_BUILDER_FACTORY = Json.createBuilderFactory(Map.of());
-    static final JsonObject EMPTY_OBJECT_SCHEMA = JSON_BUILDER_FACTORY.createObjectBuilder()
-            .add("type", "object")
-            .add("properties", JsonObject.EMPTY_JSON_OBJECT)
+    static final JsonObject EMPTY_OBJECT_SCHEMA = JsonObject.builder()
+            .set("type", "object")
+            .set("properties", JsonObject.empty())
             .build();
-    private final ReentrantLock lock = new ReentrantLock();
 
     @Override
-    public JsonObjectBuilder createJsonInitializeResponse(Set<McpCapability> capabilities, McpServerConfig config) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("protocolVersion", McpProtocolVersion.VERSION_2024_11_05.text())
-                .add("capabilities", JSON_BUILDER_FACTORY.createObjectBuilder()
-                        .add("logging", JsonValue.EMPTY_JSON_OBJECT)
-                        .add("prompts", JSON_BUILDER_FACTORY.createObjectBuilder()
-                                .add("listChanged", capabilities.contains(McpCapability.PROMPT_LIST_CHANGED)))
-                        .add("tools", JSON_BUILDER_FACTORY.createObjectBuilder()
-                                .add("listChanged", capabilities.contains(McpCapability.TOOL_LIST_CHANGED)))
-                        .add("resources", JSON_BUILDER_FACTORY.createObjectBuilder()
-                                .add("listChanged", capabilities.contains(McpCapability.RESOURCE_LIST_CHANGED))
-                                .add("subscribe", capabilities.contains(McpCapability.RESOURCE_SUBSCRIBE)))
-                        .add("completions", JsonValue.EMPTY_JSON_OBJECT)
-                        .add("elicitation", JsonValue.EMPTY_JSON_OBJECT))
-                .add("serverInfo", JSON_BUILDER_FACTORY.createObjectBuilder()
-                        .add("name", config.name())
-                        .add("version", config.version()))
-                .add("instructions", config.instructions().orElse(""));
+    public JsonObject.Builder createJsonInitializeResponse(Set<McpCapability> capabilities, McpServerConfig config) {
+        return JsonObject.builder()
+                .set("protocolVersion", McpProtocolVersion.VERSION_2024_11_05.text())
+                .set("capabilities", JsonObject.builder()
+                        .set("logging", JsonObject.empty())
+                        .set("prompts", JsonObject.builder()
+                                .set("listChanged", capabilities.contains(McpCapability.PROMPT_LIST_CHANGED)).build())
+                        .set("tools", JsonObject.builder()
+                                .set("listChanged", capabilities.contains(McpCapability.TOOL_LIST_CHANGED)).build())
+                        .set("resources", JsonObject.builder()
+                                .set("listChanged", capabilities.contains(McpCapability.RESOURCE_LIST_CHANGED))
+                                .set("subscribe", capabilities.contains(McpCapability.RESOURCE_SUBSCRIBE)).build())
+                        .set("completions", JsonObject.empty())
+                        .set("elicitation", JsonObject.empty()).build())
+                .set("serverInfo", JsonObject.builder()
+                        .set("name", config.name())
+                        .set("version", config.version()).build())
+                .set("instructions", config.instructions().orElse(""));
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpTool tool) {
+    public JsonObject.Builder toJson(McpTool tool) {
         String schema = tool.schema();
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("name", tool.name())
-                .add("description", tool.description())
-                .add("inputSchema", INPUT_SCHEMA.get(schema));
+        return JsonObject.builder()
+                .set("name", tool.name())
+                .set("description", tool.description())
+                .set("inputSchema", INPUT_SCHEMA.get(schema));
     }
 
     @Override
     public JsonObject toolCall(McpTool tool, McpToolResult result) {
-        JsonArrayBuilder array = JSON_BUILDER_FACTORY.createArrayBuilder();
+        List<JsonValue> contentValues = new ArrayList<>();
         for (McpToolContent content : McpToolSupport.aggregateContent(result)) {
-            toJson(content).ifPresent(array::add);
+            toJson(content).map(JsonObject.Builder::build).ifPresent(contentValues::add);
         }
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("content", array)
-                .add("isError", result.error())
+        return JsonObject.builder()
+                .setValues("content", contentValues)
+                .set("isError", result.error())
                 .build();
     }
 
     @Override
     public JsonObject listResources(McpPage<McpResource> page) {
-        JsonArrayBuilder builder = JSON_BUILDER_FACTORY.createArrayBuilder();
-        page.components().stream()
+        List<JsonValue> values = page.components().stream()
                 .map(this::toJson)
-                .forEach(builder::add);
-        JsonObjectBuilder resources = JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("resources", builder);
+                .map(JsonObject.Builder::build)
+                .map(JsonValue.class::cast)
+                .toList();
+        JsonObject.Builder resources = JsonObject.builder()
+                .setValues("resources", values);
         if (!page.cursor().isBlank()) {
-            resources.add("nextCursor", page.cursor());
+            resources.set("nextCursor", page.cursor());
         }
         return resources.build();
     }
 
     @Override
     public JsonObject listTools(McpPage<McpTool> page) {
-        JsonArrayBuilder builder = JSON_BUILDER_FACTORY.createArrayBuilder();
-        page.components().stream()
+        List<JsonValue> values = page.components().stream()
                 .map(this::toJson)
-                .forEach(builder::add);
-        JsonObjectBuilder tools = JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("tools", builder);
+                .map(JsonObject.Builder::build)
+                .map(JsonValue.class::cast)
+                .toList();
+        JsonObject.Builder tools = JsonObject.builder()
+                .setValues("tools", values);
         if (!page.cursor().isBlank()) {
-            tools.add("nextCursor", page.cursor());
+            tools.set("nextCursor", page.cursor());
         }
         return tools.build();
     }
 
     @Override
     public JsonObject listResourceTemplates(McpPage<McpResourceTemplate> page) {
-        JsonArrayBuilder builder = JSON_BUILDER_FACTORY.createArrayBuilder();
-        page.components().stream()
+        List<JsonValue> values = page.components().stream()
                 .map(this::resourceTemplates)
-                .forEach(builder::add);
-        JsonObjectBuilder templates = JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("resourceTemplates", builder);
+                .map(JsonObject.Builder::build)
+                .map(JsonValue.class::cast)
+                .toList();
+        JsonObject.Builder templates = JsonObject.builder()
+                .setValues("resourceTemplates", values);
         if (!page.cursor().isBlank()) {
-            templates.add("nextCursor", page.cursor());
+            templates.set("nextCursor", page.cursor());
         }
         return templates.build();
     }
 
     @Override
     public JsonObject listPrompts(McpPage<McpPrompt> page) {
-        JsonArrayBuilder builder = JSON_BUILDER_FACTORY.createArrayBuilder();
-        page.components().stream()
+        List<JsonValue> values = page.components().stream()
                 .map(this::toJson)
-                .forEach(builder::add);
-        JsonObjectBuilder prompts = JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("prompts", builder);
+                .map(JsonObject.Builder::build)
+                .map(JsonValue.class::cast)
+                .toList();
+        JsonObject.Builder prompts = JsonObject.builder()
+                .setValues("prompts", values);
         if (!page.cursor().isBlank()) {
-            prompts.add("nextCursor", page.cursor());
+            prompts.set("nextCursor", page.cursor());
         }
         return prompts.build();
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpEmbeddedTextResourceContent content) {
-        var resource = JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("uri", content.uri().toASCIIString())
-                .add("mimeType", content.mediaType().text())
-                .add("text", content.text());
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("type", content.type().text())
-                .add("resource", resource);
+    public JsonObject.Builder toJson(McpEmbeddedTextResourceContent content) {
+        var resource = JsonObject.builder()
+                .set("uri", content.uri().toASCIIString())
+                .set("mimeType", content.mediaType().text())
+                .set("text", content.text());
+        return JsonObject.builder()
+                .set("type", content.type().text())
+                .set("resource", resource.build());
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpEmbeddedBinaryResourceContent content) {
-        var resource = JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("uri", content.uri().toASCIIString())
-                .add("mimeType", content.mediaType().text())
-                .add("blob", content.base64Data());
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("type", content.type().text())
-                .add("resource", resource);
+    public JsonObject.Builder toJson(McpEmbeddedBinaryResourceContent content) {
+        var resource = JsonObject.builder()
+                .set("uri", content.uri().toASCIIString())
+                .set("mimeType", content.mediaType().text())
+                .set("blob", content.base64Data());
+        return JsonObject.builder()
+                .set("type", content.type().text())
+                .set("resource", resource.build());
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpPrompt prompt) {
-        JsonArrayBuilder array = JSON_BUILDER_FACTORY.createArrayBuilder();
-        prompt.arguments().stream()
+    public JsonObject.Builder toJson(McpPrompt prompt) {
+        List<JsonValue> arguments = prompt.arguments().stream()
                 .map(this::toJson)
-                .forEach(array::add);
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("name", prompt.name())
-                .add("description", prompt.description())
-                .add("arguments", array);
+                .map(JsonObject.Builder::build)
+                .map(JsonValue.class::cast)
+                .toList();
+        return JsonObject.builder()
+                .set("name", prompt.name())
+                .set("description", prompt.description())
+                .setValues("arguments", arguments);
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpPromptArgument argument) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("name", argument.name())
-                .add("description", argument.description())
-                .add("required", argument.required());
+    public JsonObject.Builder toJson(McpPromptArgument argument) {
+        return JsonObject.builder()
+                .set("name", argument.name())
+                .set("description", argument.description())
+                .set("required", argument.required());
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpResource resource) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("uri", resource.uri())
-                .add("name", resource.name())
-                .add("description", resource.description())
-                .add("mimeType", resource.mediaType().text());
+    public JsonObject.Builder toJson(McpResource resource) {
+        return JsonObject.builder()
+                .set("uri", resource.uri())
+                .set("name", resource.name())
+                .set("description", resource.description())
+                .set("mimeType", resource.mediaType().text());
     }
 
     @Override
-    public JsonObjectBuilder resourceTemplates(McpResource resource) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("uriTemplate", resource.uri())
-                .add("name", resource.name())
-                .add("description", resource.description())
-                .add("mimeType", resource.mediaType().text());
+    public JsonObject.Builder resourceTemplates(McpResource resource) {
+        return JsonObject.builder()
+                .set("uriTemplate", resource.uri())
+                .set("name", resource.name())
+                .set("description", resource.description())
+                .set("mimeType", resource.mediaType().text());
     }
 
     @Override
     public JsonObject resourceRead(String uri, McpResourceResult result) {
-        JsonArrayBuilder array = JSON_BUILDER_FACTORY.createArrayBuilder();
+        List<JsonValue> contents = new ArrayList<>();
         for (McpResourceContent content : McpResourceSupport.aggregateContent(result)) {
-            toJson(content).map(builder -> builder.add("uri", uri)).ifPresent(array::add);
+            toJson(content)
+                    .map(builder -> builder.set("uri", uri).build())
+                    .ifPresent(contents::add);
         }
-        return JSON_BUILDER_FACTORY.createObjectBuilder().add("contents", array).build();
+        return JsonObject.builder().setValues("contents", contents).build();
     }
 
     @Override
     public JsonObject promptGet(McpPromptResult result) {
-        JsonArrayBuilder array = JSON_BUILDER_FACTORY.createArrayBuilder();
-        JsonObjectBuilder object = JSON_BUILDER_FACTORY.createObjectBuilder();
+        List<JsonValue> messages = new ArrayList<>();
+        JsonObject.Builder object = JsonObject.builder();
         for (McpPromptContent prompt : McpPromptSupport.aggregateContent(result)) {
-            toJson(prompt).ifPresent(array::add);
+            toJson(prompt).map(JsonObject.Builder::build).ifPresent(messages::add);
         }
-        result.description().ifPresent(description -> object.add("description", description));
-        return object.add("messages", array).build();
+        result.description().ifPresent(description -> object.set("description", description));
+        return object.setValues("messages", messages).build();
     }
 
     @Override
-    public Optional<JsonObjectBuilder> toJson(McpPromptContent content) {
+    public Optional<JsonObject.Builder> toJson(McpPromptContent content) {
         if (content instanceof McpPromptTextContent text) {
             return Optional.of(toJson(text));
         }
@@ -249,7 +246,7 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
     }
 
     @Override
-    public Optional<JsonObjectBuilder> toJson(McpContent content) {
+    public Optional<JsonObject.Builder> toJson(McpContent content) {
         if (content instanceof McpTextContent text) {
             return Optional.of(toJson(text));
         }
@@ -266,7 +263,7 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpSamplingMessage message) {
+    public JsonObject.Builder toJson(McpSamplingMessage message) {
         if (message instanceof McpSamplingTextMessage text) {
             return toJson(text);
         }
@@ -280,7 +277,7 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
     }
 
     @Override
-    public Optional<JsonObjectBuilder> toJson(McpResourceContent content) {
+    public Optional<JsonObject.Builder> toJson(McpResourceContent content) {
         if (content instanceof McpResourceTextContent text) {
             return Optional.of(toJson(text));
         }
@@ -291,229 +288,225 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpPromptImageContent image) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("role", image.role().text())
-                .add("content", toJson((McpImageContent) image));
+    public JsonObject.Builder toJson(McpPromptImageContent image) {
+        return JsonObject.builder()
+                .set("role", image.role().text())
+                .set("content", toJson((McpImageContent) image).build());
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpPromptTextResourceContent text) {
-        var builder = JSON_BUILDER_FACTORY.createObjectBuilder();
+    public JsonObject.Builder toJson(McpPromptTextResourceContent text) {
+        var builder = JsonObject.builder();
         var content = toJson((McpEmbeddedTextResourceContent) text);
-        return builder.add("role", text.role().text()).add("content", content);
+        return builder.set("role", text.role().text()).set("content", content.build());
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpPromptBinaryResourceContent binary) {
-        var builder = JSON_BUILDER_FACTORY.createObjectBuilder();
+    public JsonObject.Builder toJson(McpPromptBinaryResourceContent binary) {
+        var builder = JsonObject.builder();
         var content = toJson((McpEmbeddedBinaryResourceContent) binary);
-        return builder.add("role", binary.role().text()).add("content", content);
+        return builder.set("role", binary.role().text()).set("content", content.build());
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpPromptTextContent content) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("role", content.role().text())
-                .add("content", toJson((McpTextContent) content));
+    public JsonObject.Builder toJson(McpPromptTextContent content) {
+        return JsonObject.builder()
+                .set("role", content.role().text())
+                .set("content", toJson((McpTextContent) content).build());
     }
 
     @Override
-    public Optional<JsonObjectBuilder> toJson(McpPromptAudioContent audio) {
+    public Optional<JsonObject.Builder> toJson(McpPromptAudioContent audio) {
         return Optional.empty();
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpSamplingImageMessage image) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("role", image.role().text())
-                .add("content", JSON_BUILDER_FACTORY.createObjectBuilder()
-                        .add("type", image.type().text())
-                        .add("data", image.encodeBase64Data())
-                        .add("mimeType", image.mediaType().text()));
+    public JsonObject.Builder toJson(McpSamplingImageMessage image) {
+        return JsonObject.builder()
+                .set("role", image.role().text())
+                .set("content", JsonObject.builder()
+                        .set("type", image.type().text())
+                        .set("data", image.encodeBase64Data())
+                        .set("mimeType", image.mediaType().text()).build());
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpSamplingTextMessage text) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("role", text.role().text())
-                .add("content", JSON_BUILDER_FACTORY.createObjectBuilder()
-                        .add("type", text.type().text())
-                        .add("text", text.text()));
+    public JsonObject.Builder toJson(McpSamplingTextMessage text) {
+        return JsonObject.builder()
+                .set("role", text.role().text())
+                .set("content", JsonObject.builder()
+                        .set("type", text.type().text())
+                        .set("text", text.text()).build());
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpSamplingAudioMessage audio) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("role", audio.role().text())
-                .add("content", JSON_BUILDER_FACTORY.createObjectBuilder()
-                        .add("type", audio.type().text())
-                        .add("data", audio.encodeBase64Data())
-                        .add("mimeType", audio.mediaType().text()));
+    public JsonObject.Builder toJson(McpSamplingAudioMessage audio) {
+        return JsonObject.builder()
+                .set("role", audio.role().text())
+                .set("content", JsonObject.builder()
+                        .set("type", audio.type().text())
+                        .set("data", audio.encodeBase64Data())
+                        .set("mimeType", audio.mediaType().text()).build());
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpTextContent content) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("type", content.type().text())
-                .add("text", content.text());
+    public JsonObject.Builder toJson(McpTextContent content) {
+        return JsonObject.builder()
+                .set("type", content.type().text())
+                .set("text", content.text());
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpImageContent content) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("type", content.type().text())
-                .add("data", content.base64Data())
-                .add("mimeType", content.mediaType().text());
+    public JsonObject.Builder toJson(McpImageContent content) {
+        return JsonObject.builder()
+                .set("type", content.type().text())
+                .set("data", content.base64Data())
+                .set("mimeType", content.mediaType().text());
     }
 
     @Override
-    public Optional<JsonObjectBuilder> toJson(McpAudioContent content) {
+    public Optional<JsonObject.Builder> toJson(McpAudioContent content) {
         return Optional.empty();
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpResourceBinaryContent content) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("mimeType", content.mediaType().text())
-                .add("blob", content.base64Data());
+    public JsonObject.Builder toJson(McpResourceBinaryContent content) {
+        return JsonObject.builder()
+                .set("mimeType", content.mediaType().text())
+                .set("blob", content.base64Data());
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpResourceTextContent content) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("mimeType", content.mediaType().text())
-                .add("text", content.text());
+    public JsonObject.Builder toJson(McpResourceTextContent content) {
+        return JsonObject.builder()
+                .set("mimeType", content.mediaType().text())
+                .set("text", content.text());
     }
 
     @Override
     public JsonObject progressNotification(McpProgress progress, int newProgress, String message) {
-        JsonObjectBuilder params = JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("progress", newProgress)
-                .add("total", progress.total());
+        JsonObject.Builder params = JsonObject.builder()
+                .set("progress", newProgress)
+                .set("total", progress.total());
         if (progress.token().isBlank()) {
-            params.add("progressToken", progress.tokenInt());
+            params.set("progressToken", progress.tokenInt());
         } else {
-            params.add("progressToken", progress.token());
+            params.set("progressToken", progress.token());
         }
         if (message != null) {
-            params.add("message", message);
+            params.set("message", message);
         }
         return createJsonRpcNotification(METHOD_NOTIFICATION_PROGRESS, params);
     }
 
     @Override
     public JsonObject createLoggingNotification(McpLogger.Level level, String name, String message) {
-        var params = JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("level", level.text())
-                .add("logger", name)
-                .add("data", message);
+        var params = JsonObject.builder()
+                .set("level", level.text())
+                .set("logger", name)
+                .set("data", message);
         return createJsonRpcNotification(METHOD_NOTIFICATION_MESSAGE, params);
     }
 
     @Override
     public JsonObject createUpdateNotification(String uri) {
-        var params = JSON_BUILDER_FACTORY.createObjectBuilder().add("uri", uri);
+        var params = JsonObject.builder().set("uri", uri);
         return createJsonRpcNotification(METHOD_NOTIFICATION_UPDATE, params);
     }
 
     @Override
     public JsonObject completionComplete(McpCompletionResult result) {
-        var builder = JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("values", JSON_BUILDER_FACTORY.createArrayBuilder(result.values()));
-        result.hasMore().ifPresent(hasMore -> builder.add("hasMore", hasMore));
-        result.total().ifPresent(total -> builder.add("total", total));
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("completion", builder)
+        var builder = JsonObject.builder()
+                .setStrings("values", result.values());
+        result.hasMore().ifPresent(hasMore -> builder.set("hasMore", hasMore));
+        result.total().ifPresent(total -> builder.set("total", total));
+        return JsonObject.builder()
+                .set("completion", builder.build())
                 .build();
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpSamplingRequest request) {
-        var hints = JSON_BUILDER_FACTORY.createArrayBuilder();
-        var params = JSON_BUILDER_FACTORY.createObjectBuilder();
-        var messages = JSON_BUILDER_FACTORY.createArrayBuilder();
-        var sequences = JSON_BUILDER_FACTORY.createArrayBuilder();
-        var modelPreference = JSON_BUILDER_FACTORY.createObjectBuilder();
+    public JsonObject.Builder toJson(McpSamplingRequest request) {
+        List<JsonValue> hints = new ArrayList<>();
+        var params = JsonObject.builder();
+        List<JsonValue> messages = new ArrayList<>();
+        var modelPreference = JsonObject.builder();
 
         request.hints()
                 .stream()
                 .flatMap(List::stream)
-                .map(hint -> JSON_BUILDER_FACTORY.createObjectBuilder().add("name", hint))
+                .map(hint -> JsonObject.builder().set("name", hint).build())
                 .forEach(hints::add);
-        request.hints().map(it -> modelPreference.add("hints", hints));
-        request.speedPriority().map(speed -> modelPreference.add("speedPriority", speed));
-        request.costPriority().map(priority -> modelPreference.add("costPriority", priority));
-        request.intelligencePriority().map(intelligence -> modelPreference.add("intelligencePriority", intelligence));
-        params.add("modelPreference", modelPreference);
+        request.hints().ifPresent(it -> modelPreference.setValues("hints", hints));
+        request.speedPriority().ifPresent(speed -> modelPreference.set("speedPriority", speed));
+        request.costPriority().ifPresent(priority -> modelPreference.set("costPriority", priority));
+        request.intelligencePriority().ifPresent(intelligence -> modelPreference.set("intelligencePriority", intelligence));
+        params.set("modelPreference", modelPreference.build());
 
         McpSamplingSupport.aggregate(request).stream()
                 .map(this::toJson)
+                .map(JsonObject.Builder::build)
                 .forEach(messages::add);
-        params.add("messages", messages);
-        params.add("maxTokens", request.maxTokens());
-        request.systemPrompt().map(prompt -> params.add("systemPrompt", prompt));
-        request.temperature().map(temperature -> params.add("temperature", temperature));
-        request.includeContext().map(context -> params.add("includeContext", context.text()));
-        request.stopSequences()
-                .stream()
-                .flatMap(List::stream)
-                .forEach(sequences::add);
-        request.stopSequences().map(it -> params.add("stopSequences", sequences));
-        request.metadata().map(metadata -> params.add("metadata", metadata));
+        params.setValues("messages", messages);
+        params.set("maxTokens", request.maxTokens());
+        request.systemPrompt().ifPresent(prompt -> params.set("systemPrompt", prompt));
+        request.temperature().ifPresent(temperature -> params.set("temperature", temperature));
+        request.includeContext().ifPresent(context -> params.set("includeContext", context.text()));
+        request.stopSequences().ifPresent(sequences -> params.setStrings("stopSequences", sequences));
+        request.metadata().ifPresent(metadata -> params.set("metadata", McpJsonBinding.serialize(metadata)));
         return params;
     }
 
     @Override
-    public JsonObject createJsonRpcNotification(String method, JsonObjectBuilder params) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("jsonrpc", "2.0")
-                .add("method", method)
-                .add("params", params)
+    public JsonObject createJsonRpcNotification(String method, JsonObject.Builder params) {
+        return JsonObject.builder()
+                .set("jsonrpc", "2.0")
+                .set("method", method)
+                .set("params", params.build())
                 .build();
     }
 
     @Override
-    public JsonObject createJsonRpcRequest(long id, String method, JsonObjectBuilder params) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("jsonrpc", "2.0")
-                .add("id", id)
-                .add("method", method)
-                .add("params", params)
+    public JsonObject createJsonRpcRequest(long id, String method, JsonObject.Builder params) {
+        return JsonObject.builder()
+                .set("jsonrpc", "2.0")
+                .set("id", id)
+                .set("method", method)
+                .set("params", params.build())
                 .build();
     }
 
     @Override
-    public JsonObjectBuilder createJsonRpcRequest(long id, String method) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("jsonrpc", "2.0")
-                .add("id", id)
-                .add("method", method);
+    public JsonObject.Builder createJsonRpcRequest(long id, String method) {
+        return JsonObject.builder()
+                .set("jsonrpc", "2.0")
+                .set("id", id)
+                .set("method", method);
     }
 
     @Override
-    public JsonObject createJsonRpcErrorResponse(long id, JsonObjectBuilder params) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("jsonrpc", "2.0")
-                .add("id", id)
-                .add("error", params)
+    public JsonObject createJsonRpcErrorResponse(long id, JsonObject.Builder params) {
+        return JsonObject.builder()
+                .set("jsonrpc", "2.0")
+                .set("id", id)
+                .set("error", params.build())
                 .build();
     }
 
     @Override
     public JsonObject createJsonRpcResultResponse(long id, JsonValue params) {
-        return JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("jsonrpc", "2.0")
-                .add("id", id)
-                .add("result", params)
+        return JsonObject.builder()
+                .set("jsonrpc", "2.0")
+                .set("id", id)
+                .set("result", params)
                 .build();
     }
 
     @Override
     public JsonObject jsonrpcErrorTimeoutResponse(long requestId) {
-        var error = JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("code", INTERNAL_ERROR)
-                .add("message", "response timeout");
+        var error = JsonObject.builder()
+                .set("code", INTERNAL_ERROR)
+                .set("message", "response timeout");
         return createJsonRpcErrorResponse(requestId, error);
     }
 
@@ -521,22 +514,22 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
     public List<McpRoot> parseRoots(JsonObject response) {
         find(response, "error")
                 .filter(this::isJsonObject)
-                .map(JsonValue::asJsonObject)
+                .map(JsonValue::asObject)
                 .map(JsonRpcError::create)
                 .ifPresent(error -> {
                     throw new McpRootException(error.message());
                 });
         JsonArray roots = find(response, "result")
-                .map(JsonValue::asJsonObject)
+                .map(JsonValue::asObject)
                 .flatMap(result -> find(result, "roots"))
-                .map(JsonValue::asJsonArray)
+                .map(JsonValue::asArray)
                 .orElseThrow(() -> new McpRootException("Wrong response format: %s".formatted(response)));
 
-        return IntStream.range(0, roots.size())
-                .mapToObj(roots::getJsonObject)
+        return roots.values().stream()
+                .map(JsonValue::asObject)
                 .map(root -> McpRoot.builder()
-                        .uri(URI.create(root.getString("uri")))
-                        .name(Optional.ofNullable(root.getString("name", null)))
+                        .uri(URI.create(root.stringValue("uri").orElseThrow()))
+                        .name(root.stringValue("name"))
                         .build())
                 .toList();
     }
@@ -551,7 +544,7 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
     public McpSamplingResponse createSamplingResponse(JsonObject object) throws McpSamplingException {
         find(object, "error")
                 .filter(this::isJsonObject)
-                .map(JsonValue::asJsonObject)
+                .map(JsonValue::asObject)
                 .map(JsonRpcError::create)
                 .ifPresent(error -> {
                     throw new McpSamplingException(error.message());
@@ -559,16 +552,19 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
         try {
             var result = find(object, "result")
                     .filter(this::isJsonObject)
-                    .map(JsonValue::asJsonObject)
+                    .map(JsonValue::asObject)
                     .orElseThrow(() -> new McpSamplingException(String.format("Sampling result not found: %s", object)));
 
-            String model = result.getString("model");
-            McpRole role = McpRole.valueOf(result.getString("role").toUpperCase());
-            McpSamplingMessage message = parseMessage(role, result.getJsonObject("content"));
+            String model = result.stringValue("model").orElseThrow();
+            McpRole role = result.stringValue("role")
+                    .map(String::toUpperCase)
+                    .map(McpRole::valueOf)
+                    .orElseThrow();
+            McpSamplingMessage message = parseMessage(role, result.objectValue("content").orElseThrow());
             McpStopReason stopReason = find(result, "stopReason")
                     .filter(this::isJsonString)
                     .map(JsonString.class::cast)
-                    .map(JsonString::getString)
+                    .map(JsonString::value)
                     .map(McpStopReason::map)
                     .orElse(null);
             return new McpSamplingResponseImpl(message, model, stopReason);
@@ -588,35 +584,38 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
     }
 
     McpSamplingMessage parseMessage(McpRole role, JsonObject object) {
-        String type = object.getString("type").toUpperCase();
+        String type = object.stringValue("type")
+                .map(String::toUpperCase)
+                .orElseThrow();
         McpSamplingMessageType messageType = McpSamplingMessageType.valueOf(type);
         return switch (messageType) {
-            case TEXT -> McpSamplingTextMessage.builder().text(object.getString("text")).role(role).build();
+            case TEXT -> McpSamplingTextMessage.builder().text(object.stringValue("text").orElseThrow()).role(role).build();
             case IMAGE -> {
-                byte[] data = object.getString("data").getBytes(StandardCharsets.UTF_8);
-                MediaType mediaType = MediaTypes.create(object.getString("mimeType"));
+                byte[] data = object.stringValue("data")
+                        .map(value -> value.getBytes(StandardCharsets.UTF_8))
+                        .orElseThrow();
+                MediaType mediaType = MediaTypes.create(object.stringValue("mimeType").orElseThrow());
                 yield McpSamplingImageMessage.builder().data(data).mediaType(mediaType).role(role).build();
             }
             case AUDIO -> {
-                byte[] data = object.getString("data").getBytes(StandardCharsets.UTF_8);
-                MediaType mediaType = MediaTypes.create(object.getString("mimeType"));
+                byte[] data = object.stringValue("data")
+                        .map(value -> value.getBytes(StandardCharsets.UTF_8))
+                        .orElseThrow();
+                MediaType mediaType = MediaTypes.create(object.stringValue("mimeType").orElseThrow());
                 yield McpSamplingAudioMessage.builder().data(data).mediaType(mediaType).role(role).build();
             }
         };
     }
 
     Optional<JsonValue> find(JsonObject object, String key) {
-        if (object.containsKey(key)) {
-            return Optional.of(object.get(key));
-        }
-        return Optional.empty();
+        return object.value(key);
     }
 
     boolean isJsonObject(JsonValue value) {
-        return JsonValue.ValueType.OBJECT.equals(value.getValueType());
+        return value instanceof JsonObject;
     }
 
     boolean isJsonString(JsonValue value) {
-        return JsonValue.ValueType.STRING.equals(value.getValueType());
+        return value instanceof JsonString;
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV2.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV2.java
@@ -15,28 +15,23 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.json.Json;
-import jakarta.json.JsonBuilderFactory;
-import jakarta.json.JsonObjectBuilder;
+import io.helidon.json.JsonObject;
 
 /**
  * JSON serializer for {@code 2025-03-26} MCP specification.
  */
 class McpJsonSerializerV2 extends McpJsonSerializerV1 {
-    private static final JsonBuilderFactory JSON_BUILDER_FACTORY = Json.createBuilderFactory(Map.of());
-
     @Override
-    public JsonObjectBuilder createJsonInitializeResponse(Set<McpCapability> capabilities, McpServerConfig config) {
+    public JsonObject.Builder createJsonInitializeResponse(Set<McpCapability> capabilities, McpServerConfig config) {
         return super.createJsonInitializeResponse(capabilities, config)
-                .add("protocolVersion", McpProtocolVersion.VERSION_2025_03_26.text());
+                .set("protocolVersion", McpProtocolVersion.VERSION_2025_03_26.text());
     }
 
     @Override
-    public Optional<JsonObjectBuilder> toJson(McpContent content) {
+    public Optional<JsonObject.Builder> toJson(McpContent content) {
         if (content instanceof McpAudioContent audio) {
             return toJson(audio);
         }
@@ -44,7 +39,7 @@ class McpJsonSerializerV2 extends McpJsonSerializerV1 {
     }
 
     @Override
-    public Optional<JsonObjectBuilder> toJson(McpPromptContent content) {
+    public Optional<JsonObject.Builder> toJson(McpPromptContent content) {
         if (content instanceof McpPromptAudioContent resource) {
             return toJson(resource);
         }
@@ -52,32 +47,32 @@ class McpJsonSerializerV2 extends McpJsonSerializerV1 {
     }
 
     @Override
-    public Optional<JsonObjectBuilder> toJson(McpAudioContent content) {
-        return Optional.of(JSON_BUILDER_FACTORY.createObjectBuilder()
-                                   .add("type", content.type().text())
-                                   .add("data", content.base64Data())
-                                   .add("mimeType", content.mediaType().text()));
+    public Optional<JsonObject.Builder> toJson(McpAudioContent content) {
+        return Optional.of(JsonObject.builder()
+                                   .set("type", content.type().text())
+                                   .set("data", content.base64Data())
+                                   .set("mimeType", content.mediaType().text()));
     }
 
     @Override
-    public Optional<JsonObjectBuilder> toJson(McpPromptAudioContent audio) {
+    public Optional<JsonObject.Builder> toJson(McpPromptAudioContent audio) {
         return toJson((McpAudioContent) audio)
-                .map(content -> JSON_BUILDER_FACTORY.createObjectBuilder()
-                        .add("role", audio.role().text())
-                        .add("content", content));
+                .map(content -> JsonObject.builder()
+                        .set("role", audio.role().text())
+                        .set("content", content.build()));
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpTool tool) {
+    public JsonObject.Builder toJson(McpTool tool) {
         var builder = super.toJson(tool);
         tool.annotations().ifPresent(annotations -> {
-            JsonObjectBuilder annotBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
-            annotBuilder.add("title", annotations.title());
-            annotBuilder.add("destructiveHint", annotations.destructiveHint());
-            annotBuilder.add("idempotentHint", annotations.idempotentHint());
-            annotBuilder.add("openWorldHint", annotations.openWorldHint());
-            annotBuilder.add("readOnlyHint", annotations.readOnlyHint());
-            builder.add("annotations", annotBuilder.build());
+            JsonObject.Builder annotBuilder = JsonObject.builder();
+            annotBuilder.set("title", annotations.title());
+            annotBuilder.set("destructiveHint", annotations.destructiveHint());
+            annotBuilder.set("idempotentHint", annotations.idempotentHint());
+            annotBuilder.set("openWorldHint", annotations.openWorldHint());
+            annotBuilder.set("readOnlyHint", annotations.readOnlyHint());
+            builder.set("annotations", annotBuilder.build());
         });
         return builder;
     }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3.java
@@ -15,39 +15,26 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.locks.ReentrantLock;
 
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
 import io.helidon.jsonrpc.core.JsonRpcError;
-
-import jakarta.json.Json;
-import jakarta.json.JsonBuilderFactory;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
-import jakarta.json.JsonReaderFactory;
-import jakarta.json.JsonValue;
-import jakarta.json.bind.Jsonb;
-import jakarta.json.bind.JsonbBuilder;
 
 /**
  * JSON serializer for {@code 2025-06-18} MCP specification.
  */
 class McpJsonSerializerV3 extends McpJsonSerializerV2 {
-    private static final Jsonb JSON_B = JsonbBuilder.create();
-    private static final Map<String, JsonObject> OUTPUT_SCHEMA = new McpSchemaHashMap();
-    private static final Map<String, JsonObject> ELICITATION_SCHEMA = new McpSchemaHashMap();
-    private static final JsonReaderFactory JSON_READER_FACTORY = Json.createReaderFactory(Map.of());
+    private static final McpSchemaHashMap OUTPUT_SCHEMA = new McpSchemaHashMap();
+    private static final McpSchemaHashMap ELICITATION_SCHEMA = new McpSchemaHashMap();
     private static final System.Logger LOGGER = System.getLogger(McpJsonSerializerV3.class.getName());
-    private static final JsonBuilderFactory JSON_BUILDER_FACTORY = Json.createBuilderFactory(Map.of());
-
-    private final ReentrantLock lock = new ReentrantLock();
 
     @Override
-    public JsonObjectBuilder createJsonInitializeResponse(Set<McpCapability> capabilities, McpServerConfig config) {
+    public JsonObject.Builder createJsonInitializeResponse(Set<McpCapability> capabilities, McpServerConfig config) {
         return super.createJsonInitializeResponse(capabilities, config)
-                .add("protocolVersion", McpProtocolVersion.VERSION_2025_06_18.text());
+                .set("protocolVersion", McpProtocolVersion.VERSION_2025_06_18.text());
     }
 
     @Override
@@ -59,21 +46,21 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
             }
         }
 
-        JsonObjectBuilder builder = JSON_BUILDER_FACTORY.createObjectBuilder(super.toolCall(tool, result));
+        JsonObject.Builder builder = JsonObject.builder().from(super.toolCall(tool, result));
         result.structuredContent().ifPresent((content) -> {
-            String json = JSON_B.toJson(content);
-            JsonObject sc = JSON_B.fromJson(json, JsonObject.class);
-            builder.add("structuredContent", sc);
+            JsonObject sc = McpJsonBinding.serializeObject(content);
+            String json = sc.toString();
+            builder.set("structuredContent", sc);
             if (result.textContents().isEmpty()) {
                 McpToolContent text = McpToolTextContent.builder().text(json).build();
-                toJson(text).ifPresent(it -> builder.add("content", JSON_BUILDER_FACTORY.createArrayBuilder().add(it)));
+                toJson(text).ifPresent(it -> builder.set("content", JsonArray.create(it.build())));
             }
         });
         return builder.build();
     }
 
     @Override
-    public Optional<JsonObjectBuilder> toJson(McpContent content) {
+    public Optional<JsonObject.Builder> toJson(McpContent content) {
         if (content instanceof McpResourceLinkContent link) {
             return Optional.of(toJson(link));
         }
@@ -81,45 +68,45 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpTool tool) {
+    public JsonObject.Builder toJson(McpTool tool) {
         var builder = super.toJson(tool);
-        tool.title().ifPresent(title -> builder.add("title", title));
+        tool.title().ifPresent(title -> builder.set("title", title));
         tool.outputSchema()
                 .map(OUTPUT_SCHEMA::get)
-                .ifPresent(outputSchema -> builder.add("outputSchema", outputSchema));
+                .ifPresent(outputSchema -> builder.set("outputSchema", outputSchema));
         return builder;
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpResource resource) {
+    public JsonObject.Builder toJson(McpResource resource) {
         var builder = super.toJson(resource);
-        resource.title().ifPresent(title -> builder.add("title", title));
+        resource.title().ifPresent(title -> builder.set("title", title));
         return builder;
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpPrompt prompt) {
+    public JsonObject.Builder toJson(McpPrompt prompt) {
         var builder = super.toJson(prompt);
-        prompt.title().ifPresent(title -> builder.add("title", title));
+        prompt.title().ifPresent(title -> builder.set("title", title));
         return builder;
     }
 
     @Override
-    public JsonObjectBuilder toJson(McpPromptArgument argument) {
+    public JsonObject.Builder toJson(McpPromptArgument argument) {
         var builder = super.toJson(argument);
-        argument.title().ifPresent(title -> builder.add("title", title));
+        argument.title().ifPresent(title -> builder.set("title", title));
         return builder;
     }
 
-    private JsonObjectBuilder toJson(McpResourceLinkContent content) {
-        var builder = JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("type", content.type().text())
-                .add("uri", content.uri())
-                .add("name", content.name());
-        content.size().ifPresent(size -> builder.add("size", size));
-        content.title().ifPresent(title -> builder.add("title", title));
-        content.mediaType().ifPresent(mediaType -> builder.add("mimeType", mediaType.text()));
-        content.description().ifPresent(description -> builder.add("description", description));
+    private JsonObject.Builder toJson(McpResourceLinkContent content) {
+        var builder = JsonObject.builder()
+                .set("type", content.type().text())
+                .set("uri", content.uri())
+                .set("name", content.name());
+        content.size().ifPresent(size -> builder.set("size", size));
+        content.title().ifPresent(title -> builder.set("title", title));
+        content.mediaType().ifPresent(mediaType -> builder.set("mimeType", mediaType.text()));
+        content.description().ifPresent(description -> builder.set("description", description));
         return builder;
     }
 
@@ -127,7 +114,7 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
     public McpElicitationResponse createElicitationResponse(JsonObject object) throws McpElicitationException {
         find(object, "error")
                 .filter(this::isJsonObject)
-                .map(JsonValue::asJsonObject)
+                .map(JsonValue::asObject)
                 .map(JsonRpcError::create)
                 .ifPresent(error -> {
                     throw new McpElicitationException(error.message());
@@ -135,13 +122,16 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
         try {
             var result = find(object, "result")
                     .filter(this::isJsonObject)
-                    .map(JsonValue::asJsonObject)
+                    .map(JsonValue::asObject)
                     .orElseThrow(() -> new McpElicitationException(String.format("Elicitation result not found: %s", object)));
 
-            McpElicitationAction action = McpElicitationAction.valueOf(result.getString("action").toUpperCase());
+            McpElicitationAction action = result.stringValue("action")
+                    .map(String::toUpperCase)
+                    .map(McpElicitationAction::valueOf)
+                    .orElseThrow();
             JsonObject content = find(result, "content")
                     .filter(this::isJsonObject)
-                    .map(JsonObject.class::cast)
+                    .map(JsonValue::asObject)
                     .orElse(null);
             return new McpElicitationResponseImpl(action, content);
         } catch (Exception e) {
@@ -152,11 +142,11 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
     @Override
     public JsonObject createElicitationRequest(long id, McpElicitationRequest request) {
         var builder = createJsonRpcRequest(id, METHOD_ELICITATION_CREATE);
-        var params = JSON_BUILDER_FACTORY.createObjectBuilder();
+        var params = JsonObject.builder();
         JsonObject jsonSchema = ELICITATION_SCHEMA.get(request.schema());
-        params.add("message", request.message());
-        params.add("requestedSchema", jsonSchema);
-        builder.add("params", params);
+        params.set("message", request.message());
+        params.set("requestedSchema", jsonSchema);
+        builder.set("params", params.build());
         return builder.build();
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpPagination.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpPagination.java
@@ -23,9 +23,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
+import io.helidon.json.JsonString;
 import io.helidon.jsonrpc.core.JsonRpcParams;
-
-import jakarta.json.JsonString;
 
 /**
  * Support for MCP pagination feature.
@@ -105,7 +104,7 @@ class McpPagination<T> {
     McpPage<T> page(JsonRpcParams params) {
         return params.find("cursor")
                 .map(JsonString.class::cast)
-                .map(JsonString::getString)
+                .map(JsonString::value)
                 .map(this::page)
                 .orElse(this.firstPage());
     }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpParameters.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpParameters.java
@@ -30,13 +30,15 @@ import io.helidon.common.GenericType;
 import io.helidon.common.mapper.MapperException;
 import io.helidon.common.mapper.Mappers;
 import io.helidon.common.mapper.OptionalValue;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonBoolean;
+import io.helidon.json.JsonNull;
+import io.helidon.json.JsonNumber;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonString;
+import io.helidon.json.JsonValue;
+import io.helidon.json.binding.Json;
 import io.helidon.jsonrpc.core.JsonRpcParams;
-
-import jakarta.json.JsonArray;
-import jakarta.json.JsonNumber;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonString;
-import jakarta.json.JsonValue;
 
 /**
  * MCP client parameters provided to {@link McpTool} and {@link McpPrompt}.
@@ -44,26 +46,18 @@ import jakarta.json.JsonValue;
 public final class McpParameters {
     private static final Mappers MAPPERS = Mappers.create();
     private static final EmptyValue EMPTY_VALUE = new EmptyValue();
-    private static final McpParameters EMPTY = new McpParameters(JsonValue.NULL, "null");
+    private static final McpParameters EMPTY = new McpParameters(JsonNull.instance(), "null");
 
     private final String key;
     private final JsonValue value;
-    private final JsonRpcParams params;
 
-    McpParameters(JsonRpcParams params, JsonValue root) {
-        this.params = params;
-        this.value = root;
-        this.key = "key";
-    }
-
-    private McpParameters(JsonRpcParams params, JsonValue root, String key) {
-        this.params = params;
-        this.value = root;
-        this.key = key;
+    McpParameters(JsonRpcParams params) {
+        this(params.asJsonValue(), "key");
     }
 
     private McpParameters(JsonValue root, String key) {
-        this(JsonRpcParams.create(JsonObject.EMPTY_JSON_OBJECT), root, key);
+        this.value = root;
+        this.key = key;
     }
 
     /**
@@ -74,24 +68,14 @@ public final class McpParameters {
      */
     public McpParameters get(String key) {
         if (value instanceof JsonObject jsonObject) {
-            JsonValue v = jsonObject.get(key);
-            if (v != null) {
-                if (params.get(key) instanceof JsonObject rpcObject) {
-                    JsonRpcParams rpcParams = JsonRpcParams.create(rpcObject);
-                    return new McpParameters(rpcParams, v, key);
-                }
-                if (params.get(key) instanceof JsonArray jsonArray) {
-                    JsonRpcParams rpcParams = JsonRpcParams.create(jsonArray);
-                    return new McpParameters(rpcParams, v, key);
-                }
-                return new McpParameters(params, v, key);
-            }
+            return jsonObject.value(key)
+                    .map(it -> new McpParameters(it, key))
+                    .orElse(EMPTY);
+        }
+        if (value instanceof JsonNull) {
             return EMPTY;
         }
-        if (value == JsonValue.NULL) {
-            return EMPTY;
-        }
-        throw new IllegalStateException("Cannot get " + value.getValueType() + " as an object");
+        throw new IllegalStateException("Cannot get " + value.type() + " as an object");
     }
 
     /**
@@ -101,12 +85,12 @@ public final class McpParameters {
      */
     public OptionalValue<String> asString() {
         if (value instanceof JsonString jsonString) {
-            return OptionalValue.create(MAPPERS, key, jsonString.getString());
+            return OptionalValue.create(MAPPERS, key, jsonString.value());
         }
-        if (value == JsonValue.NULL) {
+        if (value instanceof JsonNull) {
             return empty();
         }
-        throw new IllegalStateException("Cannot get " + value.getValueType() + " as a string");
+        throw new IllegalStateException("Cannot get " + value.type() + " as a string");
     }
 
     /**
@@ -115,7 +99,7 @@ public final class McpParameters {
      * @return {@code true} if a value is not present, otherwise {@code false}
      */
     public boolean isEmpty() {
-        return value == JsonValue.NULL;
+        return value instanceof JsonNull;
     }
 
     /**
@@ -124,7 +108,7 @@ public final class McpParameters {
      * @return {@code true} if a value is present, otherwise {@code false}
      */
     public boolean isPresent() {
-        return value != JsonValue.NULL;
+        return !(value instanceof JsonNull);
     }
 
     /**
@@ -166,12 +150,12 @@ public final class McpParameters {
      */
     public OptionalValue<Byte> asByte() {
         if (value instanceof JsonNumber number) {
-            return OptionalValue.create(MAPPERS, key, number.numberValue().byteValue());
+            return OptionalValue.create(MAPPERS, key, number.byteValue());
         }
-        if (value == JsonValue.NULL) {
+        if (value instanceof JsonNull) {
             return empty();
         }
-        throw new IllegalStateException("Cannot get " + value.getValueType() + "as a byte");
+        throw new IllegalStateException("Cannot get " + value.type() + "as a byte");
     }
 
     /**
@@ -181,12 +165,12 @@ public final class McpParameters {
      */
     public OptionalValue<Short> asShort() {
         if (value instanceof JsonNumber number) {
-            return OptionalValue.create(MAPPERS, key, number.bigDecimalValue().shortValue());
+            return OptionalValue.create(MAPPERS, key, number.shortValue());
         }
-        if (value == JsonValue.NULL) {
+        if (value instanceof JsonNull) {
             return empty();
         }
-        throw new IllegalStateException("Cannot get " + value.getValueType() + "as a short");
+        throw new IllegalStateException("Cannot get " + value.type() + "as a short");
     }
 
     /**
@@ -198,10 +182,10 @@ public final class McpParameters {
         if (value instanceof JsonNumber number) {
             return OptionalValue.create(MAPPERS, key, number.intValue());
         }
-        if (value == JsonValue.NULL) {
+        if (value instanceof JsonNull) {
             return empty();
         }
-        throw new IllegalStateException("Cannot get " + value.getValueType() + "as an integer");
+        throw new IllegalStateException("Cannot get " + value.type() + "as an integer");
     }
 
     /**
@@ -213,10 +197,10 @@ public final class McpParameters {
         if (value instanceof JsonNumber number) {
             return OptionalValue.create(MAPPERS, key, number.longValue());
         }
-        if (value == JsonValue.NULL) {
+        if (value instanceof JsonNull) {
             return empty();
         }
-        throw new IllegalStateException("Cannot get " + value.getValueType() + "as a long");
+        throw new IllegalStateException("Cannot get " + value.type() + "as a long");
     }
 
     /**
@@ -228,10 +212,10 @@ public final class McpParameters {
         if (value instanceof JsonNumber number) {
             return OptionalValue.create(MAPPERS, key, number.doubleValue());
         }
-        if (value == JsonValue.NULL) {
+        if (value instanceof JsonNull) {
             return empty();
         }
-        throw new IllegalStateException("Cannot get " + value.getValueType() + "as a double");
+        throw new IllegalStateException("Cannot get " + value.type() + "as a double");
     }
 
     /**
@@ -241,12 +225,12 @@ public final class McpParameters {
      */
     public OptionalValue<Float> asFloat() {
         if (value instanceof JsonNumber number) {
-            return OptionalValue.create(MAPPERS, key, number.bigDecimalValue().floatValue());
+            return OptionalValue.create(MAPPERS, key, number.floatValue());
         }
-        if (value == JsonValue.NULL) {
+        if (value instanceof JsonNull) {
             return empty();
         }
-        throw new IllegalStateException("Cannot get " + value.getValueType() + "as a float");
+        throw new IllegalStateException("Cannot get " + value.type() + "as a float");
     }
 
     /**
@@ -255,16 +239,13 @@ public final class McpParameters {
      * @return optional boolean value
      */
     public OptionalValue<Boolean> asBoolean() {
-        if (value == JsonValue.TRUE) {
-            return OptionalValue.create(MAPPERS, key, true);
+        if (value instanceof JsonBoolean jsonBoolean) {
+            return OptionalValue.create(MAPPERS, key, jsonBoolean.value());
         }
-        if (value == JsonValue.FALSE) {
-            return OptionalValue.create(MAPPERS, key, false);
-        }
-        if (value == JsonValue.NULL) {
+        if (value instanceof JsonNull) {
             return empty();
         }
-        throw new IllegalStateException("Cannot get " + value.getValueType() + "as a boolean");
+        throw new IllegalStateException("Cannot get " + value.type() + "as a boolean");
     }
 
     /**
@@ -273,26 +254,18 @@ public final class McpParameters {
      * @return optional list value
      */
     public OptionalValue<List<McpParameters>> asList() {
-        if (value == JsonValue.NULL) {
+        if (value instanceof JsonNull) {
             return empty();
         }
         if (value instanceof JsonArray array) {
             List<McpParameters> list = new ArrayList<>();
             int i = 0;
-            for (JsonValue value : array) {
-                if (value instanceof JsonObject object) {
-                    list.add(new McpParameters(JsonRpcParams.create(object), value, key + "-" + i++));
-                    continue;
-                }
-                if (value instanceof JsonArray jsonArray) {
-                    list.add(new McpParameters(JsonRpcParams.create(jsonArray), value, key + "-" + i++));
-                    continue;
-                }
-                list.add(new McpParameters(params, value, key + "-" + i++));
+            for (JsonValue value : array.values()) {
+                list.add(new McpParameters(value, key + "-" + i++));
             }
             return OptionalValue.create(MAPPERS, key, list);
         }
-        throw new IllegalStateException("Cannot get " + value.getValueType() + "as a list");
+        throw new IllegalStateException("Cannot get " + value.type() + "as a list");
     }
 
     /**
@@ -321,25 +294,16 @@ public final class McpParameters {
         if (value instanceof JsonObject object) {
             int i = 0;
             Map<String, McpParameters> map = new HashMap<>();
-            for (Map.Entry<String, JsonValue> entry : object.entrySet()) {
-                McpParameters parameter;
-                if (entry.getValue() instanceof JsonObject jsonObject) {
-                    JsonRpcParams rpcParams = JsonRpcParams.create(jsonObject);
-                    parameter = new McpParameters(rpcParams, jsonObject, entry.getKey() + "-" + i++);
-                } else if (entry.getValue() instanceof JsonArray array) {
-                    JsonRpcParams rpcParams = JsonRpcParams.create(array);
-                    parameter = new McpParameters(rpcParams, array, entry.getKey() + "-" + i++);
-                } else {
-                    parameter = new McpParameters(params, entry.getValue(), entry.getKey() + "-" + i++);
-                }
-                map.put(entry.getKey(), parameter);
+            for (String name : object.keysAsStrings()) {
+                JsonValue child = object.value(name).orElseThrow();
+                map.put(name, new McpParameters(child, name + "-" + i++));
             }
             return OptionalValue.create(MAPPERS, key, map);
         }
-        if (value == JsonValue.NULL) {
+        if (value instanceof JsonNull) {
             return empty();
         }
-        throw new IllegalStateException("Cannot get " + value.getValueType() + "as a map");
+        throw new IllegalStateException("Cannot get " + value.type() + "as a map");
     }
 
     /**
@@ -350,14 +314,16 @@ public final class McpParameters {
      * @return optional value
      */
     public <T> OptionalValue<T> as(Function<McpParameters, T> function) {
-        if (value == JsonValue.NULL) {
+        if (value instanceof JsonNull) {
             return empty();
         }
         return OptionalValue.create(MAPPERS, key, function.apply(this));
     }
 
     /**
-     * Get optional value of the parameter as the mapping class.
+     * Get optional value of the parameter as the mapping class using Helidon JSON binding.
+     * Custom types must have a Helidon JSON converter, for example by annotating
+     * the type with {@link Json.Entity} and enabling Helidon JSON code generation.
      *
      * @param clazz mapping class
      * @param <T>   class type
@@ -365,7 +331,7 @@ public final class McpParameters {
      */
     @SuppressWarnings("unchecked")
     public <T> OptionalValue<T> as(Class<T> clazz) {
-        if (value == JsonValue.NULL) {
+        if (value instanceof JsonNull) {
             return empty();
         }
         return switch (clazz.getName()) {
@@ -377,22 +343,25 @@ public final class McpParameters {
             case "java.lang.String" -> (OptionalValue<T>) asString();
             case "java.lang.Boolean" -> (OptionalValue<T>) asBoolean();
             case "java.lang.Integer" -> (OptionalValue<T>) asInteger();
-            default -> OptionalValue.create(MAPPERS, key, params.as(clazz));
+            default -> OptionalValue.create(MAPPERS, key, McpJsonBinding.deserialize(value, clazz));
         };
     }
 
     /**
-     * Get optional value of the parameter as the mapping type.
+     * Get optional value of the parameter as the mapping type using Helidon JSON binding.
+     * Custom types referenced by the generic type must have a Helidon JSON converter,
+     * for example by annotating them with {@link Json.Entity} and enabling Helidon JSON
+     * code generation.
      *
      * @param type mapping type
      * @param <T>  type
      * @return optional value
      */
     public <T> OptionalValue<T> as(GenericType<T> type) {
-        if (value == JsonValue.NULL) {
+        if (value instanceof JsonNull) {
             return empty();
         }
-        return OptionalValue.create(MAPPERS, key, type);
+        return OptionalValue.create(MAPPERS, key, McpJsonBinding.deserialize(value, type), type);
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpPromptSupport.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpPromptSupport.java
@@ -33,7 +33,7 @@ class McpPromptSupport {
      * @param text text content
      * @return a prompt result instance
      */
-    @Prototype.FactoryMethod
+    @Prototype.PrototypeFactoryMethod
     static McpPromptResult create(String text) {
         return McpPromptResult.builder().addTextContent(text).build();
     }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceSubscriber.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceSubscriber.java
@@ -22,7 +22,6 @@ import io.helidon.builder.api.RuntimeType;
 /**
  * Resource subscriber.
  */
-@RuntimeType.PrototypedBy(McpResourceSubscriberConfig.class)
 public interface McpResourceSubscriber extends RuntimeType.Api<McpResourceSubscriberConfig> {
     /**
      * Create a resource subscriber configuration builder.

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceSupport.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceSupport.java
@@ -33,7 +33,7 @@ class McpResourceSupport {
      * @param text text content
      * @return a resource result instance
      */
-    @Prototype.FactoryMethod
+    @Prototype.PrototypeFactoryMethod
     static McpResourceResult create(String text) {
         return McpResourceResult.builder().addTextContent(text).build();
     }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceTemplate.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceTemplate.java
@@ -23,12 +23,8 @@ import java.util.regex.Pattern;
 
 import io.helidon.common.LazyValue;
 import io.helidon.common.media.type.MediaType;
+import io.helidon.json.JsonObject;
 import io.helidon.jsonrpc.core.JsonRpcParams;
-
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
-
-import static io.helidon.extensions.mcp.server.McpJsonSerializer.JSON_BUILDER_FACTORY;
 
 class McpResourceTemplate implements McpResource {
     private final McpResource delegate;
@@ -76,15 +72,15 @@ class McpResourceTemplate implements McpResource {
     }
 
     McpParameters parameters(JsonRpcParams params, String uri) {
-        JsonObjectBuilder builder = JSON_BUILDER_FACTORY.createObjectBuilder();
+        JsonObject.Builder builder = JsonObject.builder();
         Matcher matcher = pattern.get().matcher(uri);
         if (matcher.matches()) {
             for (int i = 0; i < matcher.groupCount(); i++) {
-                builder.add(variables.get(i), matcher.group(i + 1));
+                builder.set(variables.get(i), matcher.group(i + 1));
             }
         }
         JsonObject parameters = builder.build();
-        return new McpParameters(JsonRpcParams.create(parameters), parameters);
+        return new McpParameters(JsonRpcParams.create(parameters));
     }
 
     private Pattern createPattern(String uri) {

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceUnsubscriber.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceUnsubscriber.java
@@ -22,7 +22,6 @@ import io.helidon.builder.api.RuntimeType;
 /**
  * MCP Resource Unsubscriber.
  */
-@RuntimeType.PrototypedBy(McpResourceUnsubscriberConfig.class)
 public interface McpResourceUnsubscriber extends RuntimeType.Api<McpResourceUnsubscriberConfig> {
     /**
      * Create a resource unsubscriber configuration builder.

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpRoots.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpRoots.java
@@ -19,7 +19,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import jakarta.json.JsonObject;
+import io.helidon.json.JsonObject;
 
 import static io.helidon.extensions.mcp.server.McpJsonSerializer.METHOD_ROOTS_LIST;
 
@@ -35,8 +35,8 @@ public final class McpRoots extends McpFeature {
         super(session, transport);
         this.timeout = session.context()
                 .get(McpServerConfigBlueprint.class, McpServerConfig.class)
-                .orElseThrow(() -> new McpInternalException("Server configuration is not set"))
-                .rootListTimeout();
+                .map(McpServerConfigBlueprint::rootListTimeout)
+                .orElseThrow(() -> new McpInternalException("Server configuration is not set"));
         this.enabled = session.capabilities().contains(McpCapability.ROOTS);
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
@@ -17,7 +17,7 @@ package io.helidon.extensions.mcp.server;
 
 import java.util.function.Consumer;
 
-import jakarta.json.JsonObject;
+import io.helidon.json.JsonObject;
 
 /**
  * MCP Sampling feature.

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingRequestBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingRequestBlueprint.java
@@ -22,8 +22,6 @@ import java.util.Optional;
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 
-import jakarta.json.JsonValue;
-
 /**
  * Configuration of an MCP sampling request.
  */
@@ -122,12 +120,18 @@ interface McpSamplingRequestBlueprint {
     Optional<McpIncludeContext> includeContext();
 
     /**
-     * Optional metadata to pass through to the LLM provider.
-     * The format of this metadata is provider-specific.
+     * Optional metadata to pass through to the LLM provider. The value is serialized using
+     * Helidon JSON binding, and its format is provider-specific. Custom types must have a
+     * Helidon JSON converter, for example by annotating the type with
+     * {@link io.helidon.json.binding.Json.Entity Json.Entity} and enabling Helidon JSON code generation.
+     *
+     * <p><strong>Compatibility:</strong> This option previously accepted {@code jakarta.json.JsonValue}. Accepting an
+     * {@link Object} instead is a backward-incompatible change. JSON-B annotations and
+     * unregistered POJOs are not supported.
      *
      * @return metadata
      */
-    Optional<JsonValue> metadata();
+    Optional<Object> metadata();
 
     /**
      * Sampling request timeout. Default is five seconds.

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingTextMessageSupport.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingTextMessageSupport.java
@@ -27,7 +27,7 @@ class McpSamplingTextMessageSupport {
      * @param text text message
      * @return sampling text message instance
      */
-    @Prototype.FactoryMethod
+    @Prototype.PrototypeFactoryMethod
     static McpSamplingTextMessage create(String text) {
         return McpSamplingTextMessage.builder().text(text).role(McpRole.ASSISTANT).build();
     }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSchemaHashMap.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSchemaHashMap.java
@@ -15,26 +15,21 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import java.io.StringReader;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonReaderFactory;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonParser;
 
 /**
  * Cache for JSON schema using a traditional lock instead of {@code sync} block to avoid
  * thread pinning for some version of jdk. Keys are schema as string and value are schema
- * as {@link jakarta.json.JsonObject}.
+ * as {@link io.helidon.json.JsonObject}.
  */
 class McpSchemaHashMap extends HashMap<String, JsonObject> {
-    private static final JsonReaderFactory JSON_READER_FACTORY = Json.createReaderFactory(Map.of());
-    private static final JsonObject EMPTY_OBJECT_SCHEMA = Json.createBuilderFactory(Map.of())
-            .createObjectBuilder()
-            .add("type", "object")
-            .add("properties", JsonObject.EMPTY_JSON_OBJECT)
+    private static final JsonObject EMPTY_OBJECT_SCHEMA = JsonObject.builder()
+            .set("type", "object")
+            .set("properties", JsonObject.empty())
             .build();
 
     private final ReentrantLock lock = new ReentrantLock();
@@ -50,9 +45,7 @@ class McpSchemaHashMap extends HashMap<String, JsonObject> {
                 if (stringSchema.isEmpty()) {
                     parsed = EMPTY_OBJECT_SCHEMA;
                 } else {
-                    try (var r = JSON_READER_FACTORY.createReader(new StringReader(stringSchema))) {
-                        parsed = r.readObject();
-                    }
+                    parsed = JsonParser.create(stringSchema).readJsonObject();
                 }
                 // store the parsed schema
                 this.put(stringSchema, parsed);

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
@@ -32,13 +32,15 @@ import java.util.function.Function;
 import io.helidon.builder.api.RuntimeType;
 import io.helidon.common.mapper.OptionalValue;
 import io.helidon.config.Config;
-import io.helidon.cors.CrossOriginConfig;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Status;
+import io.helidon.json.JsonNull;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonString;
+import io.helidon.json.JsonValue;
 import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.service.registry.Services;
-import io.helidon.webserver.cors.CorsSupport;
 import io.helidon.webserver.http.HttpFeature;
 import io.helidon.webserver.http.HttpRequest;
 import io.helidon.webserver.http.HttpRouting;
@@ -48,10 +50,6 @@ import io.helidon.webserver.jsonrpc.JsonRpcHandlers;
 import io.helidon.webserver.jsonrpc.JsonRpcRequest;
 import io.helidon.webserver.jsonrpc.JsonRpcResponse;
 import io.helidon.webserver.jsonrpc.JsonRpcRouting;
-
-import jakarta.json.JsonObject;
-import jakarta.json.JsonString;
-import jakarta.json.JsonValue;
 
 import static io.helidon.extensions.mcp.server.McpJsonSerializer.METHOD_COMPLETION_COMPLETE;
 import static io.helidon.extensions.mcp.server.McpJsonSerializer.METHOD_INITIALIZE;
@@ -174,11 +172,23 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         jsonRpcHandlers = builder.build();
     }
 
-    static McpServerFeature create(McpServerConfig config) {
+    /**
+     * Create an MCP server feature instance.
+     *
+     * @param config MCP server configuration
+     * @return the instance
+     */
+    public static McpServerFeature create(McpServerConfig config) {
         return new McpServerFeature(config);
     }
 
-    static McpServerFeature create(Consumer<McpServerConfig.Builder> consumer) {
+    /**
+     * Create an MCP server feature instance.
+     *
+     * @param consumer MCP server configuration
+     * @return the instance
+     */
+    public static McpServerFeature create(Consumer<McpServerConfig.Builder> consumer) {
         return McpServerConfig.builder().update(consumer).build();
     }
 
@@ -193,9 +203,6 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
 
     @Override
     public void setup(HttpRouting.Builder routing) {
-        var cors = CorsSupport.builder()
-                .addCrossOrigin(CrossOriginConfig.create())
-                .build();
         // add all the JSON-RPC routes first
         JsonRpcRouting jsonRpcRouting = JsonRpcRouting.builder()
                 .register(endpoint + "/message", jsonRpcHandlers)
@@ -204,7 +211,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         jsonRpcRouting.routing(routing);
 
         // additional HTTP routes for SSE and session disconnect
-        routing.get(DEFAULT_OIDC_METADATA_URI, cors, this::mcpMetadata)
+        routing.get(DEFAULT_OIDC_METADATA_URI, this::mcpMetadata)
                 .get(endpoint, this::sse)
                 .delete(endpoint, this::disconnect);
     }
@@ -224,7 +231,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         for (Config provider : providers.get()) {
             var identity = provider.get("oidc.identity-uri");
             if (identity.exists()) {
-                String identityUri = identity.asString().map(this::removeTrailingSlash).orElse(null);
+                String identityUri = identity.asString().map(this::removeTrailingSlash).orElse("");
                 response.header(HeaderNames.LOCATION, identityUri + DEFAULT_OIDC_METADATA_URI);
                 response.status(Status.SEE_OTHER_303);
                 response.send();
@@ -257,7 +264,8 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             response.status(Status.NOT_FOUND_404).send();
             return;
         }
-        foundSession.get().onDisconnect(response);
+        McpSession session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
+        session.onDisconnect(response);
         response.send();
     }
 
@@ -281,7 +289,8 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
     }
 
     private void initializeRpc(JsonRpcRequest req, JsonRpcResponse res) {
-        JsonValue requestId = req.rpcId().orElseThrow(() -> new McpInternalException("request id is required"));
+        JsonValue requestId = req.rpcId()
+                .orElseThrow(() -> new McpInternalException("request id is required"));
         Optional<McpSession> foundSession = findSession(req);
         McpSession session;
 
@@ -294,9 +303,9 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             sessions.put(sessionId, session);
             session.onConnect(res);
         } else {
-            session = foundSession.get();
+            session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
         }
-        McpParameters params = new McpParameters(req.params(), req.params().asJsonObject());
+        McpParameters params = new McpParameters(req.params());
         McpProtocolVersion protocolVersion = params.get("protocolVersion")
                 .asString()
                 .map(McpProtocolVersion::find)
@@ -315,7 +324,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
                         .ifPresent(it -> session.capability(McpCapability.ELICITATION));
         session.state(INITIALIZING);
         var payload = session.serializer().createJsonInitializeResponse(capabilities, config);
-        session.onRequest(requestId, req, res);
+        session.createTransport(requestId, req, res);
         res.result(payload.build());
         session.send(requestId, res);
     }
@@ -326,7 +335,8 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             res.send();
             return;
         }
-        session.get().state(McpSession.State.INITIALIZED);
+        McpSession foundSession = session.orElseThrow(() -> new McpInternalException("Session not found"));
+        foundSession.state(McpSession.State.INITIALIZED);
         res.status(Status.ACCEPTED_202);
     }
 
@@ -336,17 +346,20 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             res.send();
             return;
         }
-        McpSession session = foundSession.get();
+        McpSession session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
         Optional<JsonValue> reason = req.params().find("reason");
         Optional<JsonValue> requestId = req.params().find("requestId");
         // Ignore malformed request
-        if (requestId.isEmpty()) {
+        if (requestId.isEmpty()
+                || reason.isEmpty()
+                || !(reason.get() instanceof JsonString)) {
             if (LOGGER.isLoggable(Level.TRACE)) {
-                LOGGER.log(Level.TRACE, "Malformed cancellation request: %s".formatted(req.asJsonObject()));
+                LOGGER.log(Level.TRACE,
+                           "Malformed cancellation request: %s".formatted(req.asJsonObject()));
             }
             return;
         }
-        String cancelReason = ((JsonString) reason.get()).getString();
+        String cancelReason = ((JsonString) reason.get()).value();
         session.findFeatures(requestId.get())
                 .map(McpFeatures::cancellation)
                 .ifPresent(cancellation -> cancellation.cancel(cancelReason, requestId.get()));
@@ -359,47 +372,49 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             res.send();
             return;
         }
-        session.get()
-                .context()
-                .register(McpRoots.McpRootClassifier.class, true);
+        McpSession foundSession = session.orElseThrow(() -> new McpInternalException("Session not found"));
+        foundSession.context().register(McpRoots.McpRootClassifier.class, true);
         res.status(Status.ACCEPTED_202);
     }
 
     private void pingRpc(JsonRpcRequest req, JsonRpcResponse res) {
-        JsonValue requestId = req.rpcId().orElseThrow(() -> new McpInternalException("request id is required"));
+        JsonValue requestId = req.rpcId()
+                .orElseThrow(() -> new McpInternalException("request id is required"));
         Optional<McpSession> foundSession = findSessionOnRequest(requestId, req, res);
         if (!res.status().equals(Status.OK_200)) {
             res.send();
             return;
         }
-        McpSession session = foundSession.get();
-        res.result(JsonValue.EMPTY_JSON_OBJECT);
+        McpSession session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
+        res.result(JsonObject.empty());
         session.send(requestId, res);
     }
 
     private void toolsListRpc(JsonRpcRequest req, JsonRpcResponse res) {
-        JsonValue requestId = req.rpcId().orElseThrow(() -> new McpInternalException("request id is required"));
+        JsonValue requestId = req.rpcId()
+                .orElseThrow(() -> new McpInternalException("request id is required"));
         Optional<McpSession> foundSession = findSessionOnRequest(requestId, req, res);
         if (!res.status().equals(Status.OK_200)) {
             res.send();
             return;
         }
-        McpSession session = foundSession.get();
+        McpSession session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
         McpPage<McpTool> page = tools.page(req.params());
         res.result(session.serializer().listTools(page));
         session.send(requestId, res);
     }
 
     private void toolsCallRpc(JsonRpcRequest req, JsonRpcResponse res) {
-        JsonValue requestId = req.rpcId().orElseThrow(() -> new McpInternalException("request id is required"));
+        JsonValue requestId = req.rpcId()
+                .orElseThrow(() -> new McpInternalException("request id is required"));
         Optional<McpSession> foundSession = findSessionOnRequest(requestId, req, res);
         if (!res.status().equals(Status.OK_200)) {
             res.send();
             return;
         }
         boolean error = false;
-        McpSession session = foundSession.get();
-        McpParameters parameters = new McpParameters(req.params(), req.params().asJsonObject());
+        McpSession session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
+        McpParameters parameters = new McpParameters(req.params());
 
         String name = parameters.get("name").asString().orElse("");
         Optional<McpTool> tool = tools.content().stream()
@@ -431,28 +446,30 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
     }
 
     private void resourcesListRpc(JsonRpcRequest req, JsonRpcResponse res) {
-        JsonValue requestId = req.rpcId().orElseThrow(() -> new McpInternalException("request id is required"));
+        JsonValue requestId = req.rpcId()
+                .orElseThrow(() -> new McpInternalException("request id is required"));
         Optional<McpSession> foundSession = findSessionOnRequest(requestId, req, res);
         if (!res.status().equals(Status.OK_200)) {
             res.send();
             return;
         }
-        McpSession session = foundSession.get();
+        McpSession session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
         var resourceList = session.serializer().listResources(resources.page(req.params()));
         res.result(resourceList);
         session.send(requestId, res);
     }
 
     private void resourcesReadRpc(JsonRpcRequest req, JsonRpcResponse res) {
-        JsonValue requestId = req.rpcId().orElseThrow(() -> new McpInternalException("request id is required"));
+        JsonValue requestId = req.rpcId()
+                .orElseThrow(() -> new McpInternalException("request id is required"));
         Optional<McpSession> foundSession = findSessionOnRequest(requestId, req, res);
         if (!res.status().equals(Status.OK_200)) {
             res.send();
             return;
         }
-        McpSession session = foundSession.get();
+        McpSession session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
 
-        McpParameters parameters = new McpParameters(req.params(), req.params().asJsonObject());
+        McpParameters parameters = new McpParameters(req.params());
         String resourceUri = parameters.get("uri").asString().orElse("");
         Optional<McpResource> resource = resources.content().stream()
                 .filter(r -> resourceUri.equals(r.uri()))
@@ -493,14 +510,15 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
     }
 
     private void resourceSubscribeRpc(JsonRpcRequest req, JsonRpcResponse res) {
-        JsonValue requestId = req.rpcId().orElseThrow(() -> new McpInternalException("request id is required"));
+        JsonValue requestId = req.rpcId()
+                .orElseThrow(() -> new McpInternalException("request id is required"));
         Optional<McpSession> foundSession = findSessionOnRequest(requestId, req, res);
         if (!res.status().equals(Status.OK_200)) {
             res.send();
             return;
         }
-        McpSession session = foundSession.get();
-        McpParameters parameters = new McpParameters(req.params(), req.params().asJsonObject());
+        McpSession session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
+        McpParameters parameters = new McpParameters(req.params());
         String resourceUri = parameters.get("uri").asString()
                 .orElseThrow(() -> new McpInternalException("uri is required"));
 
@@ -536,7 +554,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
                                                .build());
             session.afterFeatureRequest(parameters, requestId);
             // send final response using active SSE sink
-            res.result(JsonValue.EMPTY_JSON_OBJECT);
+            res.result(JsonObject.empty());
             session.send(requestId, res);
             return;
         }
@@ -545,19 +563,20 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
                 .subscriptions()
                 .blockSubscribe(resourceUri);
         // send final response after unblocking
-        res.result(JsonValue.EMPTY_JSON_OBJECT);
+        res.result(JsonObject.empty());
         session.send(requestId, res);
     }
 
     private void resourceUnsubscribeRpc(JsonRpcRequest req, JsonRpcResponse res) {
-        JsonValue requestId = req.rpcId().orElseThrow(() -> new McpInternalException("request id is required"));
+        JsonValue requestId = req.rpcId()
+                .orElseThrow(() -> new McpInternalException("request id is required"));
         Optional<McpSession> foundSession = findSessionOnRequest(requestId, req, res);
         if (!res.status().equals(Status.OK_200)) {
             res.send();
             return;
         }
-        McpSession session = foundSession.get();
-        McpParameters parameters = new McpParameters(req.params(), req.params().asJsonObject());
+        McpSession session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
+        McpParameters parameters = new McpParameters(req.params());
         String resourceUri = parameters.get("uri").asString()
                 .orElseThrow(() -> new McpInternalException("uri is required"));
 
@@ -583,18 +602,19 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         session.features()
                 .subscriptions()
                 .unsubscribe(resourceUri);
-        res.result(JsonValue.EMPTY_JSON_OBJECT);
+        res.result(JsonObject.empty());
         session.send(requestId, res);
     }
 
     private void resourceTemplateListRpc(JsonRpcRequest req, JsonRpcResponse res) {
-        JsonValue requestId = req.rpcId().orElseThrow(() -> new McpInternalException("request id is required"));
+        JsonValue requestId = req.rpcId()
+                .orElseThrow(() -> new McpInternalException("request id is required"));
         Optional<McpSession> foundSession = findSessionOnRequest(requestId, req, res);
         if (!res.status().equals(Status.OK_200)) {
             res.send();
             return;
         }
-        McpSession session = foundSession.get();
+        McpSession session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
         var page = resourceTemplates.page(req.params());
         var payload = session.serializer().listResourceTemplates(page);
         res.result(payload);
@@ -602,13 +622,14 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
     }
 
     private void promptsListRpc(JsonRpcRequest req, JsonRpcResponse res) {
-        JsonValue requestId = req.rpcId().orElseThrow(() -> new McpInternalException("request id is required"));
+        JsonValue requestId = req.rpcId()
+                .orElseThrow(() -> new McpInternalException("request id is required"));
         Optional<McpSession> foundSession = findSessionOnRequest(requestId, req, res);
         if (!res.status().equals(Status.OK_200)) {
             res.send();
             return;
         }
-        McpSession session = foundSession.get();
+        McpSession session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
         var page = prompts.page(req.params());
         var payload = session.serializer().listPrompts(page);
         res.result(payload);
@@ -616,14 +637,15 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
     }
 
     private void promptsGetRpc(JsonRpcRequest req, JsonRpcResponse res) {
-        JsonValue requestId = req.rpcId().orElseThrow(() -> new McpInternalException("request id is required"));
+        JsonValue requestId = req.rpcId()
+                .orElseThrow(() -> new McpInternalException("request id is required"));
         Optional<McpSession> foundSession = findSessionOnRequest(requestId, req, res);
         if (!res.status().equals(Status.OK_200)) {
             res.send();
             return;
         }
-        McpSession session = foundSession.get();
-        McpParameters parameters = new McpParameters(req.params(), req.params().asJsonObject());
+        McpSession session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
+        McpParameters parameters = new McpParameters(req.params());
 
         String name = parameters.get("name").asString().orElse(null);
         if (name == null) {
@@ -659,20 +681,21 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
     }
 
     private void loggingLogLevelRpc(JsonRpcRequest req, JsonRpcResponse res) {
-        JsonValue requestId = req.rpcId().orElseThrow(() -> new McpInternalException("request id is required"));
+        JsonValue requestId = req.rpcId()
+                .orElseThrow(() -> new McpInternalException("request id is required"));
         Optional<McpSession> foundSession = findSessionOnRequest(requestId, req, res);
         if (!res.status().equals(Status.OK_200)) {
             return;
         }
 
-        McpSession session = foundSession.get();
-        McpParameters parameters = new McpParameters(req.params(), req.params().asJsonObject());
+        McpSession session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
+        McpParameters parameters = new McpParameters(req.params());
         OptionalValue<String> level = parameters.get("level").asString();
         if (level.isPresent()) {
             try {
                 McpLogger.Level logLevel = McpLogger.Level.valueOf(level.get().toUpperCase());
                 session.createFeatures(requestId, req, res).logger().setLevel(logLevel);
-                res.result(JsonValue.EMPTY_JSON_OBJECT);
+                res.result(JsonObject.empty());
                 session.send(requestId, res);
                 return;
             } catch (IllegalArgumentException e) {
@@ -687,13 +710,14 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
     }
 
     private void completionRpc(JsonRpcRequest req, JsonRpcResponse res) {
-        JsonValue requestId = req.rpcId().orElseThrow(() -> new McpInternalException("request id is required"));
+        JsonValue requestId = req.rpcId()
+                .orElseThrow(() -> new McpInternalException("request id is required"));
         Optional<McpSession> foundSession = findSessionOnRequest(requestId, req, res);
         if (!res.status().equals(Status.OK_200)) {
             return;
         }
-        McpSession session = foundSession.get();
-        McpParameters parameters = new McpParameters(req.params(), req.params().asJsonObject());
+        McpSession session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
+        McpParameters parameters = new McpParameters(req.params());
         McpParameters ref = parameters.get("ref");
         String referenceType = ref.get("type").asString().orElse(null);
         if (referenceType != null) {
@@ -789,14 +813,15 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         }
 
         // Look up session to send an error to the client
-        JsonValue requestId = request.rpcId().orElse(JsonValue.NULL);
+        JsonValue requestId = request.rpcId()
+                .orElse(JsonNull.instance());
         var session = findSession(request);
         if (session.isEmpty()) {
             response.header(HeaderValues.CONTENT_TYPE_JSON);
             if (stateless) {
                 return Optional.of(JsonRpcError.create(errorCode, throwable.getMessage()));
             }
-            return Optional.of(JsonRpcError.create(INTERNAL_ERROR, "Session not found"));
+            return Optional.of(JsonRpcError.create(INTERNAL_ERROR, "Internal server error"));
         }
         response.error(errorCode, throwable.getMessage());
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSession.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSession.java
@@ -32,12 +32,12 @@ import io.helidon.common.LazyValue;
 import io.helidon.common.LruCache;
 import io.helidon.common.UncheckedException;
 import io.helidon.common.context.Context;
+import io.helidon.json.JsonException;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
 import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.jsonrpc.JsonRpcRequest;
 import io.helidon.webserver.jsonrpc.JsonRpcResponse;
-
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
 
 import static io.helidon.extensions.mcp.server.McpJsonSerializer.prettyPrint;
 import static io.helidon.extensions.mcp.server.McpSession.State.UNINITIALIZED;
@@ -51,9 +51,9 @@ class McpSession {
     private final Context context = Context.create();
     private final Set<McpCapability> clientCapabilities;
     private final AtomicLong jsonRpcId = new AtomicLong(0);
-    private final LruCache<JsonValue, McpFeatures> features;
+    private final LruCache<String, McpFeatures> features;
     private final List<McpFeatureLifecycle> featureListeners;
-    private final LruCache<JsonValue, McpTransport> transports;
+    private final LruCache<String, McpTransport> transports;
     private final LazyValue<McpSessionFeatures> sessionFeatures;
     private final AtomicBoolean active = new AtomicBoolean(true);
     private final BlockingQueue<JsonObject> responses = new LinkedBlockingQueue<>();
@@ -76,10 +76,11 @@ class McpSession {
     }
 
     void send(JsonValue id, JsonRpcResponse response) {
-        transports.get(id)
-                .orElseThrow(() -> new McpInternalException("No transport for id " + id))
-                .send(response);
-        transports.remove(id);
+        String key = id.toString();
+        McpTransport transport = transports.get(key)
+                .orElseThrow(() -> new McpInternalException("No transport for id " + id));
+        transport.send(response);
+        transports.remove(key);
     }
 
     void onConnect(ServerResponse response) {
@@ -94,11 +95,17 @@ class McpSession {
     }
 
     McpSession onRequest(JsonValue id, JsonRpcRequest req, JsonRpcResponse res) {
-        if (transports.get(id).isEmpty()) {
-            McpTransport transport = this.manager.create(req, res);
-            transports.put(id, transport);
-        }
+        createTransport(id, req, res);
         manager.onRequest(req, res);
+        return this;
+    }
+
+    McpSession createTransport(JsonValue id, JsonRpcRequest req, JsonRpcResponse res) {
+        String key = id.toString();
+        if (transports.get(key).isEmpty()) {
+            McpTransport transport = this.manager.create(req, res);
+            transports.put(key, transport);
+        }
         return this;
     }
 
@@ -108,7 +115,7 @@ class McpSession {
     }
 
     void beforeFeatureRequest(McpParameters parameters, JsonValue requestId) {
-        features.get(requestId).ifPresent(feature -> {
+        features.get(requestId.toString()).ifPresent(feature -> {
             for (McpFeatureLifecycle listener : featureListeners) {
                 listener.beforeRequest(parameters, feature);
             }
@@ -116,7 +123,7 @@ class McpSession {
     }
 
     void afterFeatureRequest(McpParameters parameters, JsonValue requestId) {
-        features.get(requestId).ifPresent(feature -> {
+        features.get(requestId.toString()).ifPresent(feature -> {
             for (McpFeatureLifecycle listener : featureListeners) {
                 listener.afterRequest(parameters, feature);
             }
@@ -132,10 +139,11 @@ class McpSession {
     }
 
     McpFeatures createFeatures(JsonValue requestId, JsonRpcRequest request, JsonRpcResponse response) {
-        var transport = transports.get(requestId)
+        String key = requestId.toString();
+        var transport = transports.get(key)
                 .orElseThrow(() -> new McpInternalException("No transport for request id " + requestId));
         McpFeatures feat = new McpFeatures(this, transport);
-        features.put(requestId, feat);
+        features.put(key, feat);
         return feat;
     }
 
@@ -147,14 +155,14 @@ class McpSession {
                     if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
                         LOGGER.log(System.Logger.Level.DEBUG, "Response:\n" + prettyPrint(response));
                     }
-                    long id = response.getJsonNumber("id").longValue();
+                    long id = response.longValue("id").orElseThrow();
                     if (id == requestId) {
                         return response;
                     }
                 } else {
                     return serializer.jsonrpcErrorTimeoutResponse(requestId);
                 }
-            } catch (ClassCastException e) {
+            } catch (JsonException e) {
                 if (LOGGER.isLoggable(Level.TRACE)) {
                     LOGGER.log(Level.TRACE, "Received a response with wrong request id type", e);
                 }
@@ -176,12 +184,13 @@ class McpSession {
     }
 
     void clearRequest(JsonValue requestId) {
-        features.remove(requestId);
-        transports.remove(requestId);
+        String key = requestId.toString();
+        features.remove(key);
+        transports.remove(key);
     }
 
     Optional<McpFeatures> findFeatures(JsonValue requestId) {
-        return features.get(requestId);
+        return features.get(requestId.toString());
     }
 
     McpSessionFeatures features() {
@@ -218,7 +227,7 @@ class McpSession {
     }
 
     Optional<McpTransport> transport(JsonValue id) {
-        return transports.get(id);
+        return transports.get(id.toString());
     }
 
     void state(State state) {

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSsePostTransport.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSsePostTransport.java
@@ -24,13 +24,11 @@ import java.util.function.Consumer;
 import io.helidon.common.UncheckedException;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.sse.SseEvent;
+import io.helidon.json.JsonObject;
 import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.jsonrpc.JsonRpcResponse;
 import io.helidon.webserver.sse.SseSink;
 
-import jakarta.json.JsonObject;
-
-import static io.helidon.extensions.mcp.server.McpJsonSerializer.JSON_BUILDER_FACTORY;
 import static io.helidon.extensions.mcp.server.McpJsonSerializer.prettyPrint;
 
 /**
@@ -90,15 +88,15 @@ final class McpSsePostTransport implements McpTransport {
                               .build());
             poll(message -> sink.emit(SseEvent.builder()
                                               .name("message")
-                                              .data(message)
+                                              .data(message.toString())
                                               .build()));
         }
     }
 
     void onDisconnect() {
         if (active.compareAndSet(true, false)) {
-            var disconnect = JSON_BUILDER_FACTORY.createObjectBuilder()
-                    .add("disconnect", true)
+            var disconnect = JsonObject.builder()
+                    .set("disconnect", true)
                     .build();
             messages.add(disconnect);
         }
@@ -108,7 +106,7 @@ final class McpSsePostTransport implements McpTransport {
         while (active.get()) {
             try {
                 JsonObject message = messages.take();
-                if (message.getBoolean("disconnect", false)) {
+                if (message.booleanValue("disconnect", false)) {
                     if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
                         LOGGER.log(System.Logger.Level.TRACE, "Session disconnected.");
                     }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSsePostTransportManager.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSsePostTransportManager.java
@@ -47,14 +47,16 @@ final class McpSsePostTransportManager implements McpTransportManager {
     @Override
     public void onRequest(JsonRpcRequest request, JsonRpcResponse response) {
         if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
-            LOGGER.log(System.Logger.Level.DEBUG, "SSE Request:\n" + prettyPrint(request.asJsonObject()));
+            LOGGER.log(System.Logger.Level.DEBUG,
+                       "SSE Request:\n" + prettyPrint(request.asJsonObject()));
         }
     }
 
     @Override
     public void onNotification(JsonRpcRequest request, JsonRpcResponse response) {
         if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
-            LOGGER.log(System.Logger.Level.DEBUG, "SSE Notification:\n" + prettyPrint(request.asJsonObject()));
+            LOGGER.log(System.Logger.Level.DEBUG,
+                       "SSE Notification:\n" + prettyPrint(request.asJsonObject()));
         }
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpStreamableHttpTransport.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpStreamableHttpTransport.java
@@ -21,10 +21,9 @@ import java.util.concurrent.TimeUnit;
 
 import io.helidon.http.HeaderValues;
 import io.helidon.http.sse.SseEvent;
+import io.helidon.json.JsonObject;
 import io.helidon.webserver.jsonrpc.JsonRpcResponse;
 import io.helidon.webserver.sse.SseSink;
-
-import jakarta.json.JsonObject;
 
 import static io.helidon.extensions.mcp.server.McpJsonSerializer.prettyPrint;
 
@@ -47,7 +46,7 @@ final class McpStreamableHttpTransport implements McpTransport {
         }
         sink().emit(SseEvent.builder()
                             .name("message")
-                            .data(object)
+                            .data(object.toString())
                             .build());
     }
 
@@ -59,7 +58,7 @@ final class McpStreamableHttpTransport implements McpTransport {
         if (sseSink != null) {
             sseSink.emit(SseEvent.builder()
                                  .name("message")
-                                 .data(response.asJsonObject())
+                                 .data(response.asJsonObject().toString())
                                  .build());
             sseSink.close();
             return;

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpStreamableHttpTransportManager.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpStreamableHttpTransportManager.java
@@ -59,7 +59,8 @@ final class McpStreamableHttpTransportManager implements McpTransportManager {
     @Override
     public void onRequest(JsonRpcRequest request, JsonRpcResponse response) {
         if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
-            LOGGER.log(System.Logger.Level.DEBUG, "Streamable HTTP Request:\n" + prettyPrint(request.asJsonObject()));
+            LOGGER.log(System.Logger.Level.DEBUG,
+                       "Streamable HTTP Request:\n" + prettyPrint(request.asJsonObject()));
         }
         validate(request, response);
     }
@@ -80,6 +81,10 @@ final class McpStreamableHttpTransportManager implements McpTransportManager {
         }
         McpSession foundSession = session.orElseThrow(() -> new McpInternalException("No session with id " + sessionId));
         if (isNotValidNegotiatedVersion(request, foundSession)) {
+            if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
+                LOGGER.log(System.Logger.Level.DEBUG,
+                           "The provided MCP protocol version was not the one negotiated during initialization.");
+            }
             response.status(Status.BAD_REQUEST_400)
                     .error(INTERNAL_ERROR, "Wrong MCP protocol version");
         }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSubscriptions.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSubscriptions.java
@@ -19,7 +19,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import jakarta.json.JsonValue;
+import io.helidon.json.JsonValue;
 
 /**
  * Subscriptions feature used to send resource update notifications
@@ -35,8 +35,8 @@ public final class McpSubscriptions extends McpFeature {
         this.subscriptions = new ConcurrentHashMap<>();
         this.timeout = session.context()
                 .get(McpServerConfigBlueprint.class, McpServerConfig.class)
-                .orElseThrow(() -> new McpInternalException("MCP server configuration not found"))
-                .subscriptionTimeout();
+                .map(McpServerConfigBlueprint::subscriptionTimeout)
+                .orElseThrow(() -> new McpInternalException("MCP server configuration not found"));
     }
 
     /**

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpToolResultBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpToolResultBlueprint.java
@@ -77,7 +77,9 @@ interface McpToolResultBlueprint {
 
     /**
      * Structured tool result content. If specified, the tool definition
-     * must contain an output schema.
+     * must contain an output schema. The value is serialized using Helidon JSON binding.
+     * Custom types must have a Helidon JSON converter, for example by annotating
+     * the type with {@link io.helidon.json.binding.Json.Entity Json.Entity} and enabling Helidon JSON code generation.
      *
      * @return structured content
      */

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpToolSupport.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpToolSupport.java
@@ -33,7 +33,7 @@ class McpToolSupport {
      * @param text text content
      * @return tool result instance
      */
-    @Prototype.FactoryMethod
+    @Prototype.PrototypeFactoryMethod
     static McpToolResult create(String text) {
         return McpToolResult.builder().addTextContent(text).build();
     }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpTransport.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpTransport.java
@@ -17,9 +17,8 @@ package io.helidon.extensions.mcp.server;
 
 import java.time.Duration;
 
+import io.helidon.json.JsonObject;
 import io.helidon.webserver.jsonrpc.JsonRpcResponse;
-
-import jakarta.json.JsonObject;
 
 /**
  * MCP transport provides a way to send data to the connected client.

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -25,14 +25,13 @@ import io.helidon.common.features.api.HelidonFlavor;
 @Features.Description("Support for Model Context Protocol Server.")
 @Features.Flavor({HelidonFlavor.SE, HelidonFlavor.MP})
 module io.helidon.extensions.mcp.server {
-    requires jakarta.json;
-    requires jakarta.json.bind;
     requires io.helidon.common;
+    requires io.helidon.json;
+    requires io.helidon.json.binding;
     requires io.helidon.webserver.sse;
     requires io.helidon.service.registry;
     requires io.helidon.jsonrpc.core;
     requires io.helidon.webserver.jsonrpc;
-    requires io.helidon.cors;
     requires io.helidon.webserver.cors;
     requires io.helidon.config.metadata;
 

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpCancellationTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpCancellationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.helidon.extensions.mcp.server;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import jakarta.json.JsonValue;
+import io.helidon.json.JsonNull;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,7 +38,7 @@ class McpCancellationTest {
     void testCancellationRequested() {
         String reason = "Process is taking too long";
         McpCancellation cancellation = new McpCancellation();
-        cancellation.cancel(reason, JsonValue.NULL);
+        cancellation.cancel(reason, JsonNull.instance());
 
         assertThat(cancellation.result().isRequested(), is(true));
         assertThat(cancellation.result().reason(), is(reason));
@@ -51,8 +51,8 @@ class McpCancellationTest {
         McpCancellation cancellation = new McpCancellation();
 
         cancellation.registerCancellationHook(counter::getAndIncrement);
-        cancellation.cancel(reason, JsonValue.NULL);
-        cancellation.cancel(reason, JsonValue.NULL);
+        cancellation.cancel(reason, JsonNull.instance());
+        cancellation.cancel(reason, JsonNull.instance());
 
         McpCancellationResult result = cancellation.result();
         assertThat(result.isRequested(), is(true));

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpElicitationResponseTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpElicitationResponseTest.java
@@ -15,7 +15,7 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import jakarta.json.JsonValue;
+import io.helidon.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -34,7 +34,7 @@ class McpElicitationResponseTest {
     @Test
     void testCustomResponse() {
         McpElicitationResponse response = new McpElicitationResponseImpl(McpElicitationAction.ACCEPT,
-                                                                         JsonValue.EMPTY_JSON_OBJECT);
+                                                                         JsonObject.empty());
 
         assertThat(response.content().isEmpty(), is(false));
         assertThat(response.content().map(McpParameters::isPresent).orElse(false), is(true));

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerTest.java
@@ -15,11 +15,7 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import java.util.Map;
-
-import jakarta.json.Json;
-import jakarta.json.JsonBuilderFactory;
-import jakarta.json.JsonObject;
+import io.helidon.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -27,8 +23,6 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 class McpJsonSerializerTest {
-    private final JsonBuilderFactory JSON_BUILDER_FACTORY = Json.createBuilderFactory(Map.of());
-
     @Test
     void testMcpJsonSerializerV1() {
         McpJsonSerializer mjs = McpJsonSerializer.create(McpProtocolVersion.VERSION_2024_11_05);
@@ -49,10 +43,10 @@ class McpJsonSerializerTest {
 
     @Test
     void testIsResponse() {
-        JsonObject payload = JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("jsonrpc", 2.0)
-                .add("id", 1)
-                .add("result", 2)
+        JsonObject payload = JsonObject.builder()
+                .set("jsonrpc", 2.0)
+                .set("id", 1)
+                .set("result", 2)
                 .build();
 
         boolean response = McpJsonSerializer.isResponse(payload);
@@ -61,10 +55,10 @@ class McpJsonSerializerTest {
 
     @Test
     void testIsNotResponse() {
-        JsonObject payload = JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("jsonrpc", 2.0)
-                .add("id", 1)
-                .add("method", "foo/bar")
+        JsonObject payload = JsonObject.builder()
+                .set("jsonrpc", 2.0)
+                .set("id", 1)
+                .set("method", "foo/bar")
                 .build();
 
         boolean response = McpJsonSerializer.isResponse(payload);

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3Test.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3Test.java
@@ -15,18 +15,15 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import java.util.Map;
-
 import io.helidon.common.media.type.MediaTypes;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
+import io.helidon.json.JsonValueType;
+import io.helidon.json.binding.Json;
 import io.helidon.json.schema.Schema;
 import io.helidon.json.schema.SchemaString;
 
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonBuilderFactory;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
-import jakarta.json.spi.JsonProvider;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -34,9 +31,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 class McpJsonSerializerV3Test {
-    private static final JsonBuilderFactory JSON_BUILDER_FACTORY = Json.createBuilderFactory(Map.of());
     private static final McpJsonSerializer MJS = McpJsonSerializer.create(McpProtocolVersion.VERSION_2025_06_18);
-    private static final JsonProvider JSON_PROVIDER = JsonProvider.provider();
 
     @Test
     void testSerializeTool() {
@@ -51,15 +46,15 @@ class McpJsonSerializerV3Test {
         McpTool tool = new McpToolImpl(config);
 
         JsonObject payload = MJS.toJson(tool).build();
-        assertThat(payload.getString("name"), is("name"));
-        assertThat(payload.getString("title"), is("title"));
-        assertThat(payload.getString("description"), is("description"));
-        assertThat(payload.getJsonObject("inputSchema"), notNullValue());
+        assertThat(payload.stringValue("name").orElseThrow(), is("name"));
+        assertThat(payload.stringValue("title").orElseThrow(), is("title"));
+        assertThat(payload.stringValue("description").orElseThrow(), is("description"));
+        assertThat(payload.objectValue("inputSchema").orElseThrow(), notNullValue());
 
-        JsonObject outputSchema = payload.getJsonObject("outputSchema");
+        JsonObject outputSchema = payload.objectValue("outputSchema").orElseThrow();
         assertThat(outputSchema, notNullValue());
-        assertThat(outputSchema.getString("type"), is("object"));
-        assertThat(outputSchema.getJsonObject("properties"), is(JsonObject.EMPTY_JSON_OBJECT));
+        assertThat(outputSchema.stringValue("type").orElseThrow(), is("object"));
+        assertThat(outputSchema.objectValue("properties").orElseThrow(), is(JsonObject.empty()));
     }
 
     @Test
@@ -78,16 +73,19 @@ class McpJsonSerializerV3Test {
         McpTool tool = new McpToolImpl(config);
 
         JsonObject payload = MJS.toJson(tool).build();
-        assertThat(payload.getString("name"), is("name"));
-        assertThat(payload.getString("title"), is("title"));
-        assertThat(payload.getString("description"), is("description"));
-        assertThat(payload.getJsonObject("inputSchema"), notNullValue());
+        assertThat(payload.stringValue("name").orElseThrow(), is("name"));
+        assertThat(payload.stringValue("title").orElseThrow(), is("title"));
+        assertThat(payload.stringValue("description").orElseThrow(), is("description"));
+        assertThat(payload.objectValue("inputSchema").orElseThrow(), notNullValue());
 
-        JsonObject outputSchema = payload.getJsonObject("outputSchema");
+        JsonObject outputSchema = payload.objectValue("outputSchema").orElseThrow();
         assertThat(outputSchema, notNullValue());
-        assertThat(outputSchema.getString("type"), is("object"));
+        assertThat(outputSchema.stringValue("type").orElseThrow(), is("object"));
 
-        String foo = outputSchema.getJsonObject("properties").getJsonObject("foo").getString("type");
+        String foo = outputSchema.objectValue("properties")
+                .flatMap(properties -> properties.objectValue("foo"))
+                .flatMap(property -> property.stringValue("type"))
+                .orElseThrow();
         assertThat(foo, is("string"));
     }
 
@@ -104,11 +102,11 @@ class McpJsonSerializerV3Test {
         McpResource resource = new McpResourceImpl(config);
 
         JsonObject payload = MJS.toJson(resource).build();
-        assertThat(payload.getString("name"), is("name"));
-        assertThat(payload.getString("title"), is("title"));
-        assertThat(payload.getString("uri"), is("https://foo"));
-        assertThat(payload.getString("description"), is("description"));
-        assertThat(payload.getString("mimeType"), is(MediaTypes.APPLICATION_JSON.text()));
+        assertThat(payload.stringValue("name").orElseThrow(), is("name"));
+        assertThat(payload.stringValue("title").orElseThrow(), is("title"));
+        assertThat(payload.stringValue("uri").orElseThrow(), is("https://foo"));
+        assertThat(payload.stringValue("description").orElseThrow(), is("description"));
+        assertThat(payload.stringValue("mimeType").orElseThrow(), is(MediaTypes.APPLICATION_JSON.text()));
     }
 
     @Test
@@ -125,15 +123,18 @@ class McpJsonSerializerV3Test {
                 .build();
         McpPrompt prompt = new McpPromptImpl(config);
         JsonObject payload = MJS.toJson(prompt).build();
-        assertThat(payload.getString("name"), is("name"));
-        assertThat(payload.getString("title"), is("title"));
-        assertThat(payload.getString("description"), is("description"));
+        assertThat(payload.stringValue("name").orElseThrow(), is("name"));
+        assertThat(payload.stringValue("title").orElseThrow(), is("title"));
+        assertThat(payload.stringValue("description").orElseThrow(), is("description"));
 
-        JsonObject argument = payload.getJsonArray("arguments").getJsonObject(0);
-        assertThat(argument.getString("name"), is("name"));
-        assertThat(argument.getString("title"), is("title"));
-        assertThat(argument.getBoolean("required"), is(true));
-        assertThat(argument.getString("description"), is("description"));
+        JsonObject argument = payload.arrayValue("arguments")
+                .flatMap(arguments -> arguments.get(0))
+                .map(JsonValue::asObject)
+                .orElseThrow();
+        assertThat(argument.stringValue("name").orElseThrow(), is("name"));
+        assertThat(argument.stringValue("title").orElseThrow(), is("title"));
+        assertThat(argument.booleanValue("required").orElseThrow(), is(true));
+        assertThat(argument.stringValue("description").orElseThrow(), is("description"));
     }
 
     @Test
@@ -146,10 +147,10 @@ class McpJsonSerializerV3Test {
                 .build();
 
         JsonObject payload = MJS.toJson(argument).build();
-        assertThat(payload.getString("name"), is("name"));
-        assertThat(payload.getString("title"), is("title"));
-        assertThat(payload.getBoolean("required"), is(true));
-        assertThat(payload.getString("description"), is("description"));
+        assertThat(payload.stringValue("name").orElseThrow(), is("name"));
+        assertThat(payload.stringValue("title").orElseThrow(), is("title"));
+        assertThat(payload.booleanValue("required").orElseThrow(), is(true));
+        assertThat(payload.stringValue("description").orElseThrow(), is("description"));
     }
 
     @Test
@@ -164,21 +165,21 @@ class McpJsonSerializerV3Test {
                 .build();
 
         JsonObject request = MJS.createElicitationRequest(id, elicitationRequest);
-        assertThat(request.getInt("id"), is((int) id));
+        assertThat(request.intValue("id").orElseThrow(), is((int) id));
         assertThat(request.containsKey("params"), is(true));
 
-        JsonObject params = request.getJsonObject("params");
-        assertThat(params.getString("message"), is("message"));
+        JsonObject params = request.objectValue("params").orElseThrow();
+        assertThat(params.stringValue("message").orElseThrow(), is("message"));
 
-        JsonValue schema = params.get("requestedSchema");
-        assertThat(schema.getValueType(), is(JsonValue.ValueType.OBJECT));
+        JsonValue schema = params.value("requestedSchema").orElseThrow();
+        assertThat(schema.type(), is(JsonValueType.OBJECT));
     }
 
     @Test
     void testSerializeElicitationResponse() {
-        JsonObject params = JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("action", "accept")
-                .add("content", JsonValue.EMPTY_JSON_OBJECT)
+        JsonObject params = JsonObject.builder()
+                .set("action", "accept")
+                .set("content", JsonObject.empty())
                 .build();
         JsonObject elicitation = MJS.createJsonRpcResultResponse(1, params);
 
@@ -203,18 +204,21 @@ class McpJsonSerializerV3Test {
 
         JsonObject object = MJS.toolCall(tool, result);
         assertThat(object, is(notNullValue()));
-        assertThat(object.get("content"), is(notNullValue()));
-        assertThat(object.get("structuredContent"), is(notNullValue()));
+        assertThat(object.value("content").orElse(null), is(notNullValue()));
+        assertThat(object.value("structuredContent").orElse(null), is(notNullValue()));
 
-        JsonArray array = object.getJsonArray("content");
+        JsonArray array = object.arrayValue("content").orElseThrow();
         assertThat(array, is(notNullValue()));
         assertThat(array.size(), is(1));
 
-        String content = array.getJsonObject(0).getString("text");
+        String content = array.get(0)
+                .map(JsonValue::asObject)
+                .flatMap(value -> value.stringValue("text"))
+                .orElseThrow();
         assertThat(content, is("{\"foo\":\"bar\"}"));
 
-        JsonObject structuredContent = object.getJsonObject("structuredContent");
-        assertThat(structuredContent.getString("foo"), is("bar"));
+        JsonObject structuredContent = object.objectValue("structuredContent").orElseThrow();
+        assertThat(structuredContent.stringValue("foo").orElseThrow(), is("bar"));
     }
 
     @Test
@@ -233,18 +237,21 @@ class McpJsonSerializerV3Test {
 
         JsonObject object = MJS.toolCall(tool, result);
         assertThat(object, is(notNullValue()));
-        assertThat(object.get("content"), is(notNullValue()));
-        assertThat(object.get("structuredContent"), is(notNullValue()));
+        assertThat(object.value("content").orElse(null), is(notNullValue()));
+        assertThat(object.value("structuredContent").orElse(null), is(notNullValue()));
 
-        JsonArray array = object.getJsonArray("content");
+        JsonArray array = object.arrayValue("content").orElseThrow();
         assertThat(array, is(notNullValue()));
         assertThat(array.size(), is(1));
 
-        String content = array.getJsonObject(0).getString("text");
+        String content = array.get(0)
+                .map(JsonValue::asObject)
+                .flatMap(value -> value.stringValue("text"))
+                .orElseThrow();
         assertThat(content, is("foo"));
 
-        JsonObject structuredContent = object.getJsonObject("structuredContent");
-        assertThat(structuredContent.getString("foo"), is("bar"));
+        JsonObject structuredContent = object.objectValue("structuredContent").orElseThrow();
+        assertThat(structuredContent.stringValue("foo").orElseThrow(), is("bar"));
     }
 
     @Test
@@ -253,10 +260,10 @@ class McpJsonSerializerV3Test {
                 .name("name")
                 .uri("https://foo").build();
 
-        JsonObject payload = MJS.toJson(link).orElseGet(JSON_PROVIDER::createObjectBuilder).build();
-        assertThat(payload.getString("type"), is(McpContentType.RESOURCE_LINK.text()));
-        assertThat(payload.getString("uri"), is("https://foo"));
-        assertThat(payload.getString("name"), is("name"));
+        JsonObject payload = MJS.toJson(link).orElseGet(JsonObject::builder).build();
+        assertThat(payload.stringValue("type").orElseThrow(), is(McpContentType.RESOURCE_LINK.text()));
+        assertThat(payload.stringValue("uri").orElseThrow(), is("https://foo"));
+        assertThat(payload.stringValue("name").orElseThrow(), is("name"));
     }
 
     @Test
@@ -270,14 +277,14 @@ class McpJsonSerializerV3Test {
                 .mediaType(MediaTypes.APPLICATION_JSON)
                 .build();
 
-        JsonObject payload = MJS.toJson(link).orElseGet(JSON_PROVIDER::createObjectBuilder).build();
-        assertThat(payload.getJsonNumber("size").longValue(), is(10L));
-        assertThat(payload.getString("type"), is(McpContentType.RESOURCE_LINK.text()));
-        assertThat(payload.getString("name"), is("name"));
-        assertThat(payload.getString("title"), is("title"));
-        assertThat(payload.getString("uri"), is("https://foo"));
-        assertThat(payload.getString("description"), is("description"));
-        assertThat(payload.getString("mimeType"), is(MediaTypes.APPLICATION_JSON_VALUE));
+        JsonObject payload = MJS.toJson(link).orElseGet(JsonObject::builder).build();
+        assertThat(payload.longValue("size").orElseThrow(), is(10L));
+        assertThat(payload.stringValue("type").orElseThrow(), is(McpContentType.RESOURCE_LINK.text()));
+        assertThat(payload.stringValue("name").orElseThrow(), is("name"));
+        assertThat(payload.stringValue("title").orElseThrow(), is("title"));
+        assertThat(payload.stringValue("uri").orElseThrow(), is("https://foo"));
+        assertThat(payload.stringValue("description").orElseThrow(), is("description"));
+        assertThat(payload.stringValue("mimeType").orElseThrow(), is(MediaTypes.APPLICATION_JSON_VALUE));
     }
 
     @Test
@@ -294,27 +301,18 @@ class McpJsonSerializerV3Test {
         McpTool tool = new McpToolImpl(config);
         JsonObject payload = MJS.toolCall(tool, result);
 
-        JsonArray content = payload.getJsonArray("content");
+        JsonArray content = payload.arrayValue("content").orElseThrow();
         assertThat(content.size(), is(1));
 
-        JsonObject resourceLink = content.getJsonObject(0);
-        assertThat(resourceLink.getString("name"), is("name"));
-        assertThat(resourceLink.getString("uri"), is("https://foo"));
-        assertThat(resourceLink.getString("type"), is("resource_link"));
+        JsonObject resourceLink = content.get(0)
+                .map(JsonValue::asObject)
+                .orElseThrow();
+        assertThat(resourceLink.stringValue("name").orElseThrow(), is("name"));
+        assertThat(resourceLink.stringValue("uri").orElseThrow(), is("https://foo"));
+        assertThat(resourceLink.stringValue("type").orElseThrow(), is("resource_link"));
     }
 
-    public static class StructuredContent {
-        private String foo;
-
-        public StructuredContent(String foo) {
-            this.foo = foo;
-        }
-
-        public String getFoo() {
-            return foo;
-        }
-        public void setFoo(String foo) {
-            this.foo = foo;
-        }
+    @Json.Entity
+    public record StructuredContent(String foo) {
     }
 }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpParametersTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpParametersTest.java
@@ -22,13 +22,14 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
+import io.helidon.common.GenericType;
 import io.helidon.common.mapper.OptionalValue;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonParser;
+import io.helidon.json.binding.Json;
 import io.helidon.jsonrpc.core.JsonRpcParams;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonStructure;
-import jakarta.json.spi.JsonProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.JUnitException;
 
@@ -36,105 +37,83 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 class McpParametersTest {
-    private static final JsonProvider JSON_PROVIDER = JsonProvider.provider();
-
     @Test
     void testSimpleString() {
-        JsonObject object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", "bar")
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":\"bar\"}").readJsonObject();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(rpcParams, object);
+        McpParameters parameters = new McpParameters(rpcParams);
         String foo = parameters.get("foo").asString().orElse(null);
         assertThat(foo, is("bar"));
     }
 
     @Test
     void testSimpleBoolean() {
-        JsonObject object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", true)
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":true}").readJsonObject();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(rpcParams, object);
+        McpParameters parameters = new McpParameters(rpcParams);
         Boolean foo = parameters.get("foo").asBoolean().orElse(null);
         assertThat(foo, is(true));
     }
 
     @Test
     void testSimpleByte() {
-        JsonObject object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", 1)
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":1}").readJsonObject();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(rpcParams, object);
+        McpParameters parameters = new McpParameters(rpcParams);
         byte foo = parameters.get("foo").asByte().orElse(null);
         assertThat(foo, is((byte) 1));
     }
 
     @Test
     void testSimpleShort() {
-        JsonObject object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", 1)
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":1}").readJsonObject();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(rpcParams, object);
+        McpParameters parameters = new McpParameters(rpcParams);
         short foo = parameters.get("foo").asShort().orElse(null);
         assertThat(foo, is((short) 1));
     }
 
     @Test
     void testSimpleInteger() {
-        JsonObject object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", 1)
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":1}").readJsonObject();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(rpcParams, object);
+        McpParameters parameters = new McpParameters(rpcParams);
         int foo = parameters.get("foo").asInteger().orElse(null);
         assertThat(foo, is(1));
     }
 
     @Test
     void testSimpleLong() {
-        JsonObject object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", 1L)
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":1}").readJsonObject();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(rpcParams, object);
+        McpParameters parameters = new McpParameters(rpcParams);
         long foo = parameters.get("foo").asLong().orElse(null);
         assertThat(foo, is(1L));
     }
 
     @Test
     void testSimpleDouble() {
-        JsonObject object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", 1.0D)
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":1.0}").readJsonObject();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(rpcParams, object);
+        McpParameters parameters = new McpParameters(rpcParams);
         double foo = parameters.get("foo").asDouble().orElse(null);
         assertThat(foo, is(1.0D));
     }
 
     @Test
     void testSimpleFloat() {
-        JsonObject object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", 1.0F)
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":1.0}").readJsonObject();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(rpcParams, object);
+        McpParameters parameters = new McpParameters(rpcParams);
         float foo = parameters.get("foo").asFloat().orElse(null);
         assertThat(foo, is(1.0F));
     }
 
     @Test
     void testSimpleList() {
-        JsonObject object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", JSON_PROVIDER.createArrayBuilder()
-                        .add("foo1")
-                        .add("foo2"))
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":[\"foo1\",\"foo2\"]}").readJsonObject();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(rpcParams, object);
+        McpParameters parameters = new McpParameters(rpcParams);
         List<String> foo = parameters.get("foo")
                 .asList()
                 .get()
@@ -147,13 +126,9 @@ class McpParametersTest {
 
     @Test
     void testStringList() {
-        JsonObject object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", JSON_PROVIDER.createArrayBuilder()
-                        .add("foo1")
-                        .add("foo2"))
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":[\"foo1\",\"foo2\"]}").readJsonObject();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(rpcParams, object);
+        McpParameters parameters = new McpParameters(rpcParams);
         List<String> foo = parameters.get("foo")
                 .asList(String.class)
                 .orElse(List.of());
@@ -162,12 +137,9 @@ class McpParametersTest {
 
     @Test
     void testBooleanList() {
-        JsonArray array = JSON_PROVIDER.createArrayBuilder()
-                .add(true)
-                .add(false)
-                .build();
+        JsonArray array = JsonParser.create("[true,false]").readJsonArray();
         JsonRpcParams rpcParams = JsonRpcParams.create(array);
-        McpParameters parameters = new McpParameters(rpcParams, array);
+        McpParameters parameters = new McpParameters(rpcParams);
         List<Boolean> booleans = parameters.asList(Boolean.class).orElse(List.of());
         assertThat(booleans.size(), is(2));
         assertThat(booleans, is(List.of(true, false)));
@@ -175,12 +147,9 @@ class McpParametersTest {
 
     @Test
     void testIntegerList() {
-        JsonArray array = JSON_PROVIDER.createArrayBuilder()
-                .add(1)
-                .add(2)
-                .build();
+        JsonArray array = JsonParser.create("[1,2]").readJsonArray();
         JsonRpcParams rpcParams = JsonRpcParams.create(array);
-        McpParameters parameters = new McpParameters(rpcParams, array);
+        McpParameters parameters = new McpParameters(rpcParams);
         List<Integer> booleans = parameters.asList(Integer.class).orElse(List.of());
         assertThat(booleans.size(), is(2));
         assertThat(booleans, is(List.of(1, 2)));
@@ -188,12 +157,9 @@ class McpParametersTest {
 
     @Test
     void testLongList() {
-        JsonArray array = JSON_PROVIDER.createArrayBuilder()
-                .add(1L)
-                .add(2L)
-                .build();
+        JsonArray array = JsonParser.create("[1,2]").readJsonArray();
         JsonRpcParams rpcParams = JsonRpcParams.create(array);
-        McpParameters parameters = new McpParameters(rpcParams, array);
+        McpParameters parameters = new McpParameters(rpcParams);
         List<Long> booleans = parameters.asList(Long.class).orElse(List.of());
         assertThat(booleans.size(), is(2));
         assertThat(booleans, is(List.of(1L, 2L)));
@@ -201,12 +167,9 @@ class McpParametersTest {
 
     @Test
     void testDoubleList() {
-        JsonArray array = JSON_PROVIDER.createArrayBuilder()
-                .add(1D)
-                .add(2D)
-                .build();
+        JsonArray array = JsonParser.create("[1.0,2.0]").readJsonArray();
         JsonRpcParams rpcParams = JsonRpcParams.create(array);
-        McpParameters parameters = new McpParameters(rpcParams, array);
+        McpParameters parameters = new McpParameters(rpcParams);
         List<Double> booleans = parameters.asList(Double.class).orElse(List.of());
         assertThat(booleans.size(), is(2));
         assertThat(booleans, is(List.of(1D, 2D)));
@@ -214,12 +177,9 @@ class McpParametersTest {
 
     @Test
     void testFloatList() {
-        JsonArray array = JSON_PROVIDER.createArrayBuilder()
-                .add(1.0F)
-                .add(2.0F)
-                .build();
+        JsonArray array = JsonParser.create("[1.0,2.0]").readJsonArray();
         JsonRpcParams rpcParams = JsonRpcParams.create(array);
-        McpParameters parameters = new McpParameters(rpcParams, array);
+        McpParameters parameters = new McpParameters(rpcParams);
         List<Float> booleans = parameters.asList(Float.class).orElse(List.of());
         assertThat(booleans.size(), is(2));
         assertThat(booleans, is(List.of(1.0F, 2.0F)));
@@ -227,12 +187,9 @@ class McpParametersTest {
 
     @Test
     void testShortList() {
-        JsonArray array = JSON_PROVIDER.createArrayBuilder()
-                .add(1)
-                .add(2)
-                .build();
+        JsonArray array = JsonParser.create("[1,2]").readJsonArray();
         JsonRpcParams rpcParams = JsonRpcParams.create(array);
-        McpParameters parameters = new McpParameters(rpcParams, array);
+        McpParameters parameters = new McpParameters(rpcParams);
         List<Short> booleans = parameters.asList(Short.class).orElse(List.of());
         assertThat(booleans.size(), is(2));
         assertThat(booleans, is(List.of((short) 1, (short) 2)));
@@ -240,12 +197,9 @@ class McpParametersTest {
 
     @Test
     void testByteList() {
-        JsonArray array = JSON_PROVIDER.createArrayBuilder()
-                .add(1)
-                .add(2)
-                .build();
+        JsonArray array = JsonParser.create("[1,2]").readJsonArray();
         JsonRpcParams rpcParams = JsonRpcParams.create(array);
-        McpParameters parameters = new McpParameters(rpcParams, array);
+        McpParameters parameters = new McpParameters(rpcParams);
         List<Byte> booleans = parameters.asList(Byte.class).orElse(List.of());
         assertThat(booleans.size(), is(2));
         assertThat(booleans, is(List.of((byte) 1, (byte) 2)));
@@ -253,44 +207,46 @@ class McpParametersTest {
 
     @Test
     void testPojoList() {
-        JsonArray array = JSON_PROVIDER.createArrayBuilder()
-                .add(JSON_PROVIDER.createObjectBuilder()
-                             .add("foo", "foo1")
-                             .add("bar", "bar1"))
-                .add(JSON_PROVIDER.createObjectBuilder()
-                             .add("foo", "foo2")
-                             .add("bar", "bar2"))
-                .build();
+        JsonArray array = JsonParser.create("[{\"foo\":\"foo1\",\"bar\":\"bar1\"},{\"foo\":\"foo2\",\"bar\":\"bar2\"}]").readJsonArray();
         JsonRpcParams rpcParams = JsonRpcParams.create(array);
-        McpParameters parameters = new McpParameters(rpcParams, array);
+        McpParameters parameters = new McpParameters(rpcParams);
         List<Foo> foos = parameters
                 .asList(Foo.class)
                 .orElse(List.of());
         assertThat(foos.size(), is(2));
 
         Foo foo1 = foos.getFirst();
-        assertThat(foo1.foo, is("foo1"));
-        assertThat(foo1.bar, is("bar1"));
+        assertThat(foo1.foo(), is("foo1"));
+        assertThat(foo1.bar(), is("bar1"));
 
         Foo foo2 = foos.getLast();
-        assertThat(foo2.foo, is("foo2"));
-        assertThat(foo2.bar, is("bar2"));
+        assertThat(foo2.foo(), is("foo2"));
+        assertThat(foo2.bar(), is("bar2"));
+    }
+
+    @Test
+    void testGenericTypeCasting() {
+        JsonArray array = JsonParser.create("[{\"foo\":\"foo1\",\"bar\":\"bar1\"},{\"foo\":\"foo2\",\"bar\":\"bar2\"}]").readJsonArray();
+        JsonRpcParams rpcParams = JsonRpcParams.create(array);
+        McpParameters parameters = new McpParameters(rpcParams);
+        List<Foo> foos = parameters.as(new GenericType<List<Foo>>() { })
+                .orElse(List.of());
+
+        assertThat(foos.size(), is(2));
+        assertThat(foos.getFirst().foo(), is("foo1"));
+        assertThat(foos.getFirst().bar(), is("bar1"));
+        assertThat(foos.getLast().foo(), is("foo2"));
+        assertThat(foos.getLast().bar(), is("bar2"));
     }
 
     @Test
     void testListOfMap() {
-        JsonArray array = JSON_PROVIDER.createArrayBuilder()
-                .add(JSON_PROVIDER.createObjectBuilder()
-                             .add("value1", JSON_PROVIDER.createObjectBuilder()
-                                     .add("foo", "foo1")
-                                     .add("bar", "bar1")))
-                .add(JSON_PROVIDER.createObjectBuilder()
-                             .add("value2", JSON_PROVIDER.createObjectBuilder()
-                                     .add("foo", "foo2")
-                                     .add("bar", "bar2")))
-                .build();
+        JsonArray array = JsonParser.create("""
+                                            [{"value1":{"foo":"foo1","bar":"bar1"}},
+                                             {"value2":{"foo":"foo2","bar":"bar2"}}]
+                                            """).readJsonArray();
         JsonRpcParams rpcParams = JsonRpcParams.create(array);
-        McpParameters parameters = new McpParameters(rpcParams, array);
+        McpParameters parameters = new McpParameters(rpcParams);
         List<Map<String, McpParameters>> listMap = parameters.asList()
                 .map(list -> list.stream()
                         .map(McpParameters::asMap)
@@ -307,8 +263,8 @@ class McpParametersTest {
         Foo value1 = map.get("value1")
                 .as(Foo.class)
                 .orElseThrow(() -> new JUnitException("Cannot convert value1 to Foo.class"));
-        assertThat(value1.foo, is("foo1"));
-        assertThat(value1.bar, is("bar1"));
+        assertThat(value1.foo(), is("foo1"));
+        assertThat(value1.bar(), is("bar1"));
 
         map = listMap.getLast();
         assertThat(map.size(), is(1));
@@ -317,24 +273,18 @@ class McpParametersTest {
         Foo value2 = map.get("value2")
                 .as(Foo.class)
                 .orElseThrow(() -> new JUnitException("Cannot convert value2 to Foo.class"));
-        assertThat(value2.foo, is("foo2"));
-        assertThat(value2.bar, is("bar2"));
+        assertThat(value2.foo(), is("foo2"));
+        assertThat(value2.bar(), is("bar2"));
     }
 
     @Test
     void testMapOfList() {
-        JsonObject object = JSON_PROVIDER.createObjectBuilder()
-                .add("value1", JSON_PROVIDER.createArrayBuilder()
-                        .add(JSON_PROVIDER.createObjectBuilder()
-                                     .add("foo", "foo1")
-                                     .add("bar", "bar1")))
-                .add("value2", JSON_PROVIDER.createArrayBuilder()
-                        .add(JSON_PROVIDER.createObjectBuilder()
-                                     .add("foo", "foo2")
-                                     .add("bar", "bar2")))
-                .build();
+        JsonObject object = JsonParser.create("""
+                                               {"value1":[{"foo":"foo1","bar":"bar1"}],
+                                                "value2":[{"foo":"foo2","bar":"bar2"}]}
+                                               """).readJsonObject();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(rpcParams, object);
+        McpParameters parameters = new McpParameters(rpcParams);
         Map<String, McpParameters> map = parameters.asMap().orElse(Map.of());
         assertThat(map.size(), is(2));
         assertThat(map.containsKey("value1"), is(true));
@@ -344,26 +294,22 @@ class McpParametersTest {
         assertThat(value1.size(), is(1));
 
         Foo foo1 = value1.getFirst();
-        assertThat(foo1.foo, is("foo1"));
-        assertThat(foo1.bar, is("bar1"));
+        assertThat(foo1.foo(), is("foo1"));
+        assertThat(foo1.bar(), is("bar1"));
 
         List<Foo> value2 = map.get("value2").asList(Foo.class).orElse(List.of());
         assertThat(value2.size(), is(1));
 
         Foo foo2 = value2.getFirst();
-        assertThat(foo2.foo, is("foo2"));
-        assertThat(foo2.bar, is("bar2"));
+        assertThat(foo2.foo(), is("foo2"));
+        assertThat(foo2.bar(), is("bar2"));
     }
 
     @Test
     void testNestedObject() {
-        JsonObject object = JSON_PROVIDER.createObjectBuilder()
-                .add("person", JSON_PROVIDER.createObjectBuilder()
-                        .add("name", "Frank")
-                        .add("age", 10))
-                .build();
+        JsonObject object = JsonParser.create("{\"person\":{\"name\":\"Frank\",\"age\":10}}").readJsonObject();
         JsonRpcParams rpcParams = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(rpcParams, object);
+        McpParameters parameters = new McpParameters(rpcParams);
         String name = parameters.get("person").get("name").asString().orElse(null);
         int age = parameters.get("person").get("age").asInteger().orElse(-1);
 
@@ -373,40 +319,31 @@ class McpParametersTest {
 
     @Test
     void testCasting() {
-        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", "value1")
-                .add("bar", "value2")
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":\"value1\",\"bar\":\"value2\"}").readJsonObject();
         JsonRpcParams params = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(params, object);
+        McpParameters parameters = new McpParameters(params);
         Foo foo = parameters.as(Foo.class).get();
 
-        assertThat(foo.foo, is("value1"));
-        assertThat(foo.bar, is("value2"));
+        assertThat(foo.foo(), is("value1"));
+        assertThat(foo.bar(), is("value2"));
     }
 
     @Test
     void testNestedCasting() {
-        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", JSON_PROVIDER.createObjectBuilder()
-                        .add("foo", "value1")
-                        .add("bar", "value2"))
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":{\"foo\":\"value1\",\"bar\":\"value2\"}}").readJsonObject();
         JsonRpcParams params = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(params, object);
+        McpParameters parameters = new McpParameters(params);
         Foo foo = parameters.get("foo").as(Foo.class).get();
 
-        assertThat(foo.foo, is("value1"));
-        assertThat(foo.bar, is("value2"));
+        assertThat(foo.foo(), is("value1"));
+        assertThat(foo.bar(), is("value2"));
     }
 
     @Test
     void testIsNumberInt() {
-        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", 1)
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":1}").readJsonObject();
         JsonRpcParams params = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(params, object);
+        McpParameters parameters = new McpParameters(params);
         boolean isNumber = parameters.get("foo").isNumber();
 
         assertThat(isNumber, is(true));
@@ -414,11 +351,9 @@ class McpParametersTest {
 
     @Test
     void testIsNumberDouble() {
-        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", 1.0)
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":1.0}").readJsonObject();
         JsonRpcParams params = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(params, object);
+        McpParameters parameters = new McpParameters(params);
         boolean isNumber = parameters.get("foo").isNumber();
 
         assertThat(isNumber, is(true));
@@ -426,11 +361,9 @@ class McpParametersTest {
 
     @Test
     void testIsNumberString() {
-        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", "notANumber")
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":\"notANumber\"}").readJsonObject();
         JsonRpcParams params = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(params, object);
+        McpParameters parameters = new McpParameters(params);
         boolean isNumber = parameters.get("foo").isNumber();
 
         assertThat(isNumber, is(false));
@@ -438,11 +371,9 @@ class McpParametersTest {
 
     @Test
     void testIsString() {
-        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", "notANumber")
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":\"notANumber\"}").readJsonObject();
         JsonRpcParams params = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(params, object);
+        McpParameters parameters = new McpParameters(params);
         boolean isNumber = parameters.get("foo").isString();
 
         assertThat(isNumber, is(true));
@@ -450,11 +381,9 @@ class McpParametersTest {
 
     @Test
     void testIsStringNumber() {
-        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", 1)
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":1}").readJsonObject();
         JsonRpcParams params = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(params, object);
+        McpParameters parameters = new McpParameters(params);
         boolean isNumber = parameters.get("foo").isString();
 
         assertThat(isNumber, is(false));
@@ -463,11 +392,9 @@ class McpParametersTest {
     @Test
     void testIfPresent() {
         AtomicBoolean present = new AtomicBoolean(false);
-        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", 1)
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":1}").readJsonObject();
         JsonRpcParams params = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(params, object);
+        McpParameters parameters = new McpParameters(params);
         parameters.get("foo").ifPresent(it -> present.set(true));
         assertThat(present.get(), is(true));
     }
@@ -475,22 +402,18 @@ class McpParametersTest {
     @Test
     void testIfNotPresent() {
         AtomicBoolean present = new AtomicBoolean(false);
-        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", 1)
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":1}").readJsonObject();
         JsonRpcParams params = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(params, object);
+        McpParameters parameters = new McpParameters(params);
         parameters.get("bar").ifPresent(it -> present.set(true));
         assertThat(present.get(), is(false));
     }
 
     @Test
     void testIfPresentNullPointerException() {
-        JsonStructure object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", 1)
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":1}").readJsonObject();
         JsonRpcParams params = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(params, object);
+        McpParameters parameters = new McpParameters(params);
         try {
             parameters.get("foo").ifPresent(null);
             assertThat("NullPointerException must be thrown", true, is(false));
@@ -501,12 +424,9 @@ class McpParametersTest {
 
     @Test
     void testAsMap() {
-        JsonObject object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", "foo")
-                .add("bar", "bar")
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":\"foo\",\"bar\":\"bar\"}").readJsonObject();
         JsonRpcParams params = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(params, object);
+        McpParameters parameters = new McpParameters(params);
 
         Map<String, McpParameters> map = parameters.asMap()
                 .orElseGet(HashMap::new);
@@ -525,12 +445,9 @@ class McpParametersTest {
 
     @Test
     void testAsStringMap() {
-        JsonObject object = JSON_PROVIDER.createObjectBuilder()
-                .add("foo", "foo")
-                .add("bar", "bar")
-                .build();
+        JsonObject object = JsonParser.create("{\"foo\":\"foo\",\"bar\":\"bar\"}").readJsonObject();
         JsonRpcParams params = JsonRpcParams.create(object);
-        McpParameters parameters = new McpParameters(params, object);
+        McpParameters parameters = new McpParameters(params);
 
         Map<String, String> map = parameters.asMap()
                 .orElseGet(HashMap::new)
@@ -546,8 +463,7 @@ class McpParametersTest {
         assertThat(map.get("bar"), is("bar"));
     }
 
-    public static class Foo {
-        public String foo;
-        public String bar;
+    @Json.Entity
+    public record Foo(String foo, String bar) {
     }
 }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpResourceTemplateParameterTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpResourceTemplateParameterTest.java
@@ -19,7 +19,7 @@ package io.helidon.extensions.mcp.server;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.jsonrpc.core.JsonRpcParams;
 
-import jakarta.json.JsonValue;
+import io.helidon.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -34,7 +34,7 @@ class McpResourceTemplateParameterTest {
 
     @Test
     void testSimpleParameter() {
-        JsonRpcParams params = JsonRpcParams.create(JsonValue.EMPTY_JSON_OBJECT);
+        JsonRpcParams params = JsonRpcParams.create(JsonObject.empty());
         McpResourceConfig resource = builder.uri("https://{path}").build();
         McpResourceTemplate template = new McpResourceTemplate(new McpResourceImpl(resource));
         McpParameters parameters = template.parameters(params, "https://foo");
@@ -44,7 +44,7 @@ class McpResourceTemplateParameterTest {
 
     @Test
     void testTwoParameter() {
-        JsonRpcParams params = JsonRpcParams.create(JsonValue.EMPTY_JSON_OBJECT);
+        JsonRpcParams params = JsonRpcParams.create(JsonObject.empty());
         var resource = builder.uri("https://{foo}/{bar}").build();
         McpResourceTemplate template = new McpResourceTemplate(new McpResourceImpl(resource));
         McpParameters parameters = template.parameters(params, "https://foo/bar");
@@ -55,7 +55,7 @@ class McpResourceTemplateParameterTest {
 
     @Test
     void testSpaceParameter() {
-        JsonRpcParams params = JsonRpcParams.create(JsonValue.EMPTY_JSON_OBJECT);
+        JsonRpcParams params = JsonRpcParams.create(JsonObject.empty());
         var resource = builder.uri("https://{foo}/{bar}").build();
         McpResourceTemplate template = new McpResourceTemplate(new McpResourceImpl(resource));
         McpParameters parameters = template.parameters(params, "https://foo foo/bar bar");
@@ -66,7 +66,7 @@ class McpResourceTemplateParameterTest {
 
     @Test
     void testMiddleParameter() {
-        JsonRpcParams params = JsonRpcParams.create(JsonValue.EMPTY_JSON_OBJECT);
+        JsonRpcParams params = JsonRpcParams.create(JsonObject.empty());
         var resource = builder.uri("https://{foo}/path").build();
         McpResourceTemplate template = new McpResourceTemplate(new McpResourceImpl(resource));
         McpParameters parameters = template.parameters(params, "https://foo/path");
@@ -76,7 +76,7 @@ class McpResourceTemplateParameterTest {
 
     @Test
     void testProtocolParameter() {
-        JsonRpcParams params = JsonRpcParams.create(JsonValue.EMPTY_JSON_OBJECT);
+        JsonRpcParams params = JsonRpcParams.create(JsonObject.empty());
         var resource = builder.uri("{protocol}://{foo}").build();
         McpResourceTemplate template = new McpResourceTemplate(new McpResourceImpl(resource));
         McpParameters parameters = template.parameters(params, "https://foo");

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingRequestTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingRequestTest.java
@@ -17,10 +17,11 @@ package io.helidon.extensions.mcp.server;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 
 import io.helidon.common.media.type.MediaTypes;
+import io.helidon.json.JsonObject;
 
-import jakarta.json.JsonValue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -52,13 +53,14 @@ class McpSamplingRequestTest {
 
     @Test
     void testCustomValues() {
+        Map<String, Object> metadata = Map.of("enabled", true);
         McpSamplingRequest request = McpSamplingRequest.builder()
                 .maxTokens(1)
                 .temperature(0.1)
                 .costPriority(0.1)
                 .speedPriority(0.1)
                 .hints(List.of("hint1"))
-                .metadata(JsonValue.TRUE)
+                .metadata(metadata)
                 .intelligencePriority(0.1)
                 .systemPrompt("system prompt")
                 .timeout(Duration.ofSeconds(10))
@@ -99,7 +101,11 @@ class McpSamplingRequestTest {
         assertThat(audio.mediaType(), is(MediaTypes.TEXT_PLAIN));
 
         assertThat(request.metadata().isEmpty(), is(false));
-        assertThat(request.metadata().get(), is(JsonValue.TRUE));
+        assertThat(request.metadata().get(), is(metadata));
+
+        JsonObject serialized = new McpJsonSerializerV1().toJson(request).build();
+        JsonObject serializedMetadata = serialized.objectValue("metadata").orElseThrow();
+        assertThat(serializedMetadata.booleanValue("enabled").orElseThrow(), is(true));
 
         assertThat(request.includeContext().isEmpty(), is(false));
         assertThat(request.includeContext().get(), is(McpIncludeContext.NONE));

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSessionTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSessionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.server;
+
+import java.time.Duration;
+
+import io.helidon.json.JsonObject;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+class McpSessionTest {
+
+    @Test
+    void ignoresResponseWithNonNumericId() {
+        McpServerConfig config = McpServerConfig.create();
+        McpSessions sessions = new McpSessions(config.maxSessionCount());
+        McpSession session = new McpSession(sessions,
+                                            mock(McpTransportManager.class),
+                                            config,
+                                            "test-session");
+        JsonObject malformedResponse = JsonObject.builder()
+                .set("id", "not-a-number")
+                .build();
+        JsonObject expectedResponse = JsonObject.builder()
+                .set("id", 42)
+                .build();
+
+        session.acceptResponse(malformedResponse);
+        session.acceptResponse(expectedResponse);
+
+        JsonObject response = session.pollResponse(42, Duration.ofSeconds(1));
+        assertThat(response, is(expectedResponse));
+    }
+}

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSubscriptionsTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSubscriptionsTest.java
@@ -18,12 +18,12 @@ package io.helidon.extensions.mcp.server;
 
 import java.time.Duration;
 
+import io.helidon.json.JsonParser;
+import io.helidon.json.JsonValue;
 import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.jsonrpc.JsonRpcRequest;
 import io.helidon.webserver.jsonrpc.JsonRpcResponse;
 
-import jakarta.json.Json;
-import jakarta.json.JsonValue;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -36,7 +36,7 @@ class McpSubscriptionsTest {
 
     @Test
     void testStreamableSubscriptionIsRemovedOnTimeout() {
-        JsonValue requestId = Json.createValue(1);
+        JsonValue requestId = JsonParser.create("1").readJsonValue();
         McpStreamableHttpTransport transport = new McpStreamableHttpTransport(mock(JsonRpcResponse.class));
         McpSession session = session(transport);
         McpSubscriptions subscriptions = session.features().subscriptions();

--- a/tests/2024-11-05/pom.xml
+++ b/tests/2024-11-05/pom.xml
@@ -62,11 +62,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/tests/2025-03-26/pom.xml
+++ b/tests/2025-03-26/pom.xml
@@ -66,11 +66,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
@@ -113,4 +108,3 @@
     </dependencies>
 
 </project>
-

--- a/tests/2025-06-18/pom.xml
+++ b/tests/2025-06-18/pom.xml
@@ -67,8 +67,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tests/2025-06-18/src/test/java/io/helidon/extensions/mcp/tests/NegotiatedVersionTest.java
+++ b/tests/2025-06-18/src/test/java/io/helidon/extensions/mcp/tests/NegotiatedVersionTest.java
@@ -18,6 +18,7 @@ package io.helidon.extensions.mcp.tests;
 import io.helidon.extensions.mcp.tests.common.MultipleTool;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
 import io.helidon.http.Status;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webserver.WebServer;
@@ -25,8 +26,6 @@ import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
 
-import jakarta.json.JsonObject;
-import jakarta.json.spi.JsonProvider;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,7 +34,6 @@ import static org.hamcrest.Matchers.is;
 
 @ServerTest
 class NegotiatedVersionTest {
-    private static final JsonProvider JSON_PROVIDER = JsonProvider.provider();
     private static final HeaderName SESSION_ID_HEADER = HeaderNames.create("Mcp-Session-Id");
     private static final HeaderName MCP_PROTOCOL_VERSION = HeaderNames.create("Mcp-Protocol-Version");
 
@@ -54,32 +52,36 @@ class NegotiatedVersionTest {
 
     @Test
     void testInvalidMcpVersion() {
-        JsonObject initRequest = JSON_PROVIDER.createObjectBuilder()
-                .add("jsonrpc", "2.0")
-                .add("id", 1)
-                .add("method", "initialize")
-                .add("params", JSON_PROVIDER.createObjectBuilder()
-                        .add("protocolVersion", "2025-06-15")
-                        .add("capabilities", JSON_PROVIDER.createObjectBuilder()
-                                .add("roots", JSON_PROVIDER.createObjectBuilder()
-                                        .add("listChanged", true)))
-                        .add("clientInfo", JSON_PROVIDER.createObjectBuilder()
-                                .add("name", "Example Client Display Name")
-                                .add("version", "1.0.0")))
-                .build();
+        String initRequest = """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "method": "initialize",
+                  "params": {
+                    "protocolVersion": "2025-06-15",
+                    "capabilities": {"roots": {"listChanged": true}},
+                    "clientInfo": {"name": "Example Client Display Name", "version": "1.0.0"}
+                  }
+                }
+                """;
         String sessionId;
-        try (var response = client.post().submit(initRequest)) {
+        try (var response = client.post()
+                .header(HeaderValues.CONTENT_TYPE_JSON)
+                .submit(initRequest)) {
             sessionId = response.headers().get(SESSION_ID_HEADER).get();
         }
 
-        JsonObject listTools = JSON_PROVIDER.createObjectBuilder()
-                .add("jsonrpc", "2.0")
-                .add("id", 2)
-                .add("method", "tools/list")
-                .build();
+        String listTools = """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "method": "tools/list"
+                }
+                """;
         try (var response = client.post()
                 .header(SESSION_ID_HEADER, sessionId)
                 .header(MCP_PROTOCOL_VERSION, "2025-12-34")
+                .header(HeaderValues.CONTENT_TYPE_JSON)
                 .submit(listTools)) {
             String res = response.entity().as(String.class);
             assertThat(response.status(), is(Status.BAD_REQUEST_400));

--- a/tests/2025-06-18/src/test/java/io/helidon/extensions/mcp/tests/StatelessServerTest.java
+++ b/tests/2025-06-18/src/test/java/io/helidon/extensions/mcp/tests/StatelessServerTest.java
@@ -22,6 +22,8 @@ import io.helidon.extensions.mcp.tests.common.StatelessServer;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Status;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
 import io.helidon.webclient.jsonrpc.JsonRpcClient;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRouting;
@@ -35,8 +37,6 @@ import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.mcp.client.McpException;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
-import jakarta.json.JsonObject;
-import jakarta.json.spi.JsonProvider;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -46,7 +46,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ServerTest
 class StatelessServerTest {
-    private static final JsonProvider JSON_PROVIDER = JsonProvider.provider();
     private static final String SUCCESS_TEXT = "Success";
     private static final String TOOL_NAME = "stateless-tool";
     private static final String PROMPT_NAME = "stateless-prompt";
@@ -90,9 +89,15 @@ class StatelessServerTest {
                 .submit()) {
             assertThat(response.error().isEmpty(), is(true));
             assertThat(response.result().isEmpty(), is(false));
-            var tools = response.result().orElseThrow().asJsonObject().getJsonArray("tools");
+            var tools = response.result()
+                    .map(result -> result.asJsonObject())
+                    .flatMap(result -> result.arrayValue("tools"))
+                    .orElseThrow();
             assertThat(tools.size(), is(1));
-            assertThat(tools.getJsonObject(0).getString("name"), is(TOOL_NAME));
+            assertThat(tools.get(0)
+                    .map(JsonValue::asObject)
+                    .flatMap(object -> object.stringValue("name"))
+                    .orElseThrow(), is(TOOL_NAME));
         }
     }
 
@@ -110,9 +115,15 @@ class StatelessServerTest {
                 .submit()) {
             assertThat(response.error().isEmpty(), is(true));
             assertThat(response.result().isEmpty(), is(false));
-            var prompts = response.result().orElseThrow().asJsonObject().getJsonArray("prompts");
+            var prompts = response.result()
+                    .map(result -> result.asJsonObject())
+                    .flatMap(result -> result.arrayValue("prompts"))
+                    .orElseThrow();
             assertThat(prompts.size(), is(1));
-            assertThat(prompts.getJsonObject(0).getString("name"), is(PROMPT_NAME));
+            assertThat(prompts.get(0)
+                    .map(JsonValue::asObject)
+                    .flatMap(object -> object.stringValue("name"))
+                    .orElseThrow(), is(PROMPT_NAME));
         }
     }
 
@@ -131,19 +142,29 @@ class StatelessServerTest {
                 .submit()) {
             assertThat(response.error().isEmpty(), is(true));
             assertThat(response.result().isEmpty(), is(false));
-            var resources = response.result().orElseThrow().asJsonObject().getJsonArray("resources");
+            var resources = response.result()
+                    .map(result -> result.asJsonObject())
+                    .flatMap(result -> result.arrayValue("resources"))
+                    .orElseThrow();
             assertThat(resources.size(), is(1));
-            assertThat(resources.getJsonObject(0).getString("name"), is(RESOURCE_NAME));
-            assertThat(resources.getJsonObject(0).getString("uri"), is(RESOURCE_URI));
+            assertThat(resources.get(0)
+                    .map(JsonValue::asObject)
+                    .flatMap(object -> object.stringValue("name"))
+                    .orElseThrow(), is(RESOURCE_NAME));
+            assertThat(resources.get(0)
+                    .map(JsonValue::asObject)
+                    .flatMap(object -> object.stringValue("uri"))
+                    .orElseThrow(), is(RESOURCE_URI));
         }
     }
 
     @Test
     void statefulToolCall() {
-        var exception = assertThrows(ToolExecutionException.class, () -> statefulClient.executeTool(ToolExecutionRequest.builder()
-                                                                                                             .name(TOOL_NAME)
-                                                                                                             .arguments("{}")
-                                                                                                             .build()));
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .name(TOOL_NAME)
+                .arguments("{}")
+                .build();
+        var exception = assertThrows(ToolExecutionException.class, () -> statefulClient.executeTool(request));
         assertThat(exception.getMessage(), containsString("Roots is enabled"));
     }
 
@@ -152,12 +173,19 @@ class StatelessServerTest {
         try (var response = statelessClient.rpcMethod("tools/call")
                 .rpcId(4)
                 .param("name", TOOL_NAME)
-                .param("arguments", JSON_PROVIDER.createObjectBuilder().build())
+                .param("arguments", JsonObject.empty())
                 .submit()) {
             assertThat(response.error().isEmpty(), is(true));
             assertThat(response.result().isEmpty(), is(false));
-            var result = response.result().orElseThrow().asJsonObject();
-            assertThat(result.getJsonArray("content").getJsonObject(0).getString("text"), is(SUCCESS_TEXT));
+            var result = response.result()
+                    .map(value -> value.asJsonObject())
+                    .orElseThrow();
+            String text = result.arrayValue("content")
+                    .flatMap(content -> content.get(0))
+                    .map(JsonValue::asObject)
+                    .flatMap(content -> content.stringValue("text"))
+                    .orElseThrow();
+            assertThat(text, is(SUCCESS_TEXT));
         }
     }
 
@@ -172,13 +200,20 @@ class StatelessServerTest {
         try (var response = statelessClient.rpcMethod("prompts/get")
                 .rpcId(5)
                 .param("name", PROMPT_NAME)
-                .param("arguments", JSON_PROVIDER.createObjectBuilder().build())
+                .param("arguments", JsonObject.empty())
                 .submit()) {
             assertThat(response.error().isEmpty(), is(true));
             assertThat(response.result().isEmpty(), is(false));
-            var prompt = response.result().orElseThrow().asJsonObject();
-            assertThat(prompt.getJsonArray("messages").getJsonObject(0).getJsonObject("content").getString("text"),
-                       is(SUCCESS_TEXT));
+            var prompt = response.result()
+                    .map(result -> result.asJsonObject())
+                    .orElseThrow();
+            String text = prompt.arrayValue("messages")
+                    .flatMap(messages -> messages.get(0))
+                    .map(JsonValue::asObject)
+                    .flatMap(message -> message.objectValue("content"))
+                    .flatMap(content -> content.stringValue("text"))
+                    .orElseThrow();
+            assertThat(text, is(SUCCESS_TEXT));
         }
     }
 
@@ -196,20 +231,27 @@ class StatelessServerTest {
                 .submit()) {
             assertThat(response.error().isEmpty(), is(true));
             assertThat(response.result().isEmpty(), is(false));
-            var resource = response.result().orElseThrow().asJsonObject();
-            assertThat(resource.getJsonArray("contents").getJsonObject(0).getString("text"), is(SUCCESS_TEXT));
+            var resource = response.result()
+                    .map(result -> result.asJsonObject())
+                    .orElseThrow();
+            String text = resource.arrayValue("contents")
+                    .flatMap(contents -> contents.get(0))
+                    .map(JsonValue::asObject)
+                    .flatMap(content -> content.stringValue("text"))
+                    .orElseThrow();
+            assertThat(text, is(SUCCESS_TEXT));
         }
     }
 
     @Test
     void statelessCompletion() {
-        JsonObject ref = JSON_PROVIDER.createObjectBuilder()
-                .add("type", "ref/prompt")
-                .add("name", COMPLETION_NAME)
+        JsonObject ref = JsonObject.builder()
+                .set("type", "ref/prompt")
+                .set("name", COMPLETION_NAME)
                 .build();
-        JsonObject argument = JSON_PROVIDER.createObjectBuilder()
-                .add("name", "arg")
-                .add("value", "suc")
+        JsonObject argument = JsonObject.builder()
+                .set("name", "arg")
+                .set("value", "suc")
                 .build();
         try (var response = statelessClient.rpcMethod("completion/complete")
                 .rpcId(7)

--- a/tests/common/pom.xml
+++ b/tests/common/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>helidon-json-schema</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json-binding</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.testing.junit5</groupId>
             <artifactId>helidon-webserver-testing-junit5</artifactId>
             <scope>test</scope>
@@ -48,11 +52,6 @@
         <dependency>
             <groupId>io.helidon.fault-tolerance</groupId>
             <artifactId>helidon-fault-tolerance</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -96,4 +95,32 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.json</groupId>
+                            <artifactId>helidon-json-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.service</groupId>
+                            <artifactId>helidon-service-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/tests/common/src/main/java/io/helidon/extensions/mcp/tests/common/MultipleTool.java
+++ b/tests/common/src/main/java/io/helidon/extensions/mcp/tests/common/MultipleTool.java
@@ -24,6 +24,7 @@ import io.helidon.extensions.mcp.server.McpServerFeature;
 import io.helidon.extensions.mcp.server.McpTool;
 import io.helidon.extensions.mcp.server.McpToolRequest;
 import io.helidon.extensions.mcp.server.McpToolResult;
+import io.helidon.json.binding.Json;
 import io.helidon.json.schema.Schema;
 import io.helidon.json.schema.SchemaNumber;
 import io.helidon.json.schema.SchemaString;
@@ -134,19 +135,7 @@ public class MultipleTool {
         }
     }
 
-    public static class StructuredContent {
-        private String foo;
-
-        StructuredContent(String foo) {
-            this.foo = foo;
-        }
-
-        public String getFoo() {
-            return foo;
-        }
-
-        public void setFoo(String foo) {
-            this.foo = foo;
-        }
+    @Json.Entity
+    public record StructuredContent(String foo) {
     }
 }

--- a/tests/common/src/main/java/io/helidon/extensions/mcp/tests/common/OutputSchemaTools.java
+++ b/tests/common/src/main/java/io/helidon/extensions/mcp/tests/common/OutputSchemaTools.java
@@ -21,6 +21,7 @@ import io.helidon.extensions.mcp.server.McpServerConfig;
 import io.helidon.extensions.mcp.server.McpTool;
 import io.helidon.extensions.mcp.server.McpToolRequest;
 import io.helidon.extensions.mcp.server.McpToolResult;
+import io.helidon.json.binding.Json;
 import io.helidon.json.schema.Schema;
 import io.helidon.json.schema.SchemaObject;
 import io.helidon.json.schema.SchemaString;
@@ -190,6 +191,7 @@ public class OutputSchemaTools {
      *
      * @param foo foo
      */
+    @Json.Entity
     public record StructuredContentPojo(String foo) {
     }
 }

--- a/tests/common/src/main/java/module-info.java
+++ b/tests/common/src/main/java/module-info.java
@@ -15,8 +15,8 @@
  */
 
 module helidon.extensions.mcp.tests.common {
-    requires jakarta.json;
     requires io.helidon.extensions.mcp.server;
+    requires io.helidon.json.binding;
     requires io.helidon.webserver;
     requires io.helidon.service.registry;
     requires io.helidon.json.schema;

--- a/tests/declarative/pom.xml
+++ b/tests/declarative/pom.xml
@@ -41,16 +41,20 @@
             <artifactId>helidon-json-schema</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json-binding</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.service</groupId>
             <artifactId>helidon-service-registry</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver.testing.junit5</groupId>
@@ -121,6 +125,11 @@
                         <path>
                             <groupId>io.helidon.json.schema</groupId>
                             <artifactId>helidon-json-schema-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.json</groupId>
+                            <artifactId>helidon-json-codegen</artifactId>
                             <version>${helidon.version}</version>
                         </path>
                         <path>

--- a/tests/declarative/src/main/java/io/helidon/extensions/mcp/tests/declarative/McpMixedComponentServer.java
+++ b/tests/declarative/src/main/java/io/helidon/extensions/mcp/tests/declarative/McpMixedComponentServer.java
@@ -22,6 +22,7 @@ import io.helidon.extensions.mcp.server.McpCompletionResult;
 import io.helidon.extensions.mcp.server.McpPromptResult;
 import io.helidon.extensions.mcp.server.McpResourceResult;
 import io.helidon.extensions.mcp.server.McpToolResult;
+import io.helidon.json.binding.Json;
 import io.helidon.json.schema.JsonSchema;
 
 @Mcp.Server("mcp-weather-server")
@@ -51,6 +52,7 @@ class McpMixedComponentServer {
         return McpCompletionResult.create();
     }
 
+    @Json.Entity
     @JsonSchema.Schema
     public static class Alert {
         public String name;
@@ -58,6 +60,7 @@ class McpMixedComponentServer {
         public Location location;
     }
 
+    @Json.Entity
     @JsonSchema.Schema
     public static class Location {
         public int latitude;

--- a/tests/declarative/src/main/java/io/helidon/extensions/mcp/tests/declarative/McpToolsServer.java
+++ b/tests/declarative/src/main/java/io/helidon/extensions/mcp/tests/declarative/McpToolsServer.java
@@ -23,6 +23,7 @@ import io.helidon.extensions.mcp.server.McpFeatures;
 import io.helidon.extensions.mcp.server.McpRequest;
 import io.helidon.extensions.mcp.server.McpToolRequest;
 import io.helidon.extensions.mcp.server.McpToolResult;
+import io.helidon.json.binding.Json;
 import io.helidon.json.schema.JsonSchema;
 
 @Mcp.Server
@@ -200,6 +201,7 @@ class McpToolsServer {
         return "values=" + String.join(",", values);
     }
 
+    @Json.Entity
     @JsonSchema.Schema
     public static class Foo {
         public String foo;

--- a/tests/declarative/src/main/java/module-info.java
+++ b/tests/declarative/src/main/java/module-info.java
@@ -16,6 +16,8 @@
 
 module io.helidon.extensions.mcp.tests.declarative {
     requires io.helidon.webserver;
+    requires io.helidon.json;
+    requires io.helidon.json.binding;
     requires io.helidon.json.schema;
     requires io.helidon.logging.common;
     requires io.helidon.service.registry;

--- a/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/JsonSchemaGenerationTest.java
+++ b/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/JsonSchemaGenerationTest.java
@@ -15,18 +15,13 @@
  */
 package io.helidon.extensions.mcp.tests.declarative;
 
-import java.io.StringReader;
-
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonParser;
 import io.helidon.service.registry.Services;
 
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class JsonSchemaGenerationTest {
@@ -34,43 +29,46 @@ class JsonSchemaGenerationTest {
     @Test
     void testFooSchema() {
         String s = Services.get(Foo__JsonSchema.class).jsonSchema();
-        JsonObject json = Json.createReader(new StringReader(s)).readObject();
-        assertThat(json.getString("type"), is("object"));
-        JsonValue properties = json.get("properties");
-        assertThat(properties, notNullValue());
-        assertThat(properties, instanceOf(JsonObject.class));
-        JsonObject propertiesJson = (JsonObject) properties;
+        JsonObject json = JsonParser.create(s).readJsonObject();
+        assertThat(json.stringValue("type").orElseThrow(), is("object"));
+        JsonObject propertiesJson = json.objectValue("properties").orElseThrow();
         assertThat(propertiesJson.size(), is(2));
-        assertThat(propertiesJson.getJsonObject("foo").getString("type"), is("string"));
-        assertThat(propertiesJson.getJsonObject("bar").getString("type"), is("integer"));
+        assertThat(propertiesJson.objectValue("foo")
+                           .flatMap(property -> property.stringValue("type"))
+                           .orElseThrow(), is("string"));
+        assertThat(propertiesJson.objectValue("bar")
+                           .flatMap(property -> property.stringValue("type"))
+                           .orElseThrow(), is("integer"));
     }
 
     @Test
     void testAlertSchema() {
         String s = Services.get(Alert__JsonSchema.class).jsonSchema();
-        JsonObject json = Json.createReader(new StringReader(s)).readObject();
-        assertThat(json.getString("type"), is("object"));
-        JsonValue properties = json.get("properties");
-        assertThat(properties, notNullValue());
-        assertThat(properties, instanceOf(JsonObject.class));
-        JsonObject propertiesJson = (JsonObject) properties;
+        JsonObject json = JsonParser.create(s).readJsonObject();
+        assertThat(json.stringValue("type").orElseThrow(), is("object"));
+        JsonObject propertiesJson = json.objectValue("properties").orElseThrow();
         assertThat(propertiesJson.size(), is(3));
-        assertThat(propertiesJson.getJsonObject("name").getString("type"), is("string"));
-        assertThat(propertiesJson.getJsonObject("priority").getString("type"), is("integer"));
-        assertThat(((JsonObject) properties).containsKey("location"), is(true));
+        assertThat(propertiesJson.objectValue("name")
+                           .flatMap(property -> property.stringValue("type"))
+                           .orElseThrow(), is("string"));
+        assertThat(propertiesJson.objectValue("priority")
+                           .flatMap(property -> property.stringValue("type"))
+                           .orElseThrow(), is("integer"));
+        assertThat(propertiesJson.containsKey("location"), is(true));
     }
 
     @Test
     void testLocationSchema() {
         String s = Services.get(Location__JsonSchema.class).jsonSchema();
-        JsonObject json = Json.createReader(new StringReader(s)).readObject();
-        assertThat(json.getString("type"), is("object"));
-        JsonValue properties = json.get("properties");
-        assertThat(properties, notNullValue());
-        assertThat(properties, instanceOf(JsonObject.class));
-        JsonObject propertiesJson = (JsonObject) properties;
+        JsonObject json = JsonParser.create(s).readJsonObject();
+        assertThat(json.stringValue("type").orElseThrow(), is("object"));
+        JsonObject propertiesJson = json.objectValue("properties").orElseThrow();
         assertThat(propertiesJson.size(), is(2));
-        assertThat(propertiesJson.getJsonObject("latitude").getString("type"), is("integer"));
-        assertThat(propertiesJson.getJsonObject("longitude").getString("type"), is("integer"));
+        assertThat(propertiesJson.objectValue("latitude")
+                           .flatMap(property -> property.stringValue("type"))
+                           .orElseThrow(), is("integer"));
+        assertThat(propertiesJson.objectValue("longitude")
+                           .flatMap(property -> property.stringValue("type"))
+                           .orElseThrow(), is("integer"));
     }
 }

--- a/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/McpStatelessAnnotationTest.java
+++ b/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/McpStatelessAnnotationTest.java
@@ -45,7 +45,12 @@ class McpStatelessAnnotationTest {
                 .submit()) {
             assertThat(response.error().isEmpty(), is(true));
             assertThat(response.result().isEmpty(), is(false));
-            assertThat(response.result().orElseThrow().asJsonObject().getJsonArray("tools").size(), is(1));
+            int toolCount = response.result()
+                    .map(result -> result.asJsonObject())
+                    .flatMap(result -> result.arrayValue("tools"))
+                    .map(tools -> tools.size())
+                    .orElseThrow();
+            assertThat(toolCount, is(1));
         }
     }
 
@@ -55,7 +60,7 @@ class McpStatelessAnnotationTest {
                 .rpcId(2)
                 .submit()) {
             assertThat(response.error().isEmpty(), is(false));
-            assertThat(response.error().orElseThrow().message(), is("Session not found"));
+            assertThat(response.error().map(error -> error.message()).orElseThrow(), is("Session not found"));
         }
     }
 }


### PR DESCRIPTION
This PR update Helidon core version to `4.5.0`. This enables support for Microprofile, an example is included.