### PR TITLE
Add tool calling support to sampling via tools and toolChoice parameters

### DIFF
--- a/docs/mcp-declarative.md
+++ b/docs/mcp-declarative.md
@@ -555,7 +555,7 @@ void convert(McpToolRequest request) {
 The `McpRequest` object is the base interface for every request, providing access to client-side data and features.
 
 - **`parameters()`**: Returns `McpParameters` for accessing client-provided parameters.
-- **`meta()`**: Returns `McpParameters` for accessing client-provided metadata.
+- **`metadata()`**: Returns optional `McpParameters` for accessing client-provided protocol metadata.
 - **`features()`**: Returns `McpFeatures` for accessing advanced features such as logging, progress, cancellation, elicitation, sampling, and roots.
 - **`protocolVersion()`**: Returns the negotiated protocol version between the server and the client.
 - **`sessionContext()`**: Returns a `Context` for session-scoped data.

--- a/docs/mcp-declarative.md
+++ b/docs/mcp-declarative.md
@@ -555,7 +555,8 @@ void convert(McpToolRequest request) {
 The `McpRequest` object is the base interface for every request, providing access to client-side data and features.
 
 - **`parameters()`**: Returns `McpParameters` for accessing client-provided parameters.
-- **`metadata()`**: Returns optional `McpParameters` for accessing client-provided protocol metadata.
+- **`metadata()`**: Returns optional `Object` protocol metadata deserialized with Helidon JSON binding. Incoming JSON objects
+  are represented as `JsonObject`.
 - **`features()`**: Returns `McpFeatures` for accessing advanced features such as logging, progress, cancellation, elicitation, sampling, and roots.
 - **`protocolVersion()`**: Returns the negotiated protocol version between the server and the client.
 - **`sessionContext()`**: Returns a `Context` for session-scoped data.

--- a/docs/mcp-declarative.md
+++ b/docs/mcp-declarative.md
@@ -555,8 +555,8 @@ void convert(McpToolRequest request) {
 The `McpRequest` object is the base interface for every request, providing access to client-side data and features.
 
 - **`parameters()`**: Returns `McpParameters` for accessing client-provided parameters.
-- **`metadata()`**: Returns optional `Object` protocol metadata deserialized with Helidon JSON binding. Incoming JSON objects
-  are represented as `JsonObject`.
+- **`metadata()`**: Returns optional `McpParameters` for accessing client-provided protocol metadata. Use
+  `McpParameters.create(Object)` to create metadata from maps or custom Helidon JSON types.
 - **`features()`**: Returns `McpFeatures` for accessing advanced features such as logging, progress, cancellation, elicitation, sampling, and roots.
 - **`protocolVersion()`**: Returns the negotiated protocol version between the server and the client.
 - **`sessionContext()`**: Returns a `Context` for session-scoped data.

--- a/docs/mcp-declarative.md
+++ b/docs/mcp-declarative.md
@@ -740,9 +740,10 @@ McpToolResult samplingTool(McpSampling sampling) {
         McpSamplingResponse response = sampling.request(req -> req
                 .timeout(Duration.ofSeconds(10))
                 .systemPrompt("You are a concise, helpful assistant.")
-                .addTextMessage(McpSamplingTextMessage.builder().text("Write a 3-line summary of Helidon MCP Sampling.").role(McpRole.USER).build()));
+                .addTextMessage(McpRole.USER,
+                                "Write a 3-line summary of Helidon MCP Sampling."));
         return McpToolResult.builder()
-                .addTextContent(response.asTextMessage().text())
+                .addTextContent(response.asTextContent().text())
                 .build();
     } catch (McpSamplingException e) {
         return McpToolResult.builder()

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -737,8 +737,8 @@ McpCompletionResult result = McpCompletionResult.builder()
 The `McpRequest` object is the base interface for every request, providing access to client-side data and features.
 
 - **`parameters()`**: Returns `McpParameters` for accessing client-provided parameters.
-- **`metadata()`**: Returns optional `Object` protocol metadata deserialized with Helidon JSON binding. Incoming JSON objects
-  are represented as `JsonObject`.
+- **`metadata()`**: Returns optional `McpParameters` for accessing client-provided protocol metadata. Use
+  `McpParameters.create(Object)` to create metadata from maps or custom Helidon JSON types.
 - **`features()`**: Returns `McpFeatures` for accessing advanced features such as logging, progress, cancellation, elicitation, sampling, and roots.
 - **`protocolVersion()`**: Returns the negotiated protocol version between the server and the client.
 - **`sessionContext()`**: Returns a `Context` for session-scoped data.
@@ -1169,9 +1169,8 @@ builder also provides `addTextMessage(String)` and `addTextMessage(McpRole, Stri
 Text, image, and audio blocks can also carry `McpAnnotations` for audience, priority, and last-modified metadata. Every
 sampling content block and sampling message envelope supports its own wire `_meta` value through `metadata(...)` and
 `metadata()`. The public tool-content types, such as `McpToolTextContent` and `McpToolImageContent`, expose the same
-annotations and metadata options. Builder values are serialized with Helidon JSON binding and must produce a JSON object;
-maps and converter-backed custom types are supported. Incoming metadata is deserialized as `Object`, with JSON objects
-represented as `JsonObject`.
+annotations and metadata options. These builders accept `McpParameters`; use `McpParameters.create(Object)` to serialize maps
+or converter-backed custom types with Helidon JSON binding. The supplied value must produce a JSON object.
 
 Create sampling request messages with the `McpSamplingRequest` builder:
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -737,7 +737,7 @@ McpCompletionResult result = McpCompletionResult.builder()
 The `McpRequest` object is the base interface for every request, providing access to client-side data and features.
 
 - **`parameters()`**: Returns `McpParameters` for accessing client-provided parameters.
-- **`meta()`**: Returns `McpParameters` for accessing client-provided metadata.
+- **`metadata()`**: Returns optional `McpParameters` for accessing client-provided protocol metadata.
 - **`features()`**: Returns `McpFeatures` for accessing advanced features such as logging, progress, cancellation, elicitation, sampling, and roots.
 - **`protocolVersion()`**: Returns the negotiated protocol version between the server and the client.
 - **`sessionContext()`**: Returns a `Context` for session-scoped data.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -737,7 +737,8 @@ McpCompletionResult result = McpCompletionResult.builder()
 The `McpRequest` object is the base interface for every request, providing access to client-side data and features.
 
 - **`parameters()`**: Returns `McpParameters` for accessing client-provided parameters.
-- **`metadata()`**: Returns optional `McpParameters` for accessing client-provided protocol metadata.
+- **`metadata()`**: Returns optional `Object` protocol metadata deserialized with Helidon JSON binding. Incoming JSON objects
+  are represented as `JsonObject`.
 - **`features()`**: Returns `McpFeatures` for accessing advanced features such as logging, progress, cancellation, elicitation, sampling, and roots.
 - **`protocolVersion()`**: Returns the negotiated protocol version between the server and the client.
 - **`sessionContext()`**: Returns a `Context` for session-scoped data.
@@ -1168,7 +1169,9 @@ builder also provides `addTextMessage(String)` and `addTextMessage(McpRole, Stri
 Text, image, and audio blocks can also carry `McpAnnotations` for audience, priority, and last-modified metadata. Every
 sampling content block and sampling message envelope supports its own wire `_meta` value through `metadata(...)` and
 `metadata()`. The public tool-content types, such as `McpToolTextContent` and `McpToolImageContent`, expose the same
-annotations and metadata options.
+annotations and metadata options. Builder values are serialized with Helidon JSON binding and must produce a JSON object;
+maps and converter-backed custom types are supported. Incoming metadata is deserialized as `Object`, with JSON objects
+represented as `JsonObject`.
 
 Create sampling request messages with the `McpSamplingRequest` builder:
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1172,8 +1172,15 @@ annotations and metadata options.
 
 Create sampling request messages with the `McpSamplingRequest` builder:
 
-Multiple content blocks in one message envelope require negotiated protocol version `2025-11-25`. For earlier protocol
-versions, create a separate message envelope for each content block.
+Sampling content and metadata support depends on the negotiated protocol version:
+
+- `2024-11-05` supports text and image content blocks.
+- `2025-03-26` adds audio content blocks.
+- `2025-06-18` adds content `_meta` and `McpAnnotations.lastModified`; message `_meta` remains unsupported.
+- `2025-11-25` adds tool-use and tool-result blocks, message `_meta`, and multiple content blocks per message envelope.
+
+For protocol versions before `2025-11-25`, create a separate message envelope for each content block and use only the content
+types and metadata fields supported by the negotiated version.
 
 ```java
 McpSamplingRequest request = McpSamplingRequest.builder()

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1102,12 +1102,22 @@ if (!sampling.enabled()) {
 }
 ```
 
-Sampling context inclusion is negotiated separately. Before setting `includeContext` to `THIS_SERVER` or `ALL_SERVERS`,
-verify that the client also supports it using `enabledContext()`:
+Sampling context inclusion is negotiated separately. `McpSamplingRequest.usesContext()` reports whether `includeContext` is
+set to `THIS_SERVER` or `ALL_SERVERS`. Before sending such a request, verify that the client also supports context inclusion
+using `enabledContext()`:
 
 ```java
 if (!sampling.enabledContext()) {
     // The client supports sampling, but not sampling context inclusion.
+}
+```
+
+Tool-enabled sampling is also negotiated separately. Before adding tool names or a tool choice to a sampling request, verify that
+the client supports them using `enabledTools()`:
+
+```java
+if (!sampling.enabledTools()) {
+    // The client supports basic sampling, but not tool-enabled sampling.
 }
 ```
 
@@ -1127,18 +1137,16 @@ McpSamplingRequest request = McpSamplingRequest.builder()
                 .timeout(Duration.ofSeconds(10))
                 .stopSequences(List.of("stop1"))
                 .includeContext(McpIncludeContext.NONE)
-                .addTextMessage(McpSamplingTextMessage.builder()
-                                                     .text("text")
-                                                     .role(McpRole.USER)
-                                                     .build())
+                .addTextMessage(McpRole.USER, "text")
                 .build();
 ```
 
 `McpIncludeContext.NONE` does not require context support. If `THIS_SERVER` or `ALL_SERVERS` is requested when
 `enabledContext()` is `false`, the `request` method throws an `McpSamplingException`.
 
-Sampling metadata is serialized using Helidon JSON binding. The metadata option accepts `Object`; maps, collections,
-arrays, primitives, and converter-backed custom classes are supported. See
+Sampling request metadata is serialized using Helidon JSON binding. This value uses the wire `metadata` field and the
+`McpSamplingRequest.metadata()` option, which accepts `Object`; maps, collections, arrays, primitives, and converter-backed
+custom classes are supported. This is separate from the protocol `_meta` field exposed through `metadata()`. See
 [Migrate from JSON-B to Helidon JSON Binding](./upgrade/upgrade_guide_1.2.md#migrate-from-json-b-to-helidon-json-binding) for the
 compatibility impact and migration steps.
 
@@ -1146,32 +1154,48 @@ Once your request is built, send it using the sampling feature.
 
 #### Sampling data model
 
-Three types of sampling request messages can be created:
+Each sampling message is an envelope with one role and an ordered collection of content blocks. A content block can contain
+text, image, audio, a tool use, or a tool result. Use `McpSamplingMessage.builder()` to create an envelope explicitly, then add
+it to the ordered `McpSamplingRequest.messages()` collection with `addMessage`. For a single text-content message, the request
+builder also provides `addTextMessage(String)` and `addTextMessage(McpRole, String)` convenience methods.
 
 - **Text**: Text message content.
 - **Image**: Image message content with a custom media type.
 - **Audio**: Audio message content with a custom media type.
+- **Tool use**: A client-model request to invoke a named sampling tool with structured input.
+- **Tool result**: The corresponding server result, represented by an `McpToolResult`.
+
+Text, image, and audio blocks can also carry `McpAnnotations` for audience, priority, and last-modified metadata. Every
+sampling content block and sampling message envelope supports its own wire `_meta` value through `metadata(...)` and
+`metadata()`. The public tool-content types, such as `McpToolTextContent` and `McpToolImageContent`, expose the same
+annotations and metadata options.
 
 Create sampling request messages with the `McpSamplingRequest` builder:
 
 ```java
 McpSamplingRequest request = McpSamplingRequest.builder()
-        .addTextMessage(message -> message.text("Explain Helidon MCP in one paragraph.")
-                                          .role(McpRole.USER))
-        .addImageMessage(image -> image.data(pngBytes)
-                                       .mediaType(MediaTypes.create("image/png"))
-                                       .role(McpRole.USER))
-        .addAudioMessage(audio -> audio.data(wavBytes)
-                                       .mediaType(MediaTypes.create("audio/wav"))
-                                       .role(McpRole.USER))
+        .addMessage(McpSamplingMessage.builder()
+                            .role(McpRole.USER)
+                            .addContent(McpSamplingTextContent.create(
+                                    "Explain Helidon MCP in one paragraph."))
+                            .addContent(McpSamplingImageContent.builder()
+                                                .data(pngBytes)
+                                                .mediaType(MediaTypes.create("image/png"))
+                                                .build())
+                            .addContent(McpSamplingAudioContent.builder()
+                                                .data(wavBytes)
+                                                .mediaType(MediaTypes.create("audio/wav"))
+                                                .build())
+                            .build())
         .build();
 ```
 
 Once your request is built, send it using the sampling feature. The `request` method may throw an `McpSamplingException` if an
-error occurs during processing. On success, it returns an `McpSamplingResponse` containing the response messages, the model used,
-and optionally a stop reason. The `messages()` method returns every response message in wire order as an immutable list.
-The compatibility methods `message()`, `asTextMessage()`, `asImageMessage()`, and `asAudioMessage()` access only the first
-message and may throw an `McpSamplingException` when the response is empty or the first message has a different content type.
+error occurs during processing. On success, it returns an `McpSamplingResponse` containing the final response message, the model
+used, and optionally a stop reason. `response.message()` returns the message envelope, and `message.contents()` returns its
+immutable, ordered content blocks. The convenience methods `asTextContent()`, `asImageContent()`, `asAudioContent()`, and
+`asToolUseContent()` access only the first content block and may throw an `McpSamplingException` when the message is empty or its
+first block has a different type.
 
 Sampling responses may include a stop reason string. The `rawStopReason()` method preserves the exact value returned by the
 client, including provider-specific values. The `stopReason()` method maps recognized standard values to `McpStopReason`
@@ -1182,8 +1206,8 @@ value.
 ```java
 try {
     McpSamplingResponse response = sampling.request(req -> req.addTextMessage("text"));
-    for (McpSamplingMessage message : response.messages()) {
-        // Process each response message.
+    for (McpSamplingContent content : response.message().contents()) {
+        // Process each response content block.
     }
     response.stopReason().ifPresent(reason -> {
         // Process a recognized standard stop reason.
@@ -1195,6 +1219,52 @@ try {
     // Handle error
 }
 ```
+
+#### Sampling with tools
+
+Tool-enabled sampling lets the client model request calls to tools registered with the MCP server. A sampling request selects
+the tools available to the model by name; it does not register additional tools. `McpToolChoice.AUTO` lets the model decide
+whether to use a tool, `REQUIRED` requires at least one tool call, and `NONE` prevents tool calls.
+
+Here, a tool named `weather` is already registered through `McpServerFeature.builder().addTool(...)`.
+
+```java
+McpSamplingRequest request = McpSamplingRequest.builder()
+        .addTool("weather")
+        .toolChoice(McpToolChoice.AUTO)
+        .addTextMessage(McpRole.USER, "What is the weather in Prague?")
+        .build();
+
+McpSamplingResponse response = sampling.request(request);
+```
+
+Providing `tools` or `toolChoice` when `enabledTools()` is `false` causes `request` to throw an `McpSamplingException`. A
+request's `usesTool()` method reports whether it contains tools, a tool choice, or tool content. A tool-enabled response can
+contain one or more `McpSamplingToolUseContent` blocks in its assistant message. Helidon automatically invokes each matching
+selected tool, appends the complete assistant message and one user message containing all matching
+`McpSamplingToolResultContent` blocks, then samples again. Results for parallel tool uses stay together in the same user message
+and retain tool-use order. The original request remains unchanged, and `request(...)` returns only the final response that has no
+tool-use blocks.
+
+Only registered tools whose names are included in `McpSamplingRequest.tools()` are eligible for automatic invocation. Registered
+tools are not offered automatically, and an unregistered request tool name causes `request(...)` to throw an
+`McpSamplingException` before sending the sampling request. If the client nevertheless requests a tool that was not offered,
+Helidon returns an error tool result so the model can recover. A `null` result or an exception from a selected tool is handled the
+same way. Tool callbacks run synchronously and sequentially. The request timeout applies independently to each sampling exchange.
+
+Helidon allows ten tool-execution rounds by default. Configure the limit with
+`mcp.server.max-sampling-tool-iterations` or `McpServerFeature.builder().maxSamplingToolIterations(...)`. The value must be greater
+than zero. The limit counts rounds, so parallel tool calls in one response count as one round. After reaching the limit, Helidon
+sends one additional request with tool choice `NONE`; another tool-use response then causes an `McpSamplingException`. A
+`REQUIRED` choice changes to `AUTO` after its first tool round because the requirement has been fulfilled.
+
+Build tool results with the type-specific builder methods, such as `addTextContent(...)`, `addImageContent(...)`,
+`addAudioContent(...)`, `addTextResourceContent(...)`, `addBinaryResourceContent(...)`, and
+`addResourceLinkContent(...)`. Read the corresponding typed lists from `textContents()`, `imageContents()`,
+`audioContents()`, `textResourceContents()`, `binaryResourceContents()`, and `resourceLinkContents()`. Content retains its
+insertion order within each typed list. On the wire, the lists are grouped in that same order: text, image, audio, text
+resource, binary resource, then resource link.
+
 #### Example
 
 Below is an example of a tool that uses the Sampling feature.
@@ -1232,7 +1302,7 @@ class SamplingTool implements McpTool {
                     .timeout(Duration.ofSeconds(10))
                     .systemPrompt("You are a concise, helpful assistant.")
                     .addTextMessage("Write a 3-line summary of Helidon MCP Sampling."));
-            return McpToolResult.create(response.asTextMessage().text());
+            return McpToolResult.create(response.asTextContent().text());
         } catch (McpSamplingException e) {
             return McpToolResult.builder()
                     .error(true)
@@ -1300,6 +1370,7 @@ mcp:
     website-url: "https://example.com/mcp"
     path: "/mcp"
     stateless: true
+    max-sampling-tool-iterations: 10
 ```
 
 The optional website URL is included in `serverInfo` when the negotiated protocol version is `2025-11-25`.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1172,6 +1172,9 @@ annotations and metadata options.
 
 Create sampling request messages with the `McpSamplingRequest` builder:
 
+Multiple content blocks in one message envelope require negotiated protocol version `2025-11-25`. For earlier protocol
+versions, create a separate message envelope for each content block.
+
 ```java
 McpSamplingRequest request = McpSamplingRequest.builder()
         .addMessage(McpSamplingMessage.builder()

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1265,10 +1265,12 @@ run synchronously and sequentially. The request timeout applies independently to
 
 Helidon allows ten tool-execution rounds and ten cumulative tool executions by default. Configure both limits with
 `mcp.server.max-sampling-tool-iterations` or `McpServerFeature.builder().maxSamplingToolIterations(...)`. The value must be
-greater than zero. Parallel tool calls in one response count as one round, but each call counts as one execution. Helidon rejects
-an entire batch that would exceed the remaining execution budget before invoking any callback. After either limit is reached,
-Helidon sends one additional request with tool choice `NONE`; another tool-use response then causes an `McpSamplingException`.
-A `REQUIRED` choice changes to `AUTO` after its first tool round because the requirement has been fulfilled.
+greater than zero. The limits are shared by all sampling calls made through the originating request's `McpFeatures`, including
+sampling calls made by selected tools. Parallel tool calls in one response count as one round, but each call counts as one
+execution. Helidon rejects an entire batch that would exceed the remaining execution budget before invoking any callback. After
+either limit is reached, Helidon sends one additional request with tool choice `NONE`; another tool-use response then causes an
+`McpSamplingException`. A `REQUIRED` choice changes to `AUTO` after its first tool round because the requirement has been
+fulfilled.
 
 Build tool results with the type-specific builder methods, such as `addTextContent(...)`, `addImageContent(...)`,
 `addAudioContent(...)`, `addTextResourceContent(...)`, `addBinaryResourceContent(...)`, and

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1255,11 +1255,12 @@ tools are not offered automatically, and an unregistered request tool name cause
 Helidon returns an error tool result so the model can recover. A `null` result or an exception from a selected tool is handled the
 same way. Tool callbacks run synchronously and sequentially. The request timeout applies independently to each sampling exchange.
 
-Helidon allows ten tool-execution rounds by default. Configure the limit with
-`mcp.server.max-sampling-tool-iterations` or `McpServerFeature.builder().maxSamplingToolIterations(...)`. The value must be greater
-than zero. The limit counts rounds, so parallel tool calls in one response count as one round. After reaching the limit, Helidon
-sends one additional request with tool choice `NONE`; another tool-use response then causes an `McpSamplingException`. A
-`REQUIRED` choice changes to `AUTO` after its first tool round because the requirement has been fulfilled.
+Helidon allows ten tool-execution rounds and ten cumulative tool executions by default. Configure both limits with
+`mcp.server.max-sampling-tool-iterations` or `McpServerFeature.builder().maxSamplingToolIterations(...)`. The value must be
+greater than zero. Parallel tool calls in one response count as one round, but each call counts as one execution. Helidon rejects
+an entire batch that would exceed the remaining execution budget before invoking any callback. After either limit is reached,
+Helidon sends one additional request with tool choice `NONE`; another tool-use response then causes an `McpSamplingException`.
+A `REQUIRED` choice changes to `AUTO` after its first tool round because the requirement has been fulfilled.
 
 Build tool results with the type-specific builder methods, such as `addTextContent(...)`, `addImageContent(...)`,
 `addAudioContent(...)`, `addTextResourceContent(...)`, `addBinaryResourceContent(...)`, and

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1259,8 +1259,9 @@ tool-use blocks.
 Only registered tools whose names are included in `McpSamplingRequest.tools()` are eligible for automatic invocation. Registered
 tools are not offered automatically, and an unregistered request tool name causes `request(...)` to throw an
 `McpSamplingException` before sending the sampling request. If the client nevertheless requests a tool that was not offered,
-Helidon returns an error tool result so the model can recover. A `null` result or an exception from a selected tool is handled the
-same way. Tool callbacks run synchronously and sequentially. The request timeout applies independently to each sampling exchange.
+Helidon returns an error tool result so the model can recover. Tool callbacks must return a non-null `McpToolResult`; use
+`McpToolResult.create()` for an empty result. An exception from a selected tool is returned as an error tool result. Tool callbacks
+run synchronously and sequentially. The request timeout applies independently to each sampling exchange.
 
 Helidon allows ten tool-execution rounds and ten cumulative tool executions by default. Configure both limits with
 `mcp.server.max-sampling-tool-iterations` or `McpServerFeature.builder().maxSamplingToolIterations(...)`. The value must be

--- a/docs/upgrade/README.md
+++ b/docs/upgrade/README.md
@@ -1,5 +1,6 @@
 # Upgrade Guides
 
+- [To 1.3](upgrade_guide_1.3.md)
 - [To 1.2](upgrade_guide_1.2.md)
 - [To 1.1](upgrade_guide_1.1.md)
 - [To 1.1 Declarative](upgrade_guide_declarative_1.1.md)

--- a/docs/upgrade/upgrade_guide_1.3.md
+++ b/docs/upgrade/upgrade_guide_1.3.md
@@ -176,7 +176,7 @@ McpSamplingTextContent content = McpSamplingTextContent.builder()
                 .addAudience(McpRole.USER)
                 .priority(0.8)
                 .build())
-        .metadata(new McpParameters(JsonObject.builder()
+        .metadata(McpParameters.create(JsonObject.builder()
                 .set("traceId", "trace-1")
                 .build()))
         .build();

--- a/docs/upgrade/upgrade_guide_1.3.md
+++ b/docs/upgrade/upgrade_guide_1.3.md
@@ -16,8 +16,27 @@ changes and explains how to migrate existing code from `1.2.x` to `1.3.0`.
 - `McpSamplingContentType` includes `TOOL_USE` and `TOOL_RESULT`.
 - Sampling requests select registered server tools by name, and Helidon executes sampling tool loops automatically.
 - Sampling messages and content support protocol `_meta`; annotated content supports audience, priority, and last-modified data.
+- `McpRequest` exposes protocol `_meta` through `metadata()`; the former `meta()` accessor is deprecated.
 
 The sections below describe how to migrate applications to version `1.3.0`.
+
+## Migrate request metadata access
+
+`McpRequest` now extends `McpMetadata`. Replace the deprecated `meta()` accessor with the optional `metadata()` accessor:
+
+```java
+// Before
+String traceId = request.meta().get("traceId").asString().orElse("unknown");
+
+// After
+String traceId = request.metadata()
+        .map(metadata -> metadata.get("traceId").asString().orElse("unknown"))
+        .orElse("unknown");
+```
+
+The generated request builder now uses `metadata(McpParameters)` instead of `meta(McpParameters)`. The `meta()` request
+accessor remains as a deprecated compatibility bridge, but the former builder method is removed. Recompile builder callers and
+custom `McpRequest` implementations; custom implementations must provide `metadata()`.
 
 ## Migrate sampling requests to message envelopes
 
@@ -180,7 +199,7 @@ McpSamplingTextContent content = McpSamplingTextContent.builder()
                 .addAudience(McpRole.USER)
                 .priority(0.8)
                 .build())
-        .metadata(McpParameters.create(JsonObject.builder()
+        .metadata(new McpParameters(JsonObject.builder()
                 .set("traceId", "trace-1")
                 .build()))
         .build();

--- a/docs/upgrade/upgrade_guide_1.3.md
+++ b/docs/upgrade/upgrade_guide_1.3.md
@@ -16,7 +16,7 @@ changes and explains how to migrate existing code from `1.2.x` to `1.3.0`.
 - `McpSamplingContentType` includes `TOOL_USE` and `TOOL_RESULT`.
 - Sampling requests select registered server tools by name, and Helidon executes sampling tool loops automatically.
 - Sampling messages and content support protocol `_meta`; annotated content supports audience, priority, and last-modified data.
-- `McpRequest` exposes protocol `_meta` through `metadata()`; the former `meta()` accessor is deprecated.
+- `McpRequest` exposes protocol `_meta` through `metadata()`; the former `meta()` accessor is removed.
 
 The sections below describe how to migrate applications to version `1.3.0`.
 
@@ -34,10 +34,25 @@ String traceId = request.metadata()
         .orElse("unknown");
 ```
 
-`McpMetadata.metadata()` returns `Optional<McpParameters>`. The generated request builder uses `metadata(McpParameters)`
-instead of the former `meta(McpParameters)`. Use `McpParameters.create(Object)` to serialize a map or custom type with Helidon
-JSON binding; the value must produce a JSON object. The `meta()` request accessor remains as a deprecated compatibility bridge.
-Recompile builder callers and custom `McpRequest` implementations; custom implementations must provide `metadata()`.
+`McpMetadata.metadata()` returns `Optional<McpParameters>`. The generated request builder provides
+`metadata(McpParameters)` and `metadata()`. The former `McpRequest.meta()` accessor and generated builder methods
+`meta(McpParameters)` and `meta()` are removed. Replace builder calls as well:
+
+```java
+// Before
+builder.meta(metadata);
+McpParameters current = builder.meta().orElseThrow();
+
+// After
+builder.metadata(metadata);
+McpParameters current = builder.metadata().orElseThrow();
+```
+
+`McpRequest` builders are public for framework use but are not intended for application request construction. Applications
+should consume request instances supplied by the server. Existing binaries that invoke a removed `meta` method can fail with
+`NoSuchMethodError`; recompile them after applying these source changes. Custom `McpRequest` implementations must implement
+`metadata()`. Use `McpParameters.create(Object)` to serialize a map or custom type with Helidon JSON binding; the value must
+produce a JSON object.
 
 ## Migrate sampling requests to message envelopes
 

--- a/docs/upgrade/upgrade_guide_1.3.md
+++ b/docs/upgrade/upgrade_guide_1.3.md
@@ -64,9 +64,12 @@ McpSamplingRequest request = McpSamplingRequest.builder()
         .build();
 ```
 
-Use separate message envelopes when content blocks have different roles or must remain separate messages. A separate envelope
-for each content block, as shown above, works with every supported protocol version. Multiple content blocks in one envelope are
-supported only when protocol version `2025-11-25` is negotiated; those blocks retain their insertion order on the wire.
+Use separate message envelopes when content blocks have different roles or must remain separate messages. Protocol version
+`2024-11-05` supports text and image content blocks, `2025-03-26` adds audio, and `2025-06-18` adds content `_meta` and
+`McpAnnotations.lastModified` while message `_meta` remains unsupported. Protocol version `2025-11-25` adds tool-use and
+tool-result blocks, message `_meta`, and multiple content blocks per envelope; those blocks retain their insertion order on the
+wire. For earlier protocol versions, use one content block per envelope and only the content types and metadata fields supported
+by the negotiated version.
 
 The principal type and accessor replacements are:
 
@@ -166,8 +169,9 @@ of tool rounds and cumulative tool executions with `mcp.server.max-sampling-tool
 
 ## Use annotations and protocol metadata
 
-Sampling message envelopes and content blocks can carry protocol `_meta` through `metadata(McpParameters)`. Annotated sampling
-content can also carry `McpAnnotations`, including audience roles, priority, and last-modified data.
+Sampling content blocks can carry protocol `_meta` through `metadata(McpParameters)` starting with `2025-06-18`; message
+envelopes can carry it starting with `2025-11-25`. Annotated sampling content supports audience and priority in every supported
+version, while `lastModified` requires `2025-06-18` or later.
 
 ```java
 McpSamplingTextContent content = McpSamplingTextContent.builder()

--- a/docs/upgrade/upgrade_guide_1.3.md
+++ b/docs/upgrade/upgrade_guide_1.3.md
@@ -34,8 +34,8 @@ String traceId = request.metadata()
         .orElse("unknown");
 ```
 
-The generated request builder now uses `metadata(McpParameters)` instead of `meta(McpParameters)`. The `meta()` request
-accessor remains as a deprecated compatibility bridge, but the former builder method is removed. Recompile builder callers and
+`McpParameters` instances are supplied by Helidon from protocol data; applications consume them through `metadata()` rather
+than constructing parameter wrappers. The `meta()` request accessor remains as a deprecated compatibility bridge. Recompile
 custom `McpRequest` implementations; custom implementations must provide `metadata()`.
 
 ## Migrate sampling requests to message envelopes
@@ -186,11 +186,10 @@ and tool results, and continues sampling. It returns the final response without 
 of tool rounds and cumulative tool executions with `mcp.server.max-sampling-tool-iterations` or
 `McpServerFeature.builder().maxSamplingToolIterations(...)`.
 
-## Use annotations and protocol metadata
+## Use annotations and access protocol metadata
 
-Sampling content blocks can carry protocol `_meta` through `metadata(McpParameters)` starting with `2025-06-18`; message
-envelopes can carry it starting with `2025-11-25`. Annotated sampling content supports audience and priority in every supported
-version, while `lastModified` requires `2025-06-18` or later.
+Annotated sampling content supports audience and priority in every supported version, while `lastModified` requires
+`2025-06-18` or later.
 
 ```java
 McpSamplingTextContent content = McpSamplingTextContent.builder()
@@ -199,10 +198,16 @@ McpSamplingTextContent content = McpSamplingTextContent.builder()
                 .addAudience(McpRole.USER)
                 .priority(0.8)
                 .build())
-        .metadata(new McpParameters(JsonObject.builder()
-                .set("traceId", "trace-1")
-                .build()))
         .build();
+```
+
+Sampling content blocks expose protocol `_meta` through `metadata()` starting with `2025-06-18`; message envelopes expose it
+starting with `2025-11-25`. Helidon creates the returned `McpParameters` from wire data. Read metadata received from the client:
+
+```java
+String traceId = response.asTextContent().metadata()
+        .map(metadata -> metadata.get("traceId").asString().orElse("unknown"))
+        .orElse("unknown");
 ```
 
 This protocol `_meta` is distinct from `McpSamplingRequest.metadata(Object)`, which remains provider-specific sampling metadata

--- a/docs/upgrade/upgrade_guide_1.3.md
+++ b/docs/upgrade/upgrade_guide_1.3.md
@@ -1,0 +1,209 @@
+# Upgrade Guide for Version 1.3.0
+
+Helidon MCP `1.3.0` replaces the sampling API's type-specific message model with ordered message envelopes and content blocks.
+It also adds tool-enabled sampling for MCP specification `2025-11-25`. This document summarizes the backward-incompatible
+changes and explains how to migrate existing code from `1.2.x` to `1.3.0`.
+
+## Overview of Changes
+
+- The separate sampling request lists for text, image, and audio messages are replaced by one ordered `messages()` list.
+- `McpSamplingMessage` now represents a role-bearing envelope containing ordered `McpSamplingContent` blocks.
+- The `McpSampling*Message` leaf types and `McpSamplingMessageType` are replaced by `McpSampling*Content` types and
+  `McpSamplingContentType`.
+- Sampling responses continue to expose one value through `message()`, which now returns a message envelope; the
+  `as*Message()` methods are replaced by first-content convenience methods.
+- Image and audio `data()` methods return decoded raw bytes, and `decodeBase64Data()` is removed.
+- `McpSamplingContentType` includes `TOOL_USE` and `TOOL_RESULT`.
+- Sampling requests select registered server tools by name, and Helidon executes sampling tool loops automatically.
+- Sampling messages and content support protocol `_meta`; annotated content supports audience, priority, and last-modified data.
+
+The sections below describe how to migrate applications to version `1.3.0`.
+
+## Migrate sampling requests to message envelopes
+
+In `1.2.x`, a sampling request stores text, image, and audio messages in separate lists. In `1.3.0`, each
+`McpSamplingMessage` contains one role and an ordered list of content blocks.
+
+Previous usage:
+
+```java
+McpSamplingRequest request = McpSamplingRequest.builder()
+        .addTextMessage(text -> text
+                .role(McpRole.USER)
+                .text("Summarize this image."))
+        .addImageMessage(image -> image
+                .role(McpRole.USER)
+                .data(imageBytes)
+                .mediaType(MediaTypes.create("image/png")))
+        .build();
+```
+
+Updated usage:
+
+```java
+McpSamplingRequest request = McpSamplingRequest.builder()
+        .addMessage(McpSamplingMessage.builder()
+                .role(McpRole.USER)
+                .addContent(McpSamplingTextContent.create("Summarize this image."))
+                .build())
+        .addMessage(McpSamplingMessage.builder()
+                .role(McpRole.USER)
+                .addContent(McpSamplingImageContent.builder()
+                        .data(imageBytes)
+                        .mediaType(MediaTypes.create("image/png"))
+                        .build())
+                .build())
+        .build();
+```
+
+For a simple text message, use the convenience method:
+
+```java
+McpSamplingRequest request = McpSamplingRequest.builder()
+        .addTextMessage(McpRole.USER, "Summarize this text.")
+        .build();
+```
+
+Use separate message envelopes when content blocks have different roles or must remain separate messages. A separate envelope
+for each content block, as shown above, works with every supported protocol version. Multiple content blocks in one envelope are
+supported only when protocol version `2025-11-25` is negotiated; those blocks retain their insertion order on the wire.
+
+The principal type and accessor replacements are:
+
+| `1.2.x` API | `1.3.0` API |
+| --- | --- |
+| `McpSamplingTextMessage` | `McpSamplingTextContent` |
+| `McpSamplingImageMessage` | `McpSamplingImageContent` |
+| `McpSamplingAudioMessage` | `McpSamplingAudioContent` |
+| `McpSamplingMediaMessage` | `McpSamplingMediaContent` |
+| `McpSamplingMessageType` | `McpSamplingContentType` |
+| `textMessages()`, `imageMessages()`, `audioMessages()` | `messages()` |
+
+The type-specific `clear*Messages()` methods, list setters and adders, leaf-message adders, and consumer-builder overloads are
+also removed. Replace them with `clearMessages()`, `messages(...)`, `addMessages(...)`, and `addMessage(...)`. The existing
+`addTextMessage(String)` convenience method remains available, and `addTextMessage(McpRole, String)` is new in `1.3.0`.
+
+## Migrate sampling response access
+
+Sampling responses now contain one message envelope. Iterate over that envelope's ordered content blocks instead of iterating
+over leaf messages.
+
+Previous usage:
+
+```java
+McpSamplingMessage message = response.message();
+String text = response.asTextMessage().text();
+byte[] image = response.asImageMessage().decodeBase64Data();
+```
+
+Updated usage:
+
+```java
+String text = response.asTextContent().text();
+byte[] image = response.asImageContent().data();
+for (McpSamplingContent content : response.message().contents()) {
+    // Process each ordered content block.
+}
+```
+
+The first-content convenience methods are now `asTextContent()`, `asImageContent()`, `asAudioContent()`, and
+`asToolUseContent()`.
+
+## Use raw media bytes
+
+`McpSamplingMediaContent.data()` returns raw bytes for both application-built content and content parsed from sampling responses.
+Do not decode the returned bytes again. The former `decodeBase64Data()` method is removed. Use `encodeBase64Data()` only when a
+base64 string is required.
+
+## Handle the expanded sampling content types
+
+Code that previously switched on `McpSamplingMessageType` must switch on each content block's `McpSamplingContentType`.
+Exhaustive switches must also handle the new `TOOL_USE` and `TOOL_RESULT` constants.
+
+```java
+for (McpSamplingContent content : response.message().contents()) {
+    switch (content.type()) {
+        case TEXT -> handleText((McpSamplingTextContent) content);
+        case IMAGE -> handleImage((McpSamplingImageContent) content);
+        case AUDIO -> handleAudio((McpSamplingAudioContent) content);
+        case TOOL_USE -> handleToolUse((McpSamplingToolUseContent) content);
+        case TOOL_RESULT -> handleToolResult((McpSamplingToolResultContent) content);
+    }
+}
+```
+
+`TOOL_USE` represents an assistant request to invoke a sampling tool. `TOOL_RESULT` represents the corresponding result in a
+follow-up user message.
+
+## Enable sampling with registered tools
+
+Tool-enabled sampling is new in `1.3.0`. Register each `McpTool` with the server, then select the tools available to one sampling
+request by name. `McpSamplingRequest.tools()` is a `List<String>`; it does not contain tool implementations.
+
+```java
+McpTool weather = new WeatherTool();
+McpServerFeature server = McpServerFeature.builder()
+        .addTool(weather)
+        .build();
+
+McpSamplingRequest request = McpSamplingRequest.builder()
+        .addTool(weather.name())
+        .toolChoice(McpToolChoice.AUTO)
+        .addTextMessage(McpRole.USER, "What is the weather in Prague?")
+        .build();
+
+McpSamplingResponse response = sampling.request(request);
+```
+
+Before sending a request with tool names or a tool choice, verify `sampling.enabledTools()`. Only names selected by the request
+are offered to the client and eligible for automatic invocation. Each selected name must match exactly one registered server
+tool, and names in one request must be unique.
+
+When a response contains tool-use content, `McpSampling.request(...)` invokes the selected tools, appends the assistant message
+and tool results, and continues sampling. It returns the final response without tool-use content. Configure the maximum number
+of tool rounds with `mcp.server.max-sampling-tool-iterations` or
+`McpServerFeature.builder().maxSamplingToolIterations(...)`.
+
+## Use annotations and protocol metadata
+
+Sampling message envelopes and content blocks can carry protocol `_meta` through `metadata(McpParameters)`. Annotated sampling
+content can also carry `McpAnnotations`, including audience roles, priority, and last-modified data.
+
+```java
+McpSamplingTextContent content = McpSamplingTextContent.builder()
+        .text("Important context")
+        .annotations(McpAnnotations.builder()
+                .addAudience(McpRole.USER)
+                .priority(0.8)
+                .build())
+        .metadata(new McpParameters(JsonObject.builder()
+                .set("traceId", "trace-1")
+                .build()))
+        .build();
+```
+
+This protocol `_meta` is distinct from `McpSamplingRequest.metadata(Object)`, which remains provider-specific sampling metadata
+as described in the `1.2.0` upgrade guide.
+
+## Update custom implementations of generated interfaces
+
+Version `1.3.0` adds abstract methods to generated public interfaces. Applications that use the Helidon builders receive the
+new defaults automatically. Applications that implement these interfaces directly must update their implementations:
+
+- `McpServerConfig` adds `maxSamplingToolIterations()`. Return the configured limit, or `10` to retain the default behavior.
+- `McpToolTextContent`, `McpToolImageContent`, `McpToolAudioContent`, `McpToolTextResourceContent`,
+  `McpToolBinaryResourceContent`, and `McpToolResourceLinkContent` add `annotations()` and `metadata()`. Return
+  `Optional.empty()` when the content has no annotations or protocol `_meta` value.
+- For `McpToolTextResourceContent` and `McpToolBinaryResourceContent`, `metadata()` represents the outer embedded-content
+  `_meta` field. The flattened API does not expose the nested resource-content `_meta` field.
+- `McpToolResourceLinkContent` also adds `icons()`.
+
+These additions are source-incompatible with custom implementations because recompilation requires implementations for the new
+abstract methods. Previously compiled custom implementations can fail with `AbstractMethodError` when version `1.3.0` invokes
+one of the new methods. Recompile and update such implementations before upgrading.
+
+## Recompile applications
+
+The removed and renamed public sampling types, request accessors, response accessors, and builder methods create source and
+binary incompatibilities. Recompile applications after updating their sampling code. Previously compiled code can otherwise fail
+with errors such as `NoClassDefFoundError`, `NoSuchMethodError`, or `IncompatibleClassChangeError`.

--- a/docs/upgrade/upgrade_guide_1.3.md
+++ b/docs/upgrade/upgrade_guide_1.3.md
@@ -30,13 +30,17 @@ String traceId = request.meta().get("traceId").asString().orElse("unknown");
 
 // After
 String traceId = request.metadata()
-        .map(metadata -> metadata.get("traceId").asString().orElse("unknown"))
+        .filter(JsonObject.class::isInstance)
+        .map(JsonObject.class::cast)
+        .flatMap(metadata -> metadata.stringValue("traceId"))
         .orElse("unknown");
 ```
 
-`McpParameters` instances are supplied by Helidon from protocol data; applications consume them through `metadata()` rather
-than constructing parameter wrappers. The `meta()` request accessor remains as a deprecated compatibility bridge. Recompile
-custom `McpRequest` implementations; custom implementations must provide `metadata()`.
+`McpMetadata.metadata()` now returns `Optional<Object>`. Helidon JSON binding deserializes incoming JSON objects as
+`JsonObject`. Generated builders now accept `metadata(Object)` instead of `metadata(McpParameters)`; supplied values must
+serialize to a JSON object. Maps and custom types with a Helidon JSON converter are supported. The `meta()` request accessor
+remains as a deprecated compatibility bridge. Recompile builder callers and custom `McpRequest` implementations; custom
+implementations must provide `metadata()`.
 
 ## Migrate sampling requests to message envelopes
 
@@ -202,11 +206,14 @@ McpSamplingTextContent content = McpSamplingTextContent.builder()
 ```
 
 Sampling content blocks expose protocol `_meta` through `metadata()` starting with `2025-06-18`; message envelopes expose it
-starting with `2025-11-25`. Helidon creates the returned `McpParameters` from wire data. Read metadata received from the client:
+starting with `2025-11-25`. Metadata uses the same Helidon JSON binding contract as request metadata. Read metadata received
+from the client as a `JsonObject`:
 
 ```java
 String traceId = response.asTextContent().metadata()
-        .map(metadata -> metadata.get("traceId").asString().orElse("unknown"))
+        .filter(JsonObject.class::isInstance)
+        .map(JsonObject.class::cast)
+        .flatMap(metadata -> metadata.stringValue("traceId"))
         .orElse("unknown");
 ```
 
@@ -221,7 +228,8 @@ new defaults automatically. Applications that implement these interfaces directl
 - `McpServerConfig` adds `maxSamplingToolIterations()`. Return the configured limit, or `10` to retain the default behavior.
 - `McpToolTextContent`, `McpToolImageContent`, `McpToolAudioContent`, `McpToolTextResourceContent`,
   `McpToolBinaryResourceContent`, and `McpToolResourceLinkContent` add `annotations()` and `metadata()`. Return
-  `Optional.empty()` when the content has no annotations or protocol `_meta` value.
+  `Optional.empty()` when the content has no annotations or protocol `_meta` value; otherwise return `Optional<Object>`
+  metadata supported by Helidon JSON binding.
 - For `McpToolTextResourceContent` and `McpToolBinaryResourceContent`, `metadata()` represents the outer embedded-content
   `_meta` field. The flattened API does not expose the nested resource-content `_meta` field.
 - `McpToolResourceLinkContent` also adds `icons()`.

--- a/docs/upgrade/upgrade_guide_1.3.md
+++ b/docs/upgrade/upgrade_guide_1.3.md
@@ -161,7 +161,7 @@ tool, and names in one request must be unique.
 
 When a response contains tool-use content, `McpSampling.request(...)` invokes the selected tools, appends the assistant message
 and tool results, and continues sampling. It returns the final response without tool-use content. Configure the maximum number
-of tool rounds with `mcp.server.max-sampling-tool-iterations` or
+of tool rounds and cumulative tool executions with `mcp.server.max-sampling-tool-iterations` or
 `McpServerFeature.builder().maxSamplingToolIterations(...)`.
 
 ## Use annotations and protocol metadata

--- a/docs/upgrade/upgrade_guide_1.3.md
+++ b/docs/upgrade/upgrade_guide_1.3.md
@@ -30,17 +30,14 @@ String traceId = request.meta().get("traceId").asString().orElse("unknown");
 
 // After
 String traceId = request.metadata()
-        .filter(JsonObject.class::isInstance)
-        .map(JsonObject.class::cast)
-        .flatMap(metadata -> metadata.stringValue("traceId"))
+        .map(metadata -> metadata.get("traceId").asString().orElse("unknown"))
         .orElse("unknown");
 ```
 
-`McpMetadata.metadata()` now returns `Optional<Object>`. Helidon JSON binding deserializes incoming JSON objects as
-`JsonObject`. Generated builders now accept `metadata(Object)` instead of `metadata(McpParameters)`; supplied values must
-serialize to a JSON object. Maps and custom types with a Helidon JSON converter are supported. The `meta()` request accessor
-remains as a deprecated compatibility bridge. Recompile builder callers and custom `McpRequest` implementations; custom
-implementations must provide `metadata()`.
+`McpMetadata.metadata()` returns `Optional<McpParameters>`. The generated request builder uses `metadata(McpParameters)`
+instead of the former `meta(McpParameters)`. Use `McpParameters.create(Object)` to serialize a map or custom type with Helidon
+JSON binding; the value must produce a JSON object. The `meta()` request accessor remains as a deprecated compatibility bridge.
+Recompile builder callers and custom `McpRequest` implementations; custom implementations must provide `metadata()`.
 
 ## Migrate sampling requests to message envelopes
 
@@ -202,18 +199,16 @@ McpSamplingTextContent content = McpSamplingTextContent.builder()
                 .addAudience(McpRole.USER)
                 .priority(0.8)
                 .build())
+        .metadata(McpParameters.create(Map.of("traceId", "trace-1")))
         .build();
 ```
 
 Sampling content blocks expose protocol `_meta` through `metadata()` starting with `2025-06-18`; message envelopes expose it
-starting with `2025-11-25`. Metadata uses the same Helidon JSON binding contract as request metadata. Read metadata received
-from the client as a `JsonObject`:
+starting with `2025-11-25`. Metadata uses the same `McpParameters` access API as request metadata:
 
 ```java
 String traceId = response.asTextContent().metadata()
-        .filter(JsonObject.class::isInstance)
-        .map(JsonObject.class::cast)
-        .flatMap(metadata -> metadata.stringValue("traceId"))
+        .map(metadata -> metadata.get("traceId").asString().orElse("unknown"))
         .orElse("unknown");
 ```
 
@@ -228,8 +223,8 @@ new defaults automatically. Applications that implement these interfaces directl
 - `McpServerConfig` adds `maxSamplingToolIterations()`. Return the configured limit, or `10` to retain the default behavior.
 - `McpToolTextContent`, `McpToolImageContent`, `McpToolAudioContent`, `McpToolTextResourceContent`,
   `McpToolBinaryResourceContent`, and `McpToolResourceLinkContent` add `annotations()` and `metadata()`. Return
-  `Optional.empty()` when the content has no annotations or protocol `_meta` value; otherwise return `Optional<Object>`
-  metadata supported by Helidon JSON binding.
+  `Optional.empty()` when the content has no annotations or protocol `_meta` value; otherwise return
+  `Optional<McpParameters>`.
 - For `McpToolTextResourceContent` and `McpToolBinaryResourceContent`, `metadata()` represents the outer embedded-content
   `_meta` field. The flattened API does not expose the nested resource-content `_meta` field.
 - `McpToolResourceLinkContent` also adds `icons()`.

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpAnnotationsBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpAnnotationsBlueprint.java
@@ -16,20 +16,36 @@
 package io.helidon.extensions.mcp.server;
 
 import java.util.List;
+import java.util.Optional;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 
 /**
- * Tool resource link content.
+ * Optional annotations for MCP content.
  */
 @Prototype.Blueprint
-interface McpToolResourceLinkContentBlueprint extends McpResourceLinkContent, McpToolContent {
+interface McpAnnotationsBlueprint {
     /**
-     * Optional icons for this resource link.
+     * Roles for which the content is intended.
      *
-     * @return icons
+     * @return audience roles
      */
     @Option.Singular
-    List<McpIcon> icons();
+    List<McpRole> audience();
+
+    /**
+     * Content importance from zero to one.
+     *
+     * @return priority
+     */
+    @Option.Decorator(McpDecorators.AnnotationsPriorityDecorator.class)
+    Optional<Double> priority();
+
+    /**
+     * Last modification time as an ISO 8601 string.
+     *
+     * @return last modification time
+     */
+    Optional<String> lastModified();
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpCancellation.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpCancellation.java
@@ -17,8 +17,12 @@
 package io.helidon.extensions.mcp.server;
 
 import java.lang.System.Logger.Level;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
-import io.helidon.common.LazyValue;
 import io.helidon.json.JsonValue;
 
 /**
@@ -28,10 +32,11 @@ import io.helidon.json.JsonValue;
  * to wait for the completion of the operation.
  */
 public final class McpCancellation {
-    private static final System.Logger LOGGER = System.getLogger(McpServerFeature.class.getName());
-    private final Runnable noop = () -> {};
+    private static final System.Logger LOGGER = System.getLogger(McpCancellation.class.getName());
+
+    private final Lock lock = new ReentrantLock();
+    private final List<Runnable> hooks = new ArrayList<>();
     private volatile McpCancellationResult result;
-    private LazyValue<Runnable> hook = LazyValue.create(() -> noop);
 
     McpCancellation() {
         result = new McpCancellationResultImpl(false);
@@ -47,12 +52,27 @@ public final class McpCancellation {
     }
 
     /**
-     * Actions to be performed when cancellation get triggered.
+     * Register an action to perform when cancellation is triggered. Each registered hook is invoked once. If cancellation
+     * was already requested, the hook is invoked before this method returns.
      *
      * @param hook cancellation hook
+     * @throws NullPointerException if the hook is {@code null}
      */
     public void registerCancellationHook(Runnable hook) {
-        this.hook = LazyValue.create(() -> hook);
+        Objects.requireNonNull(hook, "hook is null");
+        boolean runNow;
+        lock.lock();
+        try {
+            runNow = result.isRequested();
+            if (!runNow) {
+                hooks.add(hook);
+            }
+        } finally {
+            lock.unlock();
+        }
+        if (runNow) {
+            runHook(hook);
+        }
     }
 
     /**
@@ -77,12 +97,31 @@ public final class McpCancellation {
     }
 
     private void cancel(McpCancellationResult cancellationResult, JsonValue requestId) {
-        if (!hook.isLoaded()) {
-            if (LOGGER.isLoggable(Level.DEBUG)) {
-                LOGGER.log(Level.DEBUG, "Cancelling task with request id: %s", requestId);
+        List<Runnable> registeredHooks;
+        lock.lock();
+        try {
+            if (result.isRequested()) {
+                return;
             }
             result = cancellationResult;
-            hook.get().run();
+            registeredHooks = List.copyOf(hooks);
+            hooks.clear();
+        } finally {
+            lock.unlock();
+        }
+        if (LOGGER.isLoggable(Level.DEBUG)) {
+            LOGGER.log(Level.DEBUG, "Cancelling task with request id: %s", requestId);
+        }
+        for (Runnable hook : registeredHooks) {
+            runHook(hook);
+        }
+    }
+
+    private static void runHook(Runnable hook) {
+        try {
+            hook.run();
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.WARNING, "Cancellation hook failed", e);
         }
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpCancellation.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpCancellation.java
@@ -75,6 +75,16 @@ public final class McpCancellation {
         }
     }
 
+    void unregisterCancellationHook(Runnable hook) {
+        Objects.requireNonNull(hook, "hook is null");
+        lock.lock();
+        try {
+            hooks.remove(hook);
+        } finally {
+            lock.unlock();
+        }
+    }
+
     /**
      * Cancel the current operation. This method can be triggered only once and
      * additional calls are ignored.

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionRequestImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionRequestImpl.java
@@ -56,8 +56,8 @@ final class McpCompletionRequestImpl implements McpCompletionRequest {
     }
 
     @Override
-    public McpParameters meta() {
-        return request.meta();
+    public Optional<McpParameters> metadata() {
+        return request.metadata();
     }
 
     @Override

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionRequestImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionRequestImpl.java
@@ -56,7 +56,7 @@ final class McpCompletionRequestImpl implements McpCompletionRequest {
     }
 
     @Override
-    public Optional<Object> metadata() {
+    public Optional<McpParameters> metadata() {
         return request.metadata();
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionRequestImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpCompletionRequestImpl.java
@@ -56,7 +56,7 @@ final class McpCompletionRequestImpl implements McpCompletionRequest {
     }
 
     @Override
-    public Optional<McpParameters> metadata() {
+    public Optional<Object> metadata() {
         return request.metadata();
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpDecorators.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpDecorators.java
@@ -86,6 +86,19 @@ final class McpDecorators {
     }
 
     /**
+     * Enforce annotation priority value between 0 and 1.
+     */
+    static class AnnotationsPriorityDecorator implements Prototype.OptionDecorator<McpAnnotations.BuilderBase<?, ?>, Optional<Double>> {
+        @Override
+        public void decorate(McpAnnotations.BuilderBase<?, ?> builder, Optional<Double> value) {
+            value.filter(priority -> !McpDecorators.isPositiveAndLessThanOne(priority))
+                    .ifPresent(priority -> {
+                        throw new IllegalArgumentException("Annotation priority must be in range [0, 1]");
+                    });
+        }
+    }
+
+    /**
      * The URI scheme must be {@code file} when creating an MCP root.
      */
     static class RootUriDecorator implements Prototype.OptionDecorator<McpRoot.BuilderBase<?, ?>, URI> {
@@ -137,6 +150,16 @@ final class McpDecorators {
         public void decorate(McpServerConfig.BuilderBase<?, ?> builder, Integer value) {
             if (value < 0) {
                 throw new IllegalArgumentException("value must be greater than zero");
+            }
+        }
+    }
+
+    static class SamplingToolIterationsDecorator
+            implements Prototype.OptionDecorator<McpServerConfig.BuilderBase<?, ?>, Integer> {
+        @Override
+        public void decorate(McpServerConfig.BuilderBase<?, ?> builder, Integer value) {
+            if (value <= 0) {
+                throw new IllegalArgumentException("Maximum sampling tool iterations must be greater than zero");
             }
         }
     }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpDecorators.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpDecorators.java
@@ -88,7 +88,8 @@ final class McpDecorators {
     /**
      * Enforce annotation priority value between 0 and 1.
      */
-    static class AnnotationsPriorityDecorator implements Prototype.OptionDecorator<McpAnnotations.BuilderBase<?, ?>, Optional<Double>> {
+    static class AnnotationsPriorityDecorator
+            implements Prototype.OptionDecorator<McpAnnotations.BuilderBase<?, ?>, Optional<Double>> {
         @Override
         public void decorate(McpAnnotations.BuilderBase<?, ?> builder, Optional<Double> value) {
             value.filter(priority -> !McpDecorators.isPositiveAndLessThanOne(priority))

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpDecorators.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpDecorators.java
@@ -32,6 +32,10 @@ final class McpDecorators {
     private McpDecorators() {
     }
 
+    static boolean isPositiveAndLessThanOne(Double value) {
+        return 0 <= value && value <= 1.0;
+    }
+
     /**
      * Enforce positive page size.
      * <p>
@@ -163,9 +167,5 @@ final class McpDecorators {
                 throw new IllegalArgumentException("Maximum sampling tool iterations must be greater than zero");
             }
         }
-    }
-
-    static boolean isPositiveAndLessThanOne(Double value) {
-        return 0 <= value && value <= 1.0;
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpElicitation.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpElicitation.java
@@ -65,8 +65,13 @@ public final class McpElicitation extends McpFeature {
         }
         long id = session().jsonRpcId();
         JsonObject payload = session().serializer().createElicitationRequest(id, request);
-        transport().send(payload);
-        JsonObject response = session().pollResponse(id, request.timeout());
-        return session().serializer().createElicitationResponse(response);
+        session().prepareResponse(id);
+        try {
+            transport().send(payload);
+            JsonObject response = session().pollResponse(id, request.timeout());
+            return session().serializer().createElicitationResponse(response);
+        } finally {
+            session().discardResponse(id);
+        }
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpElicitation.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpElicitation.java
@@ -68,8 +68,9 @@ public final class McpElicitation extends McpFeature {
         session().prepareResponse(id);
         try {
             transport().send(payload);
-            JsonObject response = session().pollResponse(id, request.timeout());
-            return session().serializer().createElicitationResponse(response);
+            McpResponse response = session().pollResponse(id, request.timeout())
+                    .orElseThrow(() -> new McpElicitationException("response timeout"));
+            return session().serializer().createElicitationResponse(response.asJsonObject());
         } finally {
             session().discardResponse(id);
         }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpFeatures.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpFeatures.java
@@ -18,7 +18,6 @@ package io.helidon.extensions.mcp.server;
 import java.util.Objects;
 
 import io.helidon.common.LazyValue;
-import io.helidon.common.context.Context;
 
 /**
  * Support for optional client features:
@@ -56,7 +55,6 @@ import io.helidon.common.context.Context;
  */
 public final class McpFeatures {
     private final McpSession session;
-    private final Context requestContext;
     private final LazyValue<McpRoots> roots;
     private final LazyValue<McpLogger> logger;
     private final LazyValue<McpSampling> sampling;
@@ -65,15 +63,9 @@ public final class McpFeatures {
     private final LazyValue<McpCancellation> cancellation;
 
     McpFeatures(McpSession session, McpTransport transport) {
-        this(session, transport, Context.create());
-    }
-
-    McpFeatures(McpSession session, McpTransport transport, Context requestContext) {
         Objects.requireNonNull(session, "session is null");
         Objects.requireNonNull(transport, "transport is null");
-        Objects.requireNonNull(requestContext, "request context is null");
         this.session = session;
-        this.requestContext = requestContext;
         this.cancellation = LazyValue.create(McpCancellation::new);
         this.roots = LazyValue.create(() -> new McpRoots(session, transport));
         this.logger = LazyValue.create(() -> new McpLogger(session, transport));
@@ -143,9 +135,5 @@ public final class McpFeatures {
      */
     public McpSubscriptions subscriptions() {
         return session.features().subscriptions();
-    }
-
-    Context requestContext() {
-        return requestContext;
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpFeatures.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpFeatures.java
@@ -82,10 +82,6 @@ public final class McpFeatures {
         this.elicitation = LazyValue.create(() -> new McpElicitation(session, transport));
     }
 
-    Context requestContext() {
-        return requestContext;
-    }
-
     /**
      * Get a {@link io.helidon.extensions.mcp.server.McpProgress} feature.
      *
@@ -147,5 +143,9 @@ public final class McpFeatures {
      */
     public McpSubscriptions subscriptions() {
         return session.features().subscriptions();
+    }
+
+    Context requestContext() {
+        return requestContext;
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpFeatures.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpFeatures.java
@@ -18,6 +18,7 @@ package io.helidon.extensions.mcp.server;
 import java.util.Objects;
 
 import io.helidon.common.LazyValue;
+import io.helidon.common.context.Context;
 
 /**
  * Support for optional client features:
@@ -55,6 +56,7 @@ import io.helidon.common.LazyValue;
  */
 public final class McpFeatures {
     private final McpSession session;
+    private final Context requestContext;
     private final LazyValue<McpRoots> roots;
     private final LazyValue<McpLogger> logger;
     private final LazyValue<McpSampling> sampling;
@@ -63,15 +65,25 @@ public final class McpFeatures {
     private final LazyValue<McpCancellation> cancellation;
 
     McpFeatures(McpSession session, McpTransport transport) {
+        this(session, transport, Context.create());
+    }
+
+    McpFeatures(McpSession session, McpTransport transport, Context requestContext) {
         Objects.requireNonNull(session, "session is null");
         Objects.requireNonNull(transport, "transport is null");
+        Objects.requireNonNull(requestContext, "request context is null");
         this.session = session;
+        this.requestContext = requestContext;
         this.cancellation = LazyValue.create(McpCancellation::new);
         this.roots = LazyValue.create(() -> new McpRoots(session, transport));
         this.logger = LazyValue.create(() -> new McpLogger(session, transport));
-        this.sampling = LazyValue.create(() -> new McpSampling(session, transport));
+        this.sampling = LazyValue.create(() -> new McpSampling(session, transport, this));
         this.progress = LazyValue.create(() -> new McpProgress(session, transport));
         this.elicitation = LazyValue.create(() -> new McpElicitation(session, transport));
+    }
+
+    Context requestContext() {
+        return requestContext;
     }
 
     /**

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpIconBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpIconBlueprint.java
@@ -16,20 +16,43 @@
 package io.helidon.extensions.mcp.server;
 
 import java.util.List;
+import java.util.Optional;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.media.type.MediaType;
 
 /**
- * Tool resource link content.
+ * An optionally-sized MCP icon.
  */
 @Prototype.Blueprint
-interface McpToolResourceLinkContentBlueprint extends McpResourceLinkContent, McpToolContent {
+interface McpIconBlueprint {
     /**
-     * Optional icons for this resource link.
+     * Icon source URI or data URI.
      *
-     * @return icons
+     * @return icon source
+     */
+    String src();
+
+    /**
+     * Optional MIME type override.
+     *
+     * @return MIME type
+     */
+    Optional<MediaType> mediaType();
+
+    /**
+     * Sizes at which the icon can be used.
+     *
+     * @return icon sizes
      */
     @Option.Singular
-    List<McpIcon> icons();
+    List<String> sizes();
+
+    /**
+     * Optional display theme.
+     *
+     * @return icon theme
+     */
+    Optional<McpIconTheme> theme();
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpIconTheme.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpIconTheme.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,21 +15,23 @@
  */
 package io.helidon.extensions.mcp.server;
 
+import java.util.Locale;
+
 /**
- * MCP sampling message.
+ * Display theme for an MCP icon.
  */
-public interface McpSamplingMessage {
+public enum McpIconTheme {
     /**
-     * Sampling message role.
-     *
-     * @return role
+     * Icon intended for a light background.
      */
-    McpRole role();
+    LIGHT,
 
     /**
-     * Sampling message type.
-     *
-     * @return type
+     * Icon intended for a dark background.
      */
-    McpSamplingMessageType type();
+    DARK;
+
+    String text() {
+        return name().toLowerCase(Locale.ROOT);
+    }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonBinding.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonBinding.java
@@ -34,6 +34,9 @@ final class McpJsonBinding {
     }
 
     static JsonObject serializeObject(Object value) {
+        if (value instanceof JsonObject object) {
+            return object;
+        }
         byte[] json = JSON_BINDING.get().serializeToBytes(value);
         return JsonParser.create(json).readJsonObject();
     }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializer.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializer.java
@@ -235,6 +235,8 @@ interface McpJsonSerializer {
 
     JsonObject.Builder toJson(McpSamplingContent content);
 
+    JsonObject.Builder toJson(McpSamplingToolUseContent content);
+
     JsonObject createSamplingRequest(long id, McpSamplingRequest request, List<McpTool> tools);
 
     McpSamplingResponse createSamplingResponse(JsonObject object) throws McpSamplingException;

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializer.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializer.java
@@ -229,17 +229,13 @@ interface McpJsonSerializer {
 
     // ---------- SAMPLING ----------
 
-    JsonObject.Builder toJson(McpSamplingRequest request);
+    JsonObject.Builder toJson(McpSamplingRequest request, List<McpTool> tools);
 
     JsonObject.Builder toJson(McpSamplingMessage message);
 
-    JsonObject.Builder toJson(McpSamplingImageMessage image);
+    JsonObject.Builder toJson(McpSamplingContent content);
 
-    JsonObject.Builder toJson(McpSamplingTextMessage text);
-
-    JsonObject.Builder toJson(McpSamplingAudioMessage audio);
-
-    JsonObject createSamplingRequest(long id, McpSamplingRequest request);
+    JsonObject createSamplingRequest(long id, McpSamplingRequest request, List<McpTool> tools);
 
     McpSamplingResponse createSamplingResponse(JsonObject object) throws McpSamplingException;
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializer.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializer.java
@@ -261,8 +261,6 @@ interface McpJsonSerializer {
 
     JsonObject createJsonRpcResultResponse(long id, JsonValue params);
 
-    JsonObject jsonrpcErrorTimeoutResponse(long requestId);
-
     // ---------- ROOTS ----------
 
     List<McpRoot> parseRoots(JsonObject response);

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV1.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV1.java
@@ -578,7 +578,7 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
                     .role(role)
                     .contents(parseContents(find(result, "content").orElseThrow()));
             result.objectValue(META)
-                    .map(McpParameters::new)
+                    .map(value -> McpJsonBinding.deserialize(value, Object.class))
                     .ifPresent(messageBuilder::metadata);
             McpSamplingMessage message = messageBuilder.build();
             return find(result, "stopReason")
@@ -615,7 +615,9 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
             case TEXT -> {
                 McpSamplingTextContent.Builder builder = McpSamplingTextContent.builder()
                         .text(object.stringValue("text").orElseThrow());
-                object.objectValue(META).map(McpParameters::new).ifPresent(builder::metadata);
+                object.objectValue(META)
+                        .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                        .ifPresent(builder::metadata);
                 parseAnnotations(object).ifPresent(builder::annotations);
                 yield builder.build();
             }
@@ -627,7 +629,9 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
                 McpSamplingImageContent.Builder builder = McpSamplingImageContent.builder()
                         .data(data)
                         .mediaType(mediaType);
-                object.objectValue(META).map(McpParameters::new).ifPresent(builder::metadata);
+                object.objectValue(META)
+                        .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                        .ifPresent(builder::metadata);
                 parseAnnotations(object).ifPresent(builder::annotations);
                 yield builder.build();
             }
@@ -639,7 +643,9 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
                 McpSamplingAudioContent.Builder builder = McpSamplingAudioContent.builder()
                         .data(data)
                         .mediaType(mediaType);
-                object.objectValue(META).map(McpParameters::new).ifPresent(builder::metadata);
+                object.objectValue(META)
+                        .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                        .ifPresent(builder::metadata);
                 parseAnnotations(object).ifPresent(builder::annotations);
                 yield builder.build();
             }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV1.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV1.java
@@ -355,12 +355,19 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
                     .set("mimeType", audio.mediaType().text());
             audio.annotations()
                     .ifPresent(annotations -> builder.set("annotations", toJson(annotations)));
-        } else if (content instanceof McpSamplingToolUseContent || content instanceof McpSamplingToolResultContent) {
+        } else if (content instanceof McpSamplingToolUseContent toolUse) {
+            builder = toJson(toolUse);
+        } else if (content instanceof McpSamplingToolResultContent) {
             throw new McpSamplingException("Sampling tools are not supported by this protocol version");
         } else {
             throw new McpSamplingException("Unsupported sampling content implementation: " + content.getClass().getName());
         }
         return builder;
+    }
+
+    @Override
+    public JsonObject.Builder toJson(McpSamplingToolUseContent content) {
+        throw new McpSamplingException("Sampling tools are not supported by this protocol version");
     }
 
     @Override

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV1.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV1.java
@@ -32,8 +32,6 @@ import io.helidon.json.JsonString;
 import io.helidon.json.JsonValue;
 import io.helidon.jsonrpc.core.JsonRpcError;
 
-import static io.helidon.jsonrpc.core.JsonRpcError.INTERNAL_ERROR;
-
 /**
  * JSON serializer for {@code 2024-11-05} MCP specification.
  */
@@ -522,14 +520,6 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
                 .set("id", id)
                 .set("result", params)
                 .build();
-    }
-
-    @Override
-    public JsonObject jsonrpcErrorTimeoutResponse(long requestId) {
-        var error = JsonObject.builder()
-                .set("code", INTERNAL_ERROR)
-                .set("message", "response timeout");
-        return createJsonRpcErrorResponse(requestId, error);
     }
 
     @Override

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV1.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV1.java
@@ -578,7 +578,7 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
                     .role(role)
                     .contents(parseContents(find(result, "content").orElseThrow()));
             result.objectValue(META)
-                    .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                    .map(McpParameters::new)
                     .ifPresent(messageBuilder::metadata);
             McpSamplingMessage message = messageBuilder.build();
             return find(result, "stopReason")
@@ -616,7 +616,7 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
                 McpSamplingTextContent.Builder builder = McpSamplingTextContent.builder()
                         .text(object.stringValue("text").orElseThrow());
                 object.objectValue(META)
-                        .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                        .map(McpParameters::new)
                         .ifPresent(builder::metadata);
                 parseAnnotations(object).ifPresent(builder::annotations);
                 yield builder.build();
@@ -630,7 +630,7 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
                         .data(data)
                         .mediaType(mediaType);
                 object.objectValue(META)
-                        .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                        .map(McpParameters::new)
                         .ifPresent(builder::metadata);
                 parseAnnotations(object).ifPresent(builder::annotations);
                 yield builder.build();
@@ -644,7 +644,7 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
                         .data(data)
                         .mediaType(mediaType);
                 object.objectValue(META)
-                        .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                        .map(McpParameters::new)
                         .ifPresent(builder::metadata);
                 parseAnnotations(object).ifPresent(builder::annotations);
                 yield builder.build();

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV1.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV1.java
@@ -16,9 +16,10 @@
 package io.helidon.extensions.mcp.server;
 
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -252,33 +253,39 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
 
     @Override
     public Optional<JsonObject.Builder> toJson(McpContent content) {
+        Optional<JsonObject.Builder> result;
         if (content instanceof McpTextContent text) {
-            return Optional.of(toJson(text));
+            result = Optional.of(toJson(text));
+        } else if (content instanceof McpImageContent image) {
+            result = Optional.of(toJson(image));
+        } else if (content instanceof McpAudioContent audio) {
+            result = toJson(audio);
+        } else if (content instanceof McpEmbeddedTextResourceContent text) {
+            result = Optional.of(toJson(text));
+        } else if (content instanceof McpEmbeddedBinaryResourceContent binary) {
+            result = Optional.of(toJson(binary));
+        } else if (content instanceof McpResourceLinkContent) {
+            result = Optional.empty();
+        } else if (content instanceof McpToolContent) {
+            throw new McpException("Unsupported tool content implementation: " + content.getClass().getName());
+        } else {
+            result = Optional.empty();
         }
-        if (content instanceof McpImageContent image) {
-            return Optional.of(toJson(image));
+        if (content instanceof McpToolContent toolContent) {
+            result.ifPresent(builder -> toolContent.annotations()
+                    .ifPresent(annotations -> builder.set("annotations", toJson(annotations))));
         }
-        if (content instanceof McpEmbeddedTextResourceContent text) {
-            return Optional.of(toJson(text));
-        }
-        if (content instanceof McpEmbeddedBinaryResourceContent binary) {
-            return Optional.of(toJson(binary));
-        }
-        return Optional.empty();
+        return result;
     }
 
     @Override
     public JsonObject.Builder toJson(McpSamplingMessage message) {
-        if (message instanceof McpSamplingTextMessage text) {
-            return toJson(text);
+        if (message.contents().size() != 1) {
+            throw new McpSamplingException("This protocol version requires exactly one content block per sampling message");
         }
-        if (message instanceof McpSamplingImageMessage image) {
-            return toJson(image);
-        }
-        if (message instanceof McpSamplingAudioMessage resource) {
-            return toJson(resource);
-        }
-        throw new IllegalArgumentException("Unsupported content type: " + message.getClass().getName());
+        return JsonObject.builder()
+                .set("role", message.role().text())
+                .set("content", toJson(message.contents().getFirst()).build());
     }
 
     @Override
@@ -326,32 +333,34 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
     }
 
     @Override
-    public JsonObject.Builder toJson(McpSamplingImageMessage image) {
-        return JsonObject.builder()
-                .set("role", image.role().text())
-                .set("content", JsonObject.builder()
-                        .set("type", image.type().text())
-                        .set("data", image.encodeBase64Data())
-                        .set("mimeType", image.mediaType().text()).build());
-    }
-
-    @Override
-    public JsonObject.Builder toJson(McpSamplingTextMessage text) {
-        return JsonObject.builder()
-                .set("role", text.role().text())
-                .set("content", JsonObject.builder()
-                        .set("type", text.type().text())
-                        .set("text", text.text()).build());
-    }
-
-    @Override
-    public JsonObject.Builder toJson(McpSamplingAudioMessage audio) {
-        return JsonObject.builder()
-                .set("role", audio.role().text())
-                .set("content", JsonObject.builder()
-                        .set("type", audio.type().text())
-                        .set("data", audio.encodeBase64Data())
-                        .set("mimeType", audio.mediaType().text()).build());
+    public JsonObject.Builder toJson(McpSamplingContent content) {
+        JsonObject.Builder builder;
+        if (content instanceof McpSamplingTextContent text) {
+            builder = JsonObject.builder()
+                    .set("type", text.type().text())
+                    .set("text", text.text());
+            text.annotations()
+                    .ifPresent(annotations -> builder.set("annotations", toJson(annotations)));
+        } else if (content instanceof McpSamplingImageContent image) {
+            builder = JsonObject.builder()
+                    .set("type", image.type().text())
+                    .set("data", image.encodeBase64Data())
+                    .set("mimeType", image.mediaType().text());
+            image.annotations()
+                    .ifPresent(annotations -> builder.set("annotations", toJson(annotations)));
+        } else if (content instanceof McpSamplingAudioContent audio) {
+            builder = JsonObject.builder()
+                    .set("type", audio.type().text())
+                    .set("data", audio.encodeBase64Data())
+                    .set("mimeType", audio.mediaType().text());
+            audio.annotations()
+                    .ifPresent(annotations -> builder.set("annotations", toJson(annotations)));
+        } else if (content instanceof McpSamplingToolUseContent || content instanceof McpSamplingToolResultContent) {
+            throw new McpSamplingException("Sampling tools are not supported by this protocol version");
+        } else {
+            throw new McpSamplingException("Unsupported sampling content implementation: " + content.getClass().getName());
+        }
+        return builder;
     }
 
     @Override
@@ -432,7 +441,7 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
     }
 
     @Override
-    public JsonObject.Builder toJson(McpSamplingRequest request) {
+    public JsonObject.Builder toJson(McpSamplingRequest request, List<McpTool> tools) {
         List<JsonValue> hints = new ArrayList<>();
         var params = JsonObject.builder();
         List<JsonValue> messages = new ArrayList<>();
@@ -449,7 +458,7 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
         request.intelligencePriority().ifPresent(intelligence -> modelPreference.set("intelligencePriority", intelligence));
         params.set("modelPreference", modelPreference.build());
 
-        McpSamplingSupport.aggregate(request).stream()
+        request.messages().stream()
                 .map(this::toJson)
                 .map(JsonObject.Builder::build)
                 .forEach(messages::add);
@@ -541,8 +550,8 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
     }
 
     @Override
-    public JsonObject createSamplingRequest(long id, McpSamplingRequest request) {
-        var params = toJson(request);
+    public JsonObject createSamplingRequest(long id, McpSamplingRequest request, List<McpTool> tools) {
+        var params = toJson(request, tools);
         return createJsonRpcRequest(id, METHOD_SAMPLING_CREATE_MESSAGE, params);
     }
 
@@ -563,16 +572,22 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
 
             String model = result.stringValue("model").orElseThrow();
             McpRole role = result.stringValue("role")
-                    .map(String::toUpperCase)
+                    .map(value -> value.toUpperCase(Locale.ROOT))
                     .map(McpRole::valueOf)
                     .orElseThrow();
-            List<McpSamplingMessage> messages = parseMessages(role, find(result, "content").orElseThrow());
+            McpSamplingMessage.Builder messageBuilder = McpSamplingMessage.builder()
+                    .role(role)
+                    .contents(parseContents(find(result, "content").orElseThrow()));
+            result.objectValue("_meta")
+                    .map(McpParameters::new)
+                    .ifPresent(messageBuilder::metadata);
+            McpSamplingMessage message = messageBuilder.build();
             return find(result, "stopReason")
                     .filter(this::isJsonString)
                     .map(JsonString.class::cast)
                     .map(JsonString::value)
-                    .map(stopReason -> new McpSamplingResponseImpl(messages, model, stopReason))
-                    .orElseGet(() -> new McpSamplingResponseImpl(messages, model));
+                    .map(stopReason -> new McpSamplingResponseImpl(message, model, stopReason))
+                    .orElseGet(() -> new McpSamplingResponseImpl(message, model));
         } catch (Exception e) {
             throw new McpSamplingException("Wrong sampling response format", e);
         }
@@ -588,32 +603,73 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
         throw new McpElicitationException("Elicitation not supported");
     }
 
-    List<McpSamplingMessage> parseMessages(McpRole role, JsonValue content) {
-        return List.of(parseMessage(role, content.asObject()));
+    List<McpSamplingContent> parseContents(JsonValue content) {
+        return List.of(parseContent(content.asObject()));
     }
 
-    McpSamplingMessage parseMessage(McpRole role, JsonObject object) {
+    McpSamplingContent parseContent(JsonObject object) {
         String type = object.stringValue("type")
-                .map(String::toUpperCase)
+                .map(value -> value.toUpperCase(Locale.ROOT))
                 .orElseThrow();
-        McpSamplingMessageType messageType = McpSamplingMessageType.valueOf(type);
-        return switch (messageType) {
-            case TEXT -> McpSamplingTextMessage.builder().text(object.stringValue("text").orElseThrow()).role(role).build();
+        McpSamplingContentType contentType = McpSamplingContentType.valueOf(type);
+        return switch (contentType) {
+            case TEXT -> {
+                McpSamplingTextContent.Builder builder = McpSamplingTextContent.builder()
+                        .text(object.stringValue("text").orElseThrow());
+                object.objectValue("_meta").map(McpParameters::new).ifPresent(builder::metadata);
+                parseAnnotations(object).ifPresent(builder::annotations);
+                yield builder.build();
+            }
             case IMAGE -> {
                 byte[] data = object.stringValue("data")
-                        .map(value -> value.getBytes(StandardCharsets.UTF_8))
+                        .map(value -> Base64.getDecoder().decode(value))
                         .orElseThrow();
                 MediaType mediaType = MediaTypes.create(object.stringValue("mimeType").orElseThrow());
-                yield McpSamplingImageMessage.builder().data(data).mediaType(mediaType).role(role).build();
+                McpSamplingImageContent.Builder builder = McpSamplingImageContent.builder()
+                        .data(data)
+                        .mediaType(mediaType);
+                object.objectValue("_meta").map(McpParameters::new).ifPresent(builder::metadata);
+                parseAnnotations(object).ifPresent(builder::annotations);
+                yield builder.build();
             }
             case AUDIO -> {
                 byte[] data = object.stringValue("data")
-                        .map(value -> value.getBytes(StandardCharsets.UTF_8))
+                        .map(value -> Base64.getDecoder().decode(value))
                         .orElseThrow();
                 MediaType mediaType = MediaTypes.create(object.stringValue("mimeType").orElseThrow());
-                yield McpSamplingAudioMessage.builder().data(data).mediaType(mediaType).role(role).build();
+                McpSamplingAudioContent.Builder builder = McpSamplingAudioContent.builder()
+                        .data(data)
+                        .mediaType(mediaType);
+                object.objectValue("_meta").map(McpParameters::new).ifPresent(builder::metadata);
+                parseAnnotations(object).ifPresent(builder::annotations);
+                yield builder.build();
             }
+            case TOOL_USE, TOOL_RESULT -> throw new IllegalArgumentException("Unsupported sampling content type: " + type);
         };
+    }
+
+    Optional<McpAnnotations> parseAnnotations(JsonObject content) {
+        return content.objectValue("annotations").map(annotations -> {
+            McpAnnotations.Builder builder = McpAnnotations.builder();
+            annotations.arrayValue("audience").ifPresent(audience -> audience.values().stream()
+                    .map(JsonValue::asString)
+                    .map(JsonString::value)
+                    .map(value -> value.toUpperCase(Locale.ROOT))
+                    .map(McpRole::valueOf)
+                    .forEach(builder::addAudience));
+            annotations.doubleValue("priority").ifPresent(builder::priority);
+            annotations.stringValue("lastModified").ifPresent(builder::lastModified);
+            return builder.build();
+        });
+    }
+
+    JsonObject toJson(McpAnnotations annotations) {
+        JsonObject.Builder builder = JsonObject.builder();
+        if (!annotations.audience().isEmpty()) {
+            builder.setStrings("audience", annotations.audience().stream().map(McpRole::text).toList());
+        }
+        annotations.priority().ifPresent(priority -> builder.set("priority", priority));
+        return builder.build();
     }
 
     Optional<JsonValue> find(JsonObject object, String key) {

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV1.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV1.java
@@ -32,6 +32,8 @@ import io.helidon.json.JsonString;
 import io.helidon.json.JsonValue;
 import io.helidon.jsonrpc.core.JsonRpcError;
 
+import static io.helidon.extensions.mcp.server.McpMetadata.META;
+
 /**
  * JSON serializer for {@code 2024-11-05} MCP specification.
  */
@@ -575,7 +577,7 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
             McpSamplingMessage.Builder messageBuilder = McpSamplingMessage.builder()
                     .role(role)
                     .contents(parseContents(find(result, "content").orElseThrow()));
-            result.objectValue("_meta")
+            result.objectValue(META)
                     .map(McpParameters::new)
                     .ifPresent(messageBuilder::metadata);
             McpSamplingMessage message = messageBuilder.build();
@@ -613,7 +615,7 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
             case TEXT -> {
                 McpSamplingTextContent.Builder builder = McpSamplingTextContent.builder()
                         .text(object.stringValue("text").orElseThrow());
-                object.objectValue("_meta").map(McpParameters::new).ifPresent(builder::metadata);
+                object.objectValue(META).map(McpParameters::new).ifPresent(builder::metadata);
                 parseAnnotations(object).ifPresent(builder::annotations);
                 yield builder.build();
             }
@@ -625,7 +627,7 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
                 McpSamplingImageContent.Builder builder = McpSamplingImageContent.builder()
                         .data(data)
                         .mediaType(mediaType);
-                object.objectValue("_meta").map(McpParameters::new).ifPresent(builder::metadata);
+                object.objectValue(META).map(McpParameters::new).ifPresent(builder::metadata);
                 parseAnnotations(object).ifPresent(builder::annotations);
                 yield builder.build();
             }
@@ -637,7 +639,7 @@ class McpJsonSerializerV1 implements McpJsonSerializer {
                 McpSamplingAudioContent.Builder builder = McpSamplingAudioContent.builder()
                         .data(data)
                         .mediaType(mediaType);
-                object.objectValue("_meta").map(McpParameters::new).ifPresent(builder::metadata);
+                object.objectValue(META).map(McpParameters::new).ifPresent(builder::metadata);
                 parseAnnotations(object).ifPresent(builder::annotations);
                 yield builder.build();
             }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV2.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV2.java
@@ -31,14 +31,6 @@ class McpJsonSerializerV2 extends McpJsonSerializerV1 {
     }
 
     @Override
-    public Optional<JsonObject.Builder> toJson(McpContent content) {
-        if (content instanceof McpAudioContent audio) {
-            return toJson(audio);
-        }
-        return super.toJson(content);
-    }
-
-    @Override
     public Optional<JsonObject.Builder> toJson(McpPromptContent content) {
         if (content instanceof McpPromptAudioContent resource) {
             return toJson(resource);

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3.java
@@ -15,10 +15,10 @@
  */
 package io.helidon.extensions.mcp.server;
 
+import java.util.ArrayList;
 import java.util.Optional;
 import java.util.Set;
 
-import io.helidon.json.JsonArray;
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonValue;
 import io.helidon.jsonrpc.core.JsonRpcError;
@@ -46,14 +46,19 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
             }
         }
 
-        JsonObject.Builder builder = JsonObject.builder().from(super.toolCall(tool, result));
+        JsonObject original = super.toolCall(tool, result);
+        JsonObject.Builder builder = JsonObject.builder().from(original);
+        var contentValues = new ArrayList<>(original.arrayValue("content").orElseThrow().values());
         result.structuredContent().ifPresent((content) -> {
             JsonObject sc = McpJsonBinding.serializeObject(content);
             String json = sc.toString();
             builder.set("structuredContent", sc);
-            if (result.textContents().isEmpty()) {
+            if (McpToolSupport.aggregateContent(result).stream().noneMatch(McpToolTextContent.class::isInstance)) {
                 McpToolContent text = McpToolTextContent.builder().text(json).build();
-                toJson(text).ifPresent(it -> builder.set("content", JsonArray.create(it.build())));
+                toJson(text).ifPresent(it -> {
+                    contentValues.add(it.build());
+                    builder.setValues("content", contentValues);
+                });
             }
         });
         return builder.build();
@@ -61,10 +66,36 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
 
     @Override
     public Optional<JsonObject.Builder> toJson(McpContent content) {
+        Optional<JsonObject.Builder> result;
         if (content instanceof McpResourceLinkContent link) {
-            return Optional.of(toJson(link));
+            result = Optional.of(toJson(link));
+        } else {
+            result = super.toJson(content);
         }
-        return super.toJson(content);
+        if (content instanceof McpToolContent toolContent) {
+            result.ifPresent(builder -> {
+                toolContent.annotations().ifPresent(annotations -> builder.set("annotations", toJson(annotations)));
+                toolContent.metadata()
+                        .ifPresent(metadata -> builder.set("_meta",
+                                                           toolParameterObject(metadata, "Tool content metadata")));
+            });
+        }
+        return result;
+    }
+
+    @Override
+    public JsonObject.Builder toJson(McpSamplingContent content) {
+        JsonObject.Builder builder = super.toJson(content);
+        content.metadata()
+                .ifPresent(metadata -> builder.set("_meta", parameterObject(metadata, "Sampling content metadata")));
+        return builder;
+    }
+
+    @Override
+    JsonObject toJson(McpAnnotations annotations) {
+        JsonObject.Builder builder = JsonObject.builder().from(super.toJson(annotations));
+        annotations.lastModified().ifPresent(lastModified -> builder.set("lastModified", lastModified));
+        return builder.build();
     }
 
     @Override
@@ -108,6 +139,20 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
         content.mediaType().ifPresent(mediaType -> builder.set("mimeType", mediaType.text()));
         content.description().ifPresent(description -> builder.set("description", description));
         return builder;
+    }
+
+    JsonObject parameterObject(McpParameters parameters, String field) {
+        if (parameters.value() instanceof JsonObject object) {
+            return object;
+        }
+        throw new McpSamplingException(field + " must be a JSON object");
+    }
+
+    private JsonObject toolParameterObject(McpParameters parameters, String field) {
+        if (parameters.value() instanceof JsonObject object) {
+            return object;
+        }
+        throw new McpException(field + " must be a JSON object");
     }
 
     @Override

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3.java
@@ -142,17 +142,13 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
     }
 
     JsonObject parameterObject(McpParameters parameters, String field) {
-        if (parameters.value() instanceof JsonObject object) {
-            return object;
-        }
-        throw new McpSamplingException(field + " must be a JSON object");
+        return parameters.asJsonObject()
+                .orElseThrow(() -> new McpSamplingException(field + " must be a JSON object"));
     }
 
     private JsonObject toolParameterObject(McpParameters parameters, String field) {
-        if (parameters.value() instanceof JsonObject object) {
-            return object;
-        }
-        throw new McpException(field + " must be a JSON object");
+        return parameters.asJsonObject()
+                .orElseThrow(() -> new McpException(field + " must be a JSON object"));
     }
 
     @Override

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3.java
@@ -78,7 +78,8 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
             result.ifPresent(builder -> {
                 toolContent.annotations().ifPresent(annotations -> builder.set("annotations", toJson(annotations)));
                 toolContent.metadata()
-                        .ifPresent(metadata -> builder.set(META, serializeToolContentMetadata(metadata)));
+                        .ifPresent(metadata -> builder.set(META, metadata.asJsonObject()
+                                .orElseThrow(() -> new McpException("Tool content metadata must be a JSON object"))));
             });
         }
         return result;
@@ -88,7 +89,8 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
     public JsonObject.Builder toJson(McpSamplingContent content) {
         JsonObject.Builder builder = super.toJson(content);
         content.metadata()
-                .ifPresent(metadata -> builder.set(META, serializeSamplingContentMetadata(metadata)));
+                .ifPresent(metadata -> builder.set(META, metadata.asJsonObject()
+                        .orElseThrow(() -> new McpSamplingException("Sampling content metadata must be a JSON object"))));
         return builder;
     }
 
@@ -170,14 +172,6 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
         return builder.build();
     }
 
-    JsonObject serializeSamplingContentMetadata(Object metadata) {
-        try {
-            return McpJsonBinding.serializeObject(metadata);
-        } catch (RuntimeException e) {
-            throw new McpSamplingException("Sampling content metadata must be a JSON object", e);
-        }
-    }
-
     private JsonObject.Builder toJson(McpResourceLinkContent content) {
         var builder = JsonObject.builder()
                 .set("type", content.type().text())
@@ -188,14 +182,6 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
         content.mediaType().ifPresent(mediaType -> builder.set("mimeType", mediaType.text()));
         content.description().ifPresent(description -> builder.set("description", description));
         return builder;
-    }
-
-    private JsonObject serializeToolContentMetadata(Object metadata) {
-        try {
-            return McpJsonBinding.serializeObject(metadata);
-        } catch (RuntimeException e) {
-            throw new McpException("Tool content metadata must be a JSON object", e);
-        }
     }
 
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3.java
@@ -23,6 +23,8 @@ import io.helidon.json.JsonObject;
 import io.helidon.json.JsonValue;
 import io.helidon.jsonrpc.core.JsonRpcError;
 
+import static io.helidon.extensions.mcp.server.McpMetadata.META;
+
 /**
  * JSON serializer for {@code 2025-06-18} MCP specification.
  */
@@ -76,7 +78,7 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
             result.ifPresent(builder -> {
                 toolContent.annotations().ifPresent(annotations -> builder.set("annotations", toJson(annotations)));
                 toolContent.metadata()
-                        .ifPresent(metadata -> builder.set("_meta", metadata.asJsonObject()
+                        .ifPresent(metadata -> builder.set(META, metadata.asJsonObject()
                                 .orElseThrow(() -> new McpException("Tool content metadata must be a JSON object"))));
             });
         }
@@ -87,7 +89,7 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
     public JsonObject.Builder toJson(McpSamplingContent content) {
         JsonObject.Builder builder = super.toJson(content);
         content.metadata()
-                .ifPresent(metadata -> builder.set("_meta", metadata.asJsonObject()
+                .ifPresent(metadata -> builder.set(META, metadata.asJsonObject()
                         .orElseThrow(() -> new McpSamplingException("Sampling content metadata must be a JSON object"))));
         return builder;
     }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3.java
@@ -92,13 +92,6 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
     }
 
     @Override
-    JsonObject toJson(McpAnnotations annotations) {
-        JsonObject.Builder builder = JsonObject.builder().from(super.toJson(annotations));
-        annotations.lastModified().ifPresent(lastModified -> builder.set("lastModified", lastModified));
-        return builder.build();
-    }
-
-    @Override
     public JsonObject.Builder toJson(McpTool tool) {
         var builder = super.toJson(tool);
         tool.title().ifPresent(title -> builder.set("title", title));
@@ -127,28 +120,6 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
         var builder = super.toJson(argument);
         argument.title().ifPresent(title -> builder.set("title", title));
         return builder;
-    }
-
-    private JsonObject.Builder toJson(McpResourceLinkContent content) {
-        var builder = JsonObject.builder()
-                .set("type", content.type().text())
-                .set("uri", content.uri())
-                .set("name", content.name());
-        content.size().ifPresent(size -> builder.set("size", size));
-        content.title().ifPresent(title -> builder.set("title", title));
-        content.mediaType().ifPresent(mediaType -> builder.set("mimeType", mediaType.text()));
-        content.description().ifPresent(description -> builder.set("description", description));
-        return builder;
-    }
-
-    JsonObject parameterObject(McpParameters parameters, String field) {
-        return parameters.asJsonObject()
-                .orElseThrow(() -> new McpSamplingException(field + " must be a JSON object"));
-    }
-
-    private JsonObject toolParameterObject(McpParameters parameters, String field) {
-        return parameters.asJsonObject()
-                .orElseThrow(() -> new McpException(field + " must be a JSON object"));
     }
 
     @Override
@@ -189,5 +160,34 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
         params.set("requestedSchema", jsonSchema);
         builder.set("params", params.build());
         return builder.build();
+    }
+
+    @Override
+    JsonObject toJson(McpAnnotations annotations) {
+        JsonObject.Builder builder = JsonObject.builder().from(super.toJson(annotations));
+        annotations.lastModified().ifPresent(lastModified -> builder.set("lastModified", lastModified));
+        return builder.build();
+    }
+
+    JsonObject parameterObject(McpParameters parameters, String field) {
+        return parameters.asJsonObject()
+                .orElseThrow(() -> new McpSamplingException(field + " must be a JSON object"));
+    }
+
+    private JsonObject.Builder toJson(McpResourceLinkContent content) {
+        var builder = JsonObject.builder()
+                .set("type", content.type().text())
+                .set("uri", content.uri())
+                .set("name", content.name());
+        content.size().ifPresent(size -> builder.set("size", size));
+        content.title().ifPresent(title -> builder.set("title", title));
+        content.mediaType().ifPresent(mediaType -> builder.set("mimeType", mediaType.text()));
+        content.description().ifPresent(description -> builder.set("description", description));
+        return builder;
+    }
+
+    private JsonObject toolParameterObject(McpParameters parameters, String field) {
+        return parameters.asJsonObject()
+                .orElseThrow(() -> new McpException(field + " must be a JSON object"));
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3.java
@@ -76,8 +76,8 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
             result.ifPresent(builder -> {
                 toolContent.annotations().ifPresent(annotations -> builder.set("annotations", toJson(annotations)));
                 toolContent.metadata()
-                        .ifPresent(metadata -> builder.set("_meta",
-                                                           toolParameterObject(metadata, "Tool content metadata")));
+                        .ifPresent(metadata -> builder.set("_meta", metadata.asJsonObject()
+                                .orElseThrow(() -> new McpException("Tool content metadata must be a JSON object"))));
             });
         }
         return result;
@@ -87,7 +87,8 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
     public JsonObject.Builder toJson(McpSamplingContent content) {
         JsonObject.Builder builder = super.toJson(content);
         content.metadata()
-                .ifPresent(metadata -> builder.set("_meta", parameterObject(metadata, "Sampling content metadata")));
+                .ifPresent(metadata -> builder.set("_meta", metadata.asJsonObject()
+                        .orElseThrow(() -> new McpSamplingException("Sampling content metadata must be a JSON object"))));
         return builder;
     }
 
@@ -169,11 +170,6 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
         return builder.build();
     }
 
-    JsonObject parameterObject(McpParameters parameters, String field) {
-        return parameters.asJsonObject()
-                .orElseThrow(() -> new McpSamplingException(field + " must be a JSON object"));
-    }
-
     private JsonObject.Builder toJson(McpResourceLinkContent content) {
         var builder = JsonObject.builder()
                 .set("type", content.type().text())
@@ -186,8 +182,4 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
         return builder;
     }
 
-    private JsonObject toolParameterObject(McpParameters parameters, String field) {
-        return parameters.asJsonObject()
-                .orElseThrow(() -> new McpException(field + " must be a JSON object"));
-    }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3.java
@@ -78,8 +78,7 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
             result.ifPresent(builder -> {
                 toolContent.annotations().ifPresent(annotations -> builder.set("annotations", toJson(annotations)));
                 toolContent.metadata()
-                        .ifPresent(metadata -> builder.set(META, metadata.asJsonObject()
-                                .orElseThrow(() -> new McpException("Tool content metadata must be a JSON object"))));
+                        .ifPresent(metadata -> builder.set(META, serializeToolContentMetadata(metadata)));
             });
         }
         return result;
@@ -89,8 +88,7 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
     public JsonObject.Builder toJson(McpSamplingContent content) {
         JsonObject.Builder builder = super.toJson(content);
         content.metadata()
-                .ifPresent(metadata -> builder.set(META, metadata.asJsonObject()
-                        .orElseThrow(() -> new McpSamplingException("Sampling content metadata must be a JSON object"))));
+                .ifPresent(metadata -> builder.set(META, serializeSamplingContentMetadata(metadata)));
         return builder;
     }
 
@@ -172,6 +170,14 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
         return builder.build();
     }
 
+    JsonObject serializeSamplingContentMetadata(Object metadata) {
+        try {
+            return McpJsonBinding.serializeObject(metadata);
+        } catch (RuntimeException e) {
+            throw new McpSamplingException("Sampling content metadata must be a JSON object", e);
+        }
+    }
+
     private JsonObject.Builder toJson(McpResourceLinkContent content) {
         var builder = JsonObject.builder()
                 .set("type", content.type().text())
@@ -182,6 +188,14 @@ class McpJsonSerializerV3 extends McpJsonSerializerV2 {
         content.mediaType().ifPresent(mediaType -> builder.set("mimeType", mediaType.text()));
         content.description().ifPresent(description -> builder.set("description", description));
         return builder;
+    }
+
+    private JsonObject serializeToolContentMetadata(Object metadata) {
+        try {
+            return McpJsonBinding.serializeObject(metadata);
+        } catch (RuntimeException e) {
+            throw new McpException("Tool content metadata must be a JSON object", e);
+        }
     }
 
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
@@ -121,7 +121,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
     @Override
     public McpSamplingResponse createSamplingResponse(JsonObject object) throws McpSamplingException {
         McpSamplingResponse response = super.createSamplingResponse(object);
-        validateContentRoles(response.message());
+        validateSamplingResponse(response.message());
         return response;
     }
 
@@ -320,6 +320,22 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
         }
         icon.theme().ifPresent(theme -> builder.set("theme", theme.text()));
         return builder.build();
+    }
+
+    private void validateSamplingResponse(McpSamplingMessage message) {
+        if (message.role() != McpRole.ASSISTANT) {
+            throw new McpSamplingException("Sampling response must have an assistant message role");
+        }
+        if (message.contents().stream().anyMatch(McpSamplingToolResultContent.class::isInstance)) {
+            throw new McpSamplingException("Sampling response must not contain tool result content");
+        }
+        List<McpSamplingToolUseContent> toolUses = message.contents().stream()
+                .filter(McpSamplingToolUseContent.class::isInstance)
+                .map(McpSamplingToolUseContent.class::cast)
+                .toList();
+        if (toolUses.stream().map(McpSamplingToolUseContent::id).distinct().count() != toolUses.size()) {
+            throw new McpSamplingException("Sampling tool use identifiers must be unique within a message");
+        }
     }
 
     private void validateToolMessages(List<McpSamplingMessage> messages) {

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
@@ -15,11 +15,20 @@
  */
 package io.helidon.extensions.mcp.server;
 
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
+import io.helidon.common.media.type.MediaTypes;
 import io.helidon.json.JsonArray;
 import io.helidon.json.JsonObject;
+import io.helidon.json.JsonString;
 import io.helidon.json.JsonValue;
 
 /**
@@ -41,13 +50,342 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
     }
 
     @Override
-    List<McpSamplingMessage> parseMessages(McpRole role, JsonValue content) {
+    public JsonObject.Builder toJson(McpSamplingRequest request, List<McpTool> tools) {
+        validateToolMessages(request.messages());
+        JsonObject.Builder params = super.toJson(request, tools);
+
+        if (!tools.isEmpty()) {
+            List<JsonValue> serializedTools = tools.stream()
+                    .map(this::toJson)
+                    .map(JsonObject.Builder::build)
+                    .map(JsonValue.class::cast)
+                    .toList();
+            params.setValues("tools", serializedTools);
+        }
+        request.toolChoice().ifPresent(choice -> params.set("toolChoice", JsonObject.builder()
+                .set("mode", choice.text())
+                .build()));
+        return params;
+    }
+
+    @Override
+    public JsonObject.Builder toJson(McpSamplingMessage message) {
+        List<JsonValue> contents = message.contents().stream()
+                .map(this::toJson)
+                .map(JsonObject.Builder::build)
+                .map(JsonValue.class::cast)
+                .toList();
+        JsonObject.Builder builder = JsonObject.builder()
+                .set("role", message.role().text());
+        if (contents.size() == 1) {
+            builder.set("content", contents.getFirst());
+        } else {
+            builder.setValues("content", contents);
+        }
+        message.metadata()
+                .ifPresent(metadata -> builder.set("_meta", parameterObject(metadata, "Sampling message metadata")));
+        return builder;
+    }
+
+    @Override
+    public JsonObject.Builder toJson(McpSamplingContent content) {
+        JsonObject.Builder builder;
+        if (content instanceof McpSamplingToolUseContent toolUse) {
+            builder = toJson(toolUse);
+        } else if (content instanceof McpSamplingToolResultContent toolResult) {
+            builder = toJson(toolResult);
+        } else {
+            builder = super.toJson(content);
+        }
+        content.metadata()
+                .ifPresent(metadata -> builder.set("_meta", parameterObject(metadata, "Sampling content metadata")));
+        if (content instanceof McpSamplingAnnotatedContent annotated) {
+            annotated.annotations().ifPresent(annotations -> builder.set("annotations", toJson(annotations)));
+        }
+        return builder;
+    }
+
+    @Override
+    public Optional<JsonObject.Builder> toJson(McpContent content) {
+        Optional<JsonObject.Builder> result = super.toJson(content);
+        if (content instanceof McpToolResourceLinkContent link) {
+            result.ifPresent(builder -> {
+                if (!link.icons().isEmpty()) {
+                    builder.setValues("icons", link.icons().stream().map(this::toJson).toList());
+                }
+            });
+        }
+        return result;
+    }
+
+    @Override
+    public McpSamplingResponse createSamplingResponse(JsonObject object) throws McpSamplingException {
+        McpSamplingResponse response = super.createSamplingResponse(object);
+        validateContentRoles(response.message());
+        return response;
+    }
+
+    @Override
+    List<McpSamplingContent> parseContents(JsonValue content) {
         if (content instanceof JsonArray array) {
             return array.values().stream()
                     .map(JsonValue::asObject)
-                    .map(value -> parseMessage(role, value))
+                    .map(this::parseContent)
                     .toList();
         }
-        return super.parseMessages(role, content);
+        return super.parseContents(content);
+    }
+
+    @Override
+    McpSamplingContent parseContent(JsonObject object) {
+        McpSamplingContentType type = object.stringValue("type")
+                .map(value -> value.toUpperCase(Locale.ROOT))
+                .map(McpSamplingContentType::valueOf)
+                .orElseThrow();
+        return switch (type) {
+            case TOOL_USE -> parseToolUseContent(object);
+            case TOOL_RESULT -> parseToolResultContent(object);
+            case TEXT, IMAGE, AUDIO -> super.parseContent(object);
+        };
+    }
+
+    private JsonObject.Builder toJson(McpSamplingToolUseContent content) {
+        return JsonObject.builder()
+                .set("type", content.type().text())
+                .set("id", content.id())
+                .set("name", content.name())
+                .set("input", parameterObject(content.input(), "Sampling tool input"));
+    }
+
+    private JsonObject.Builder toJson(McpSamplingToolResultContent content) {
+        McpToolResult result = content.result();
+        List<JsonValue> contents = new ArrayList<>();
+        for (McpToolContent resultContent : McpToolSupport.aggregateContent(result)) {
+            toJson(resultContent).map(JsonObject.Builder::build).ifPresent(contents::add);
+        }
+        JsonObject.Builder builder = JsonObject.builder()
+                .set("type", content.type().text())
+                .set("toolUseId", content.toolUseId())
+                .setValues("content", contents)
+                .set("isError", result.error());
+        result.structuredContent()
+                .map(McpJsonBinding::serializeObject)
+                .ifPresent(structured -> builder.set("structuredContent", structured));
+        return builder;
+    }
+
+    private McpSamplingToolUseContent parseToolUseContent(JsonObject object) {
+        JsonObject input = object.objectValue("input").orElseThrow();
+        McpSamplingToolUseContent.Builder builder = McpSamplingToolUseContent.builder()
+                .id(object.stringValue("id").orElseThrow())
+                .name(object.stringValue("name").orElseThrow())
+                .input(new McpParameters(input));
+        object.objectValue("_meta")
+                .map(McpParameters::new)
+                .ifPresent(builder::metadata);
+        return builder.build();
+    }
+
+    private McpSamplingToolResultContent parseToolResultContent(JsonObject object) {
+        McpToolResult.Builder resultBuilder = McpToolResult.builder()
+                .error(object.booleanValue("isError").orElse(false));
+        for (JsonValue value : object.arrayValue("content").orElseThrow().values()) {
+            McpToolContent content = parseToolResultBlock(value.asObject());
+            if (content instanceof McpToolTextContent text) {
+                resultBuilder.addTextContent(text);
+            } else if (content instanceof McpToolImageContent image) {
+                resultBuilder.addImageContent(image);
+            } else if (content instanceof McpToolAudioContent audio) {
+                resultBuilder.addAudioContent(audio);
+            } else if (content instanceof McpToolTextResourceContent textResource) {
+                resultBuilder.addTextResourceContent(textResource);
+            } else if (content instanceof McpToolBinaryResourceContent binaryResource) {
+                resultBuilder.addBinaryResourceContent(binaryResource);
+            } else if (content instanceof McpToolResourceLinkContent resourceLink) {
+                resultBuilder.addResourceLinkContent(resourceLink);
+            } else {
+                throw new McpSamplingException("Unsupported sampling tool result content type");
+            }
+        }
+        object.objectValue("structuredContent")
+                .map(content -> McpJsonBinding.deserialize(content, Map.class))
+                .ifPresent(resultBuilder::structuredContent);
+        McpSamplingToolResultContent.Builder builder = McpSamplingToolResultContent.builder()
+                .toolUseId(object.stringValue("toolUseId").orElseThrow())
+                .result(resultBuilder.build());
+        object.objectValue("_meta")
+                .map(McpParameters::new)
+                .ifPresent(builder::metadata);
+        return builder.build();
+    }
+
+    private McpToolContent parseToolResultBlock(JsonObject content) {
+        return switch (content.stringValue("type").orElseThrow()) {
+            case "text" -> {
+                McpToolTextContent.Builder builder = McpToolTextContent.builder()
+                        .text(content.stringValue("text").orElseThrow());
+                parseAnnotations(content).ifPresent(builder::annotations);
+                content.objectValue("_meta").map(McpParameters::new).ifPresent(builder::metadata);
+                yield builder.build();
+            }
+            case "image" -> {
+                McpToolImageContent.Builder builder = McpToolImageContent.builder()
+                        .data(content.stringValue("data")
+                                      .map(value -> Base64.getDecoder().decode(value))
+                                      .orElseThrow())
+                        .mediaType(MediaTypes.create(content.stringValue("mimeType").orElseThrow()));
+                parseAnnotations(content).ifPresent(builder::annotations);
+                content.objectValue("_meta").map(McpParameters::new).ifPresent(builder::metadata);
+                yield builder.build();
+            }
+            case "audio" -> {
+                McpToolAudioContent.Builder builder = McpToolAudioContent.builder()
+                        .data(content.stringValue("data")
+                                      .map(value -> Base64.getDecoder().decode(value))
+                                      .orElseThrow())
+                        .mediaType(MediaTypes.create(content.stringValue("mimeType").orElseThrow()));
+                parseAnnotations(content).ifPresent(builder::annotations);
+                content.objectValue("_meta").map(McpParameters::new).ifPresent(builder::metadata);
+                yield builder.build();
+            }
+            case "resource_link" -> parseToolResourceLink(content);
+            case "resource" -> parseToolEmbeddedResource(content);
+            default -> throw new McpSamplingException("Unsupported sampling tool result content type");
+        };
+    }
+
+    private McpToolResourceLinkContent parseToolResourceLink(JsonObject content) {
+        McpToolResourceLinkContent.Builder builder = McpToolResourceLinkContent.builder()
+                .name(content.stringValue("name").orElseThrow())
+                .uri(content.stringValue("uri").orElseThrow());
+        content.stringValue("title").ifPresent(builder::title);
+        content.stringValue("description").ifPresent(builder::description);
+        content.stringValue("mimeType").map(MediaTypes::create).ifPresent(builder::mediaType);
+        content.longValue("size").ifPresent(builder::size);
+        content.arrayValue("icons").ifPresent(icons -> icons.values().stream()
+                .map(JsonValue::asObject)
+                .map(this::parseIcon)
+                .forEach(builder::addIcon));
+        parseAnnotations(content).ifPresent(builder::annotations);
+        content.objectValue("_meta").map(McpParameters::new).ifPresent(builder::metadata);
+        return builder.build();
+    }
+
+    private McpToolContent parseToolEmbeddedResource(JsonObject content) {
+        JsonObject resource = content.objectValue("resource").orElseThrow();
+        URI uri = URI.create(resource.stringValue("uri").orElseThrow());
+        if (resource.stringValue("text").isPresent()) {
+            McpToolTextResourceContent.Builder builder = McpToolTextResourceContent.builder()
+                    .uri(uri)
+                    .mediaType(resource.stringValue("mimeType")
+                                       .map(MediaTypes::create)
+                                       .orElse(MediaTypes.TEXT_PLAIN))
+                    .text(resource.stringValue("text").orElseThrow());
+            parseAnnotations(content).ifPresent(builder::annotations);
+            content.objectValue("_meta").map(McpParameters::new).ifPresent(builder::metadata);
+            return builder.build();
+        }
+        McpToolBinaryResourceContent.Builder builder = McpToolBinaryResourceContent.builder()
+                .uri(uri)
+                .mediaType(resource.stringValue("mimeType")
+                                   .map(MediaTypes::create)
+                                   .orElseGet(() -> MediaTypes.create("application/octet-stream")))
+                .data(resource.stringValue("blob")
+                              .map(value -> Base64.getDecoder().decode(value))
+                              .orElseThrow());
+        parseAnnotations(content).ifPresent(builder::annotations);
+        content.objectValue("_meta").map(McpParameters::new).ifPresent(builder::metadata);
+        return builder.build();
+    }
+
+    private McpIcon parseIcon(JsonObject icon) {
+        McpIcon.Builder builder = McpIcon.builder().src(icon.stringValue("src").orElseThrow());
+        icon.stringValue("mimeType").map(MediaTypes::create).ifPresent(builder::mediaType);
+        icon.arrayValue("sizes").ifPresent(sizes -> sizes.values().stream()
+                .map(JsonValue::asString)
+                .map(JsonString::value)
+                .forEach(builder::addSize));
+        icon.stringValue("theme")
+                .map(value -> value.toUpperCase(Locale.ROOT))
+                .map(McpIconTheme::valueOf)
+                .ifPresent(builder::theme);
+        return builder.build();
+    }
+
+    private JsonObject toJson(McpIcon icon) {
+        JsonObject.Builder builder = JsonObject.builder().set("src", icon.src());
+        icon.mediaType().ifPresent(mediaType -> builder.set("mimeType", mediaType.text()));
+        if (!icon.sizes().isEmpty()) {
+            builder.setStrings("sizes", icon.sizes());
+        }
+        icon.theme().ifPresent(theme -> builder.set("theme", theme.text()));
+        return builder.build();
+    }
+
+    private void validateToolMessages(List<McpSamplingMessage> messages) {
+        Set<String> expectedResults = null;
+        for (McpSamplingMessage message : messages) {
+            validateContentRoles(message);
+            List<McpSamplingToolUseContent> toolUses = message.contents().stream()
+                    .filter(McpSamplingToolUseContent.class::isInstance)
+                    .map(McpSamplingToolUseContent.class::cast)
+                    .toList();
+            List<McpSamplingToolResultContent> toolResults = message.contents().stream()
+                    .filter(McpSamplingToolResultContent.class::isInstance)
+                    .map(McpSamplingToolResultContent.class::cast)
+                    .toList();
+
+            if (expectedResults != null) {
+                Set<String> resultIds = new HashSet<>();
+                toolResults.stream()
+                        .map(McpSamplingToolResultContent::toolUseId)
+                        .forEach(resultIds::add);
+                if (toolResults.size() != message.contents().size()
+                        || resultIds.size() != toolResults.size()
+                        || !expectedResults.equals(resultIds)) {
+                    throw new McpSamplingException("Sampling tool uses must be followed by matching tool results");
+                }
+                expectedResults = null;
+                continue;
+            }
+            if (!toolResults.isEmpty()) {
+                throw new McpSamplingException("Sampling tool result does not match a preceding tool use");
+            }
+            if (!toolUses.isEmpty()) {
+                Set<String> toolUseIds = new HashSet<>();
+                toolUses.stream()
+                        .map(McpSamplingToolUseContent::id)
+                        .forEach(toolUseIds::add);
+                if (toolUseIds.size() != toolUses.size()) {
+                    throw new McpSamplingException("Sampling tool use identifiers must be unique within a message");
+                }
+                expectedResults = toolUseIds;
+            }
+        }
+        if (expectedResults != null) {
+            throw new McpSamplingException("Sampling tool uses must be followed by matching tool results");
+        }
+    }
+
+    private void validateContentRoles(McpSamplingMessage message) {
+        List<McpSamplingToolUseContent> toolUses = message.contents().stream()
+                .filter(McpSamplingToolUseContent.class::isInstance)
+                .map(McpSamplingToolUseContent.class::cast)
+                .toList();
+        boolean usesTool = !toolUses.isEmpty();
+        boolean hasToolResult = message.contents().stream().anyMatch(McpSamplingToolResultContent.class::isInstance);
+        if (usesTool && message.role() != McpRole.ASSISTANT) {
+            throw new McpSamplingException("Sampling tool use content must have an assistant message role");
+        }
+        if (hasToolResult && message.role() != McpRole.USER) {
+            throw new McpSamplingException("Sampling tool result content must have a user message role");
+        }
+        if (hasToolResult
+                && message.contents().stream().anyMatch(content -> !(content instanceof McpSamplingToolResultContent))) {
+            throw new McpSamplingException("Sampling messages with tool results must contain only tool results");
+        }
+        if (toolUses.stream().map(McpSamplingToolUseContent::id).distinct().count() != toolUses.size()) {
+            throw new McpSamplingException("Sampling tool use identifiers must be unique within a message");
+        }
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
@@ -83,7 +83,8 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
             builder.setValues("content", contents);
         }
         message.metadata()
-                .ifPresent(metadata -> builder.set("_meta", parameterObject(metadata, "Sampling message metadata")));
+                .ifPresent(metadata -> builder.set("_meta", metadata.asJsonObject()
+                        .orElseThrow(() -> new McpSamplingException("Sampling message metadata must be a JSON object"))));
         return builder;
     }
 
@@ -98,7 +99,8 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
             builder = super.toJson(content);
         }
         content.metadata()
-                .ifPresent(metadata -> builder.set("_meta", parameterObject(metadata, "Sampling content metadata")));
+                .ifPresent(metadata -> builder.set("_meta", metadata.asJsonObject()
+                        .orElseThrow(() -> new McpSamplingException("Sampling content metadata must be a JSON object"))));
         if (content instanceof McpSamplingAnnotatedContent annotated) {
             annotated.annotations().ifPresent(annotations -> builder.set("annotations", toJson(annotations)));
         }
@@ -131,7 +133,8 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                 .set("type", content.type().text())
                 .set("id", content.id())
                 .set("name", content.name())
-                .set("input", parameterObject(content.input(), "Sampling tool input"));
+                .set("input", content.input().asJsonObject()
+                        .orElseThrow(() -> new McpSamplingException("Sampling tool input must be a JSON object")));
     }
 
     @Override

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
@@ -126,6 +126,15 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
     }
 
     @Override
+    public JsonObject.Builder toJson(McpSamplingToolUseContent content) {
+        return JsonObject.builder()
+                .set("type", content.type().text())
+                .set("id", content.id())
+                .set("name", content.name())
+                .set("input", parameterObject(content.input(), "Sampling tool input"));
+    }
+
+    @Override
     List<McpSamplingContent> parseContents(JsonValue content) {
         if (content instanceof JsonArray array) {
             return array.values().stream()
@@ -147,15 +156,6 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
             case TOOL_RESULT -> parseToolResultContent(object);
             case TEXT, IMAGE, AUDIO -> super.parseContent(object);
         };
-    }
-
-    @Override
-    public JsonObject.Builder toJson(McpSamplingToolUseContent content) {
-        return JsonObject.builder()
-                .set("type", content.type().text())
-                .set("id", content.id())
-                .set("name", content.name())
-                .set("input", parameterObject(content.input(), "Sampling tool input"));
     }
 
     private JsonObject.Builder toJson(McpSamplingToolResultContent content) {

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
@@ -149,7 +149,8 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
         };
     }
 
-    private JsonObject.Builder toJson(McpSamplingToolUseContent content) {
+    @Override
+    public JsonObject.Builder toJson(McpSamplingToolUseContent content) {
         return JsonObject.builder()
                 .set("type", content.type().text())
                 .set("id", content.id())

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
@@ -31,6 +31,8 @@ import io.helidon.json.JsonObject;
 import io.helidon.json.JsonString;
 import io.helidon.json.JsonValue;
 
+import static io.helidon.extensions.mcp.server.McpMetadata.META;
+
 /**
  * JSON serializer for {@code 2025-11-25} MCP specification.
  */
@@ -83,7 +85,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
             builder.setValues("content", contents);
         }
         message.metadata()
-                .ifPresent(metadata -> builder.set("_meta", metadata.asJsonObject()
+                .ifPresent(metadata -> builder.set(META, metadata.asJsonObject()
                         .orElseThrow(() -> new McpSamplingException("Sampling message metadata must be a JSON object"))));
         return builder;
     }
@@ -99,7 +101,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
             builder = super.toJson(content);
         }
         content.metadata()
-                .ifPresent(metadata -> builder.set("_meta", metadata.asJsonObject()
+                .ifPresent(metadata -> builder.set(META, metadata.asJsonObject()
                         .orElseThrow(() -> new McpSamplingException("Sampling content metadata must be a JSON object"))));
         if (content instanceof McpSamplingAnnotatedContent annotated) {
             annotated.annotations().ifPresent(annotations -> builder.set("annotations", toJson(annotations)));
@@ -194,7 +196,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                 .id(object.stringValue("id").orElseThrow())
                 .name(object.stringValue("name").orElseThrow())
                 .input(new McpParameters(input));
-        object.objectValue("_meta")
+        object.objectValue(META)
                 .map(McpParameters::new)
                 .ifPresent(builder::metadata);
         return builder.build();
@@ -227,7 +229,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
         McpSamplingToolResultContent.Builder builder = McpSamplingToolResultContent.builder()
                 .toolUseId(object.stringValue("toolUseId").orElseThrow())
                 .result(resultBuilder.build());
-        object.objectValue("_meta")
+        object.objectValue(META)
                 .map(McpParameters::new)
                 .ifPresent(builder::metadata);
         return builder.build();
@@ -239,7 +241,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                 McpToolTextContent.Builder builder = McpToolTextContent.builder()
                         .text(content.stringValue("text").orElseThrow());
                 parseAnnotations(content).ifPresent(builder::annotations);
-                content.objectValue("_meta").map(McpParameters::new).ifPresent(builder::metadata);
+                content.objectValue(META).map(McpParameters::new).ifPresent(builder::metadata);
                 yield builder.build();
             }
             case "image" -> {
@@ -249,7 +251,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                                       .orElseThrow())
                         .mediaType(MediaTypes.create(content.stringValue("mimeType").orElseThrow()));
                 parseAnnotations(content).ifPresent(builder::annotations);
-                content.objectValue("_meta").map(McpParameters::new).ifPresent(builder::metadata);
+                content.objectValue(META).map(McpParameters::new).ifPresent(builder::metadata);
                 yield builder.build();
             }
             case "audio" -> {
@@ -259,7 +261,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                                       .orElseThrow())
                         .mediaType(MediaTypes.create(content.stringValue("mimeType").orElseThrow()));
                 parseAnnotations(content).ifPresent(builder::annotations);
-                content.objectValue("_meta").map(McpParameters::new).ifPresent(builder::metadata);
+                content.objectValue(META).map(McpParameters::new).ifPresent(builder::metadata);
                 yield builder.build();
             }
             case "resource_link" -> parseToolResourceLink(content);
@@ -281,7 +283,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                 .map(this::parseIcon)
                 .forEach(builder::addIcon));
         parseAnnotations(content).ifPresent(builder::annotations);
-        content.objectValue("_meta").map(McpParameters::new).ifPresent(builder::metadata);
+        content.objectValue(META).map(McpParameters::new).ifPresent(builder::metadata);
         return builder.build();
     }
 
@@ -296,7 +298,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                                        .orElse(MediaTypes.TEXT_PLAIN))
                     .text(resource.stringValue("text").orElseThrow());
             parseAnnotations(content).ifPresent(builder::annotations);
-            content.objectValue("_meta").map(McpParameters::new).ifPresent(builder::metadata);
+            content.objectValue(META).map(McpParameters::new).ifPresent(builder::metadata);
             return builder.build();
         }
         McpToolBinaryResourceContent.Builder builder = McpToolBinaryResourceContent.builder()
@@ -308,7 +310,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                               .map(value -> Base64.getDecoder().decode(value))
                               .orElseThrow());
         parseAnnotations(content).ifPresent(builder::annotations);
-        content.objectValue("_meta").map(McpParameters::new).ifPresent(builder::metadata);
+        content.objectValue(META).map(McpParameters::new).ifPresent(builder::metadata);
         return builder.build();
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
@@ -323,16 +323,16 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
     }
 
     private void validateSamplingResponse(McpSamplingMessage message) {
-        if (message.role() != McpRole.ASSISTANT) {
+        List<McpSamplingToolUseContent> toolUses = message.contents().stream()
+                .filter(McpSamplingToolUseContent.class::isInstance)
+                .map(McpSamplingToolUseContent.class::cast)
+                .toList();
+        if (!toolUses.isEmpty() && message.role() != McpRole.ASSISTANT) {
             throw new McpSamplingException("Sampling response must have an assistant message role");
         }
         if (message.contents().stream().anyMatch(McpSamplingToolResultContent.class::isInstance)) {
             throw new McpSamplingException("Sampling response must not contain tool result content");
         }
-        List<McpSamplingToolUseContent> toolUses = message.contents().stream()
-                .filter(McpSamplingToolUseContent.class::isInstance)
-                .map(McpSamplingToolUseContent.class::cast)
-                .toList();
         if (toolUses.stream().map(McpSamplingToolUseContent::id).distinct().count() != toolUses.size()) {
             throw new McpSamplingException("Sampling tool use identifiers must be unique within a message");
         }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
@@ -85,7 +85,8 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
             builder.setValues("content", contents);
         }
         message.metadata()
-                .ifPresent(metadata -> builder.set(META, serializeSamplingMessageMetadata(metadata)));
+                .ifPresent(metadata -> builder.set(META, metadata.asJsonObject()
+                        .orElseThrow(() -> new McpSamplingException("Sampling message metadata must be a JSON object"))));
         return builder;
     }
 
@@ -105,7 +106,8 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
         }
         if (serializeMetadata) {
             content.metadata()
-                    .ifPresent(metadata -> builder.set(META, serializeSamplingContentMetadata(metadata)));
+                    .ifPresent(metadata -> builder.set(META, metadata.asJsonObject()
+                            .orElseThrow(() -> new McpSamplingException("Sampling content metadata must be a JSON object"))));
         }
         if (content instanceof McpSamplingAnnotatedContent annotated) {
             annotated.annotations().ifPresent(annotations -> builder.set("annotations", toJson(annotations)));
@@ -201,7 +203,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                 .name(object.stringValue("name").orElseThrow())
                 .input(new McpParameters(input));
         object.objectValue(META)
-                .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                .map(McpParameters::new)
                 .ifPresent(builder::metadata);
         return builder.build();
     }
@@ -234,7 +236,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                 .toolUseId(object.stringValue("toolUseId").orElseThrow())
                 .result(resultBuilder.build());
         object.objectValue(META)
-                .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                .map(McpParameters::new)
                 .ifPresent(builder::metadata);
         return builder.build();
     }
@@ -246,7 +248,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                         .text(content.stringValue("text").orElseThrow());
                 parseAnnotations(content).ifPresent(builder::annotations);
                 content.objectValue(META)
-                        .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                        .map(McpParameters::new)
                         .ifPresent(builder::metadata);
                 yield builder.build();
             }
@@ -258,7 +260,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                         .mediaType(MediaTypes.create(content.stringValue("mimeType").orElseThrow()));
                 parseAnnotations(content).ifPresent(builder::annotations);
                 content.objectValue(META)
-                        .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                        .map(McpParameters::new)
                         .ifPresent(builder::metadata);
                 yield builder.build();
             }
@@ -270,7 +272,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                         .mediaType(MediaTypes.create(content.stringValue("mimeType").orElseThrow()));
                 parseAnnotations(content).ifPresent(builder::annotations);
                 content.objectValue(META)
-                        .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                        .map(McpParameters::new)
                         .ifPresent(builder::metadata);
                 yield builder.build();
             }
@@ -294,7 +296,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                 .forEach(builder::addIcon));
         parseAnnotations(content).ifPresent(builder::annotations);
         content.objectValue(META)
-                .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                .map(McpParameters::new)
                 .ifPresent(builder::metadata);
         return builder.build();
     }
@@ -311,7 +313,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                     .text(resource.stringValue("text").orElseThrow());
             parseAnnotations(content).ifPresent(builder::annotations);
             content.objectValue(META)
-                    .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                    .map(McpParameters::new)
                     .ifPresent(builder::metadata);
             return builder.build();
         }
@@ -325,7 +327,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                               .orElseThrow());
         parseAnnotations(content).ifPresent(builder::annotations);
         content.objectValue(META)
-                .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                .map(McpParameters::new)
                 .ifPresent(builder::metadata);
         return builder.build();
     }
@@ -437,11 +439,4 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
         }
     }
 
-    private JsonObject serializeSamplingMessageMetadata(Object metadata) {
-        try {
-            return McpJsonBinding.serializeObject(metadata);
-        } catch (RuntimeException e) {
-            throw new McpSamplingException("Sampling message metadata must be a JSON object", e);
-        }
-    }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
@@ -159,8 +159,9 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
 
     private JsonObject.Builder toJson(McpSamplingToolResultContent content) {
         McpToolResult result = content.result();
+        List<McpToolContent> resultContents = McpToolSupport.aggregateContent(result);
         List<JsonValue> contents = new ArrayList<>();
-        for (McpToolContent resultContent : McpToolSupport.aggregateContent(result)) {
+        for (McpToolContent resultContent : resultContents) {
             toJson(resultContent).map(JsonObject.Builder::build).ifPresent(contents::add);
         }
         JsonObject.Builder builder = JsonObject.builder()
@@ -170,7 +171,16 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                 .set("isError", result.error());
         result.structuredContent()
                 .map(McpJsonBinding::serializeObject)
-                .ifPresent(structured -> builder.set("structuredContent", structured));
+                .ifPresent(structured -> {
+                    builder.set("structuredContent", structured);
+                    if (resultContents.stream().noneMatch(McpToolTextContent.class::isInstance)) {
+                        McpToolContent text = McpToolTextContent.builder().text(structured.toString()).build();
+                        toJson(text).ifPresent(serialized -> {
+                            contents.add(serialized.build());
+                            builder.setValues("content", contents);
+                        });
+                    }
+                });
         return builder;
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
@@ -85,24 +85,28 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
             builder.setValues("content", contents);
         }
         message.metadata()
-                .ifPresent(metadata -> builder.set(META, metadata.asJsonObject()
-                        .orElseThrow(() -> new McpSamplingException("Sampling message metadata must be a JSON object"))));
+                .ifPresent(metadata -> builder.set(META, serializeSamplingMessageMetadata(metadata)));
         return builder;
     }
 
     @Override
     public JsonObject.Builder toJson(McpSamplingContent content) {
         JsonObject.Builder builder;
+        boolean serializeMetadata;
         if (content instanceof McpSamplingToolUseContent toolUse) {
             builder = toJson(toolUse);
+            serializeMetadata = true;
         } else if (content instanceof McpSamplingToolResultContent toolResult) {
             builder = toJson(toolResult);
+            serializeMetadata = true;
         } else {
             builder = super.toJson(content);
+            serializeMetadata = false;
         }
-        content.metadata()
-                .ifPresent(metadata -> builder.set(META, metadata.asJsonObject()
-                        .orElseThrow(() -> new McpSamplingException("Sampling content metadata must be a JSON object"))));
+        if (serializeMetadata) {
+            content.metadata()
+                    .ifPresent(metadata -> builder.set(META, serializeSamplingContentMetadata(metadata)));
+        }
         if (content instanceof McpSamplingAnnotatedContent annotated) {
             annotated.annotations().ifPresent(annotations -> builder.set("annotations", toJson(annotations)));
         }
@@ -197,7 +201,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                 .name(object.stringValue("name").orElseThrow())
                 .input(new McpParameters(input));
         object.objectValue(META)
-                .map(McpParameters::new)
+                .map(value -> McpJsonBinding.deserialize(value, Object.class))
                 .ifPresent(builder::metadata);
         return builder.build();
     }
@@ -230,7 +234,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                 .toolUseId(object.stringValue("toolUseId").orElseThrow())
                 .result(resultBuilder.build());
         object.objectValue(META)
-                .map(McpParameters::new)
+                .map(value -> McpJsonBinding.deserialize(value, Object.class))
                 .ifPresent(builder::metadata);
         return builder.build();
     }
@@ -241,7 +245,9 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                 McpToolTextContent.Builder builder = McpToolTextContent.builder()
                         .text(content.stringValue("text").orElseThrow());
                 parseAnnotations(content).ifPresent(builder::annotations);
-                content.objectValue(META).map(McpParameters::new).ifPresent(builder::metadata);
+                content.objectValue(META)
+                        .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                        .ifPresent(builder::metadata);
                 yield builder.build();
             }
             case "image" -> {
@@ -251,7 +257,9 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                                       .orElseThrow())
                         .mediaType(MediaTypes.create(content.stringValue("mimeType").orElseThrow()));
                 parseAnnotations(content).ifPresent(builder::annotations);
-                content.objectValue(META).map(McpParameters::new).ifPresent(builder::metadata);
+                content.objectValue(META)
+                        .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                        .ifPresent(builder::metadata);
                 yield builder.build();
             }
             case "audio" -> {
@@ -261,7 +269,9 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                                       .orElseThrow())
                         .mediaType(MediaTypes.create(content.stringValue("mimeType").orElseThrow()));
                 parseAnnotations(content).ifPresent(builder::annotations);
-                content.objectValue(META).map(McpParameters::new).ifPresent(builder::metadata);
+                content.objectValue(META)
+                        .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                        .ifPresent(builder::metadata);
                 yield builder.build();
             }
             case "resource_link" -> parseToolResourceLink(content);
@@ -283,7 +293,9 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                 .map(this::parseIcon)
                 .forEach(builder::addIcon));
         parseAnnotations(content).ifPresent(builder::annotations);
-        content.objectValue(META).map(McpParameters::new).ifPresent(builder::metadata);
+        content.objectValue(META)
+                .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                .ifPresent(builder::metadata);
         return builder.build();
     }
 
@@ -298,7 +310,9 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                                        .orElse(MediaTypes.TEXT_PLAIN))
                     .text(resource.stringValue("text").orElseThrow());
             parseAnnotations(content).ifPresent(builder::annotations);
-            content.objectValue(META).map(McpParameters::new).ifPresent(builder::metadata);
+            content.objectValue(META)
+                    .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                    .ifPresent(builder::metadata);
             return builder.build();
         }
         McpToolBinaryResourceContent.Builder builder = McpToolBinaryResourceContent.builder()
@@ -310,7 +324,9 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                               .map(value -> Base64.getDecoder().decode(value))
                               .orElseThrow());
         parseAnnotations(content).ifPresent(builder::annotations);
-        content.objectValue(META).map(McpParameters::new).ifPresent(builder::metadata);
+        content.objectValue(META)
+                .map(value -> McpJsonBinding.deserialize(value, Object.class))
+                .ifPresent(builder::metadata);
         return builder.build();
     }
 
@@ -418,6 +434,14 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
         }
         if (toolUses.stream().map(McpSamplingToolUseContent::id).distinct().count() != toolUses.size()) {
             throw new McpSamplingException("Sampling tool use identifiers must be unique within a message");
+        }
+    }
+
+    private JsonObject serializeSamplingMessageMetadata(Object metadata) {
+        try {
+            return McpJsonBinding.serializeObject(metadata);
+        } catch (RuntimeException e) {
+            throw new McpSamplingException("Sampling message metadata must be a JSON object", e);
         }
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpLogger.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpLogger.java
@@ -61,13 +61,6 @@ public final class McpLogger extends McpFeature {
         sendNotification(level, data);
     }
 
-    private void sendNotification(Level level, Object data) {
-        if (level.ordinal() >= level().ordinal()) {
-            var notification = session.serializer().createLoggingNotification(level, name, data);
-            transport().send(notification);
-        }
-    }
-
     /**
      * Send a debug notification to the client.
      *
@@ -229,6 +222,13 @@ public final class McpLogger extends McpFeature {
      */
     void setLevel(McpLogger.Level level) {
         session.context().register(ContextClassifier.class, level);
+    }
+
+    private void sendNotification(Level level, Object data) {
+        if (level.ordinal() >= level().ordinal()) {
+            var notification = session.serializer().createLoggingNotification(level, name, data);
+            transport().send(notification);
+        }
     }
 
     /**

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpMetadata.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpMetadata.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 /**
  * MCP component that supports optional protocol metadata.
  */
-interface McpMetadata {
+public interface McpMetadata {
     /**
      * Optional protocol metadata represented by the {@code _meta} field.
      *

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpMetadata.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpMetadata.java
@@ -17,6 +17,9 @@ package io.helidon.extensions.mcp.server;
 
 import java.util.Optional;
 
+import io.helidon.json.JsonObject;
+import io.helidon.json.binding.Json;
+
 /**
  * MCP component that supports optional protocol metadata.
  */
@@ -27,9 +30,14 @@ public interface McpMetadata {
     String META = "_meta";
 
     /**
-     * Optional protocol metadata represented by the {@value #META} field.
+     * Optional protocol metadata represented by the {@value #META} field. Values supplied to builders are serialized using
+     * Helidon JSON binding and must produce a JSON object. Custom types must have a Helidon JSON converter, for example by
+     * annotating the type with {@link Json.Entity} and enabling Helidon JSON code generation.
+     *
+     * <p>Wire metadata is deserialized using Helidon JSON binding and represented by {@link JsonObject}. JSON-B annotations
+     * and unregistered POJOs are not supported.
      *
      * @return protocol metadata
      */
-    Optional<McpParameters> metadata();
+    Optional<Object> metadata();
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpMetadata.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpMetadata.java
@@ -17,9 +17,6 @@ package io.helidon.extensions.mcp.server;
 
 import java.util.Optional;
 
-import io.helidon.json.JsonObject;
-import io.helidon.json.binding.Json;
-
 /**
  * MCP component that supports optional protocol metadata.
  */
@@ -30,14 +27,10 @@ public interface McpMetadata {
     String META = "_meta";
 
     /**
-     * Optional protocol metadata represented by the {@value #META} field. Values supplied to builders are serialized using
-     * Helidon JSON binding and must produce a JSON object. Custom types must have a Helidon JSON converter, for example by
-     * annotating the type with {@link Json.Entity} and enabling Helidon JSON code generation.
-     *
-     * <p>Wire metadata is deserialized using Helidon JSON binding and represented by {@link JsonObject}. JSON-B annotations
-     * and unregistered POJOs are not supported.
+     * Optional protocol metadata represented by the {@value #META} field. Use {@link McpParameters#create(Object)} to create
+     * metadata from a value supported by Helidon JSON binding.
      *
      * @return protocol metadata
      */
-    Optional<Object> metadata();
+    Optional<McpParameters> metadata();
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpMetadata.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpMetadata.java
@@ -15,20 +15,16 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import io.helidon.builder.api.Prototype;
+import java.util.Optional;
 
-class McpSamplingTextMessageSupport {
-    private McpSamplingTextMessageSupport() {
-    }
-
+/**
+ * MCP component that supports optional protocol metadata.
+ */
+interface McpMetadata {
     /**
-     * Create a {@link io.helidon.extensions.mcp.server.McpSamplingTextMessage} instance from the provided text.
+     * Optional protocol metadata represented by the {@code _meta} field.
      *
-     * @param text text message
-     * @return sampling text message instance
+     * @return protocol metadata
      */
-    @Prototype.PrototypeFactoryMethod
-    static McpSamplingTextMessage create(String text) {
-        return McpSamplingTextMessage.builder().text(text).role(McpRole.ASSISTANT).build();
-    }
+    Optional<McpParameters> metadata();
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpMetadata.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpMetadata.java
@@ -22,7 +22,12 @@ import java.util.Optional;
  */
 public interface McpMetadata {
     /**
-     * Optional protocol metadata represented by the {@code _meta} field.
+     * MCP protocol metadata field name.
+     */
+    String META = "_meta";
+
+    /**
+     * Optional protocol metadata represented by the {@value #META} field.
      *
      * @return protocol metadata
      */

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpParameters.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpParameters.java
@@ -74,12 +74,6 @@ public final class McpParameters {
         this.key = key;
     }
 
-    Optional<JsonObject> asJsonObject() {
-        return value instanceof JsonObject object
-                ? Optional.of(object)
-                : Optional.empty();
-    }
-
     /**
      * Get MCP parameter node.
      *
@@ -382,6 +376,12 @@ public final class McpParameters {
             return empty();
         }
         return OptionalValue.create(MAPPERS, key, McpJsonBinding.deserialize(value, type), type);
+    }
+
+    Optional<JsonObject> asJsonObject() {
+        return value instanceof JsonObject object
+                ? Optional.of(object)
+                : Optional.empty();
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpParameters.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpParameters.java
@@ -74,8 +74,10 @@ public final class McpParameters {
         this.key = key;
     }
 
-    JsonValue value() {
-        return value;
+    Optional<JsonObject> asJsonObject() {
+        return value instanceof JsonObject object
+                ? Optional.of(object)
+                : Optional.empty();
     }
 
     /**

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpParameters.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpParameters.java
@@ -59,8 +59,13 @@ public final class McpParameters {
      * Create parameters backed by a JSON object.
      *
      * @param value parameter values
+     * @return MCP parameters
      */
-    public McpParameters(JsonObject value) {
+    public static McpParameters create(JsonObject value) {
+        return new McpParameters(value);
+    }
+
+    McpParameters(JsonObject value) {
         this(Objects.requireNonNull(value, "value is null"), "key");
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpParameters.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpParameters.java
@@ -41,7 +41,7 @@ import io.helidon.json.binding.Json;
 import io.helidon.jsonrpc.core.JsonRpcParams;
 
 /**
- * MCP client parameters provided to {@link McpTool} and {@link McpPrompt}.
+ * JSON object wrapper used for MCP client parameters, protocol metadata, and sampling tool input.
  */
 public final class McpParameters {
     private static final Mappers MAPPERS = Mappers.create();
@@ -55,11 +55,6 @@ public final class McpParameters {
         this(params.asJsonValue(), "key");
     }
 
-    /**
-     * Create parameters backed by a JSON object.
-     *
-     * @param value parameter values
-     */
     McpParameters(JsonObject value) {
         this(Objects.requireNonNull(value, "value is null"), "key");
     }
@@ -67,6 +62,25 @@ public final class McpParameters {
     private McpParameters(JsonValue root, String key) {
         this.value = root;
         this.key = key;
+    }
+
+    /**
+     * Create parameters by serializing a value with Helidon JSON binding. The value must serialize to a JSON object. Custom
+     * types must have a Helidon JSON converter, for example by annotating the type with {@link Json.Entity} and enabling
+     * Helidon JSON code generation. JSON-B annotations and unregistered POJOs are not supported.
+     *
+     * @param value value to serialize
+     * @return MCP parameters
+     * @throws NullPointerException if {@code value} is {@code null}
+     * @throws IllegalArgumentException if the value cannot be serialized to a JSON object
+     */
+    public static McpParameters create(Object value) {
+        Objects.requireNonNull(value, "value is null");
+        try {
+            return new McpParameters(McpJsonBinding.serializeObject(value));
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException("value must serialize to a JSON object using Helidon JSON binding", e);
+        }
     }
 
     /**

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpParameters.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpParameters.java
@@ -60,7 +60,7 @@ public final class McpParameters {
      *
      * @param value parameter values
      */
-    public McpParameters(JsonObject value) {
+    McpParameters(JsonObject value) {
         this(Objects.requireNonNull(value, "value is null"), "key");
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpParameters.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpParameters.java
@@ -59,13 +59,8 @@ public final class McpParameters {
      * Create parameters backed by a JSON object.
      *
      * @param value parameter values
-     * @return MCP parameters
      */
-    public static McpParameters create(JsonObject value) {
-        return new McpParameters(value);
-    }
-
-    McpParameters(JsonObject value) {
+    public McpParameters(JsonObject value) {
         this(Objects.requireNonNull(value, "value is null"), "key");
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpParameters.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpParameters.java
@@ -55,9 +55,22 @@ public final class McpParameters {
         this(params.asJsonValue(), "key");
     }
 
+    /**
+     * Create parameters backed by a JSON object.
+     *
+     * @param value parameter values
+     */
+    public McpParameters(JsonObject value) {
+        this(Objects.requireNonNull(value, "value is null"), "key");
+    }
+
     private McpParameters(JsonValue root, String key) {
         this.value = root;
         this.key = key;
+    }
+
+    JsonValue value() {
+        return value;
     }
 
     /**

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpPendingResponses.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpPendingResponses.java
@@ -27,15 +27,13 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import io.helidon.json.JsonObject;
-
 /**
  * Pending JSON-RPC responses for an MCP session.
  */
 final class McpPendingResponses {
     private final Lock lock = new ReentrantLock();
     private final int capacity;
-    private final Map<Long, CompletableFuture<JsonObject>> responses = new HashMap<>();
+    private final Map<Long, CompletableFuture<McpResponse>> responses = new HashMap<>();
 
     private boolean active = true;
 
@@ -55,15 +53,15 @@ final class McpPendingResponses {
             if (responses.size() >= capacity) {
                 throw new McpInternalException("Maximum pending response count reached");
             }
-            CompletableFuture<JsonObject> response = new CompletableFuture<>();
+            CompletableFuture<McpResponse> response = new CompletableFuture<>();
             responses.put(requestId, response);
         } finally {
             lock.unlock();
         }
     }
 
-    void accept(long requestId, JsonObject response) {
-        CompletableFuture<JsonObject> pendingResponse;
+    void accept(long requestId, McpResponse response) {
+        CompletableFuture<McpResponse> pendingResponse;
         lock.lock();
         try {
             if (!active) {
@@ -78,8 +76,8 @@ final class McpPendingResponses {
         }
     }
 
-    Optional<JsonObject> poll(long requestId, Duration timeout) {
-        CompletableFuture<JsonObject> pendingResponse;
+    Optional<McpResponse> poll(long requestId, Duration timeout) {
+        CompletableFuture<McpResponse> pendingResponse;
         lock.lock();
         try {
             if (!active) {
@@ -118,7 +116,7 @@ final class McpPendingResponses {
     }
 
     void disconnect() {
-        List<CompletableFuture<JsonObject>> pending;
+        List<CompletableFuture<McpResponse>> pending;
         lock.lock();
         try {
             if (!active) {

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpPendingResponses.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpPendingResponses.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -73,6 +74,20 @@ final class McpPendingResponses {
         }
         if (pendingResponse != null) {
             pendingResponse.complete(response);
+        }
+    }
+
+    void abort(long requestId, RuntimeException exception) {
+        Objects.requireNonNull(exception, "exception is null");
+        CompletableFuture<McpResponse> pendingResponse;
+        lock.lock();
+        try {
+            pendingResponse = responses.get(requestId);
+        } finally {
+            lock.unlock();
+        }
+        if (pendingResponse != null) {
+            pendingResponse.completeExceptionally(exception);
         }
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpPendingResponses.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpPendingResponses.java
@@ -60,14 +60,14 @@ final class McpPendingResponses {
         }
     }
 
-    void accept(long requestId, McpResponse response) {
+    void accept(McpResponse response) {
         CompletableFuture<McpResponse> pendingResponse;
         lock.lock();
         try {
             if (!active) {
                 return;
             }
-            pendingResponse = responses.get(requestId);
+            pendingResponse = responses.get(response.id());
         } finally {
             lock.unlock();
         }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpPendingResponses.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpPendingResponses.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.server;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import io.helidon.common.LruCache;
+import io.helidon.json.JsonObject;
+
+/**
+ * Pending JSON-RPC responses for an MCP session.
+ */
+final class McpPendingResponses {
+    private final Lock lock = new ReentrantLock();
+    private final LruCache<Long, CompletableFuture<JsonObject>> responses;
+    private final List<CompletableFuture<JsonObject>> responseFutures = new ArrayList<>();
+
+    private boolean active = true;
+
+    McpPendingResponses(int capacity) {
+        responses = LruCache.create(capacity);
+    }
+
+    void prepare(long requestId) {
+        lock.lock();
+        try {
+            if (!active) {
+                throw new McpInternalException("Session disconnected");
+            }
+            if (responses.get(requestId).isPresent()) {
+                return;
+            }
+            if (responses.size() >= responses.capacity()) {
+                throw new McpInternalException("Maximum pending response count reached");
+            }
+            CompletableFuture<JsonObject> response = new CompletableFuture<>();
+            responses.put(requestId, response);
+            responseFutures.add(response);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    void accept(long requestId, JsonObject response) {
+        Optional<CompletableFuture<JsonObject>> pendingResponse;
+        lock.lock();
+        try {
+            if (!active) {
+                return;
+            }
+            pendingResponse = responses.get(requestId);
+        } finally {
+            lock.unlock();
+        }
+        pendingResponse.ifPresent(future -> future.complete(response));
+    }
+
+    Optional<JsonObject> poll(long requestId, Duration timeout) {
+        CompletableFuture<JsonObject> pendingResponse;
+        lock.lock();
+        try {
+            if (!active) {
+                throw new McpInternalException("Session disconnected");
+            }
+            pendingResponse = responses.get(requestId)
+                    .orElseThrow(() -> new McpInternalException("No pending response for request id " + requestId));
+        } finally {
+            lock.unlock();
+        }
+        try {
+            return Optional.of(pendingResponse.get(timeout.toMillis(), TimeUnit.MILLISECONDS));
+        } catch (TimeoutException e) {
+            return Optional.empty();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new McpInternalException("Session interrupted.", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw new McpInternalException("Unable to receive session response", cause);
+        } finally {
+            discard(requestId);
+        }
+    }
+
+    void discard(long requestId) {
+        lock.lock();
+        try {
+            responses.remove(requestId).ifPresent(responseFutures::remove);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    void disconnect() {
+        List<CompletableFuture<JsonObject>> pending;
+        lock.lock();
+        try {
+            if (!active) {
+                return;
+            }
+            active = false;
+            pending = List.copyOf(responseFutures);
+            responseFutures.clear();
+            responses.clear();
+        } finally {
+            lock.unlock();
+        }
+        var exception = new McpInternalException("Session disconnected");
+        pending.forEach(response -> response.completeExceptionally(exception));
+    }
+}

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpPendingResponses.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpPendingResponses.java
@@ -16,8 +16,9 @@
 package io.helidon.extensions.mcp.server;
 
 import java.time.Duration;
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -26,7 +27,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import io.helidon.common.LruCache;
 import io.helidon.json.JsonObject;
 
 /**
@@ -34,13 +34,13 @@ import io.helidon.json.JsonObject;
  */
 final class McpPendingResponses {
     private final Lock lock = new ReentrantLock();
-    private final LruCache<Long, CompletableFuture<JsonObject>> responses;
-    private final List<CompletableFuture<JsonObject>> responseFutures = new ArrayList<>();
+    private final int capacity;
+    private final Map<Long, CompletableFuture<JsonObject>> responses = new HashMap<>();
 
     private boolean active = true;
 
     McpPendingResponses(int capacity) {
-        responses = LruCache.create(capacity);
+        this.capacity = capacity;
     }
 
     void prepare(long requestId) {
@@ -49,22 +49,21 @@ final class McpPendingResponses {
             if (!active) {
                 throw new McpInternalException("Session disconnected");
             }
-            if (responses.get(requestId).isPresent()) {
+            if (responses.containsKey(requestId)) {
                 return;
             }
-            if (responses.size() >= responses.capacity()) {
+            if (responses.size() >= capacity) {
                 throw new McpInternalException("Maximum pending response count reached");
             }
             CompletableFuture<JsonObject> response = new CompletableFuture<>();
             responses.put(requestId, response);
-            responseFutures.add(response);
         } finally {
             lock.unlock();
         }
     }
 
     void accept(long requestId, JsonObject response) {
-        Optional<CompletableFuture<JsonObject>> pendingResponse;
+        CompletableFuture<JsonObject> pendingResponse;
         lock.lock();
         try {
             if (!active) {
@@ -74,7 +73,9 @@ final class McpPendingResponses {
         } finally {
             lock.unlock();
         }
-        pendingResponse.ifPresent(future -> future.complete(response));
+        if (pendingResponse != null) {
+            pendingResponse.complete(response);
+        }
     }
 
     Optional<JsonObject> poll(long requestId, Duration timeout) {
@@ -84,8 +85,10 @@ final class McpPendingResponses {
             if (!active) {
                 throw new McpInternalException("Session disconnected");
             }
-            pendingResponse = responses.get(requestId)
-                    .orElseThrow(() -> new McpInternalException("No pending response for request id " + requestId));
+            pendingResponse = responses.get(requestId);
+            if (pendingResponse == null) {
+                throw new McpInternalException("No pending response for request id " + requestId);
+            }
         } finally {
             lock.unlock();
         }
@@ -102,15 +105,13 @@ final class McpPendingResponses {
                 throw runtimeException;
             }
             throw new McpInternalException("Unable to receive session response", cause);
-        } finally {
-            discard(requestId);
         }
     }
 
     void discard(long requestId) {
         lock.lock();
         try {
-            responses.remove(requestId).ifPresent(responseFutures::remove);
+            responses.remove(requestId);
         } finally {
             lock.unlock();
         }
@@ -124,8 +125,7 @@ final class McpPendingResponses {
                 return;
             }
             active = false;
-            pending = List.copyOf(responseFutures);
-            responseFutures.clear();
+            pending = List.copyOf(responses.values());
             responses.clear();
         } finally {
             lock.unlock();

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpProgress.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpProgress.java
@@ -117,10 +117,6 @@ public final class McpProgress extends McpFeature {
         private McpProgressListener() {
         }
 
-        static McpProgressListener create() {
-            return INSTANCE.get();
-        }
-
         @Override
         public void beforeRequest(McpParameters parameters, McpFeatures features) {
             var progressToken = parameters.get("_meta").get("progressToken");
@@ -135,6 +131,10 @@ public final class McpProgress extends McpFeature {
         @Override
         public void afterRequest(McpParameters parameters, McpFeatures features) {
             features.progress().stopSending();
+        }
+
+        static McpProgressListener create() {
+            return INSTANCE.get();
         }
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpProgress.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpProgress.java
@@ -17,7 +17,7 @@ package io.helidon.extensions.mcp.server;
 
 import java.util.Objects;
 
-import io.helidon.common.LazyValue;
+import io.helidon.service.registry.Service;
 
 import static io.helidon.extensions.mcp.server.McpMetadata.META;
 
@@ -109,16 +109,8 @@ public final class McpProgress extends McpFeature {
      * The progress listener look for progress token inside request
      * and set it in the associate progress feature instance.
      */
+    @Service.Singleton
     static class McpProgressListener implements McpFeatureLifecycle {
-        /**
-         * The listener being static and used for every session, a singleton
-         * avoid creation of unnecessary instance per session.
-         */
-        private static final LazyValue<McpProgressListener> INSTANCE = LazyValue.create(McpProgressListener::new);
-
-        private McpProgressListener() {
-        }
-
         @Override
         public void beforeRequest(McpParameters parameters, McpFeatures features) {
             var progressToken = parameters.get(META).get("progressToken");
@@ -133,10 +125,6 @@ public final class McpProgress extends McpFeature {
         @Override
         public void afterRequest(McpParameters parameters, McpFeatures features) {
             features.progress().stopSending();
-        }
-
-        static McpProgressListener create() {
-            return INSTANCE.get();
         }
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpProgress.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpProgress.java
@@ -19,6 +19,8 @@ import java.util.Objects;
 
 import io.helidon.common.LazyValue;
 
+import static io.helidon.extensions.mcp.server.McpMetadata.META;
+
 /**
  * Progress notification to the client.
  */
@@ -119,7 +121,7 @@ public final class McpProgress extends McpFeature {
 
         @Override
         public void beforeRequest(McpParameters parameters, McpFeatures features) {
-            var progressToken = parameters.get("_meta").get("progressToken");
+            var progressToken = parameters.get(META).get("progressToken");
             if (progressToken.isNumber()) {
                 features.progress().token(progressToken.asInteger().get());
             }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpPromptRequestImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpPromptRequestImpl.java
@@ -45,7 +45,7 @@ final class McpPromptRequestImpl implements McpPromptRequest {
     }
 
     @Override
-    public Optional<McpParameters> metadata() {
+    public Optional<Object> metadata() {
         return request.metadata();
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpPromptRequestImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpPromptRequestImpl.java
@@ -15,6 +15,8 @@
  */
 package io.helidon.extensions.mcp.server;
 
+import java.util.Optional;
+
 import io.helidon.common.context.Context;
 
 final class McpPromptRequestImpl implements McpPromptRequest {
@@ -43,8 +45,8 @@ final class McpPromptRequestImpl implements McpPromptRequest {
     }
 
     @Override
-    public McpParameters meta() {
-        return request.meta();
+    public Optional<McpParameters> metadata() {
+        return request.metadata();
     }
 
     @Override

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpPromptRequestImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpPromptRequestImpl.java
@@ -45,7 +45,7 @@ final class McpPromptRequestImpl implements McpPromptRequest {
     }
 
     @Override
-    public Optional<Object> metadata() {
+    public Optional<McpParameters> metadata() {
         return request.metadata();
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpRequestBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpRequestBlueprint.java
@@ -31,9 +31,9 @@ interface McpRequestBlueprint {
     McpParameters parameters();
 
     /**
-     * MCP client {@code _meta} parameter.
+     * MCP client {@value McpMetadata#META} parameter.
      *
-     * @return the {@code _meta} parameter
+     * @return the {@value McpMetadata#META} parameter
      */
     McpParameters meta();
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpRequestBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpRequestBlueprint.java
@@ -31,17 +31,6 @@ interface McpRequestBlueprint extends McpMetadata {
     McpParameters parameters();
 
     /**
-     * MCP client {@value McpMetadata#META} parameter.
-     *
-     * @return the {@value McpMetadata#META} parameter
-     * @deprecated use {@link #metadata()}
-     */
-    @Deprecated(since = "1.3.0", forRemoval = true)
-    default McpParameters meta() {
-        return metadata().orElseGet(() -> parameters().get(META));
-    }
-
-    /**
      * MCP client features.
      *
      * @return the features

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpRequestBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpRequestBlueprint.java
@@ -38,7 +38,10 @@ interface McpRequestBlueprint extends McpMetadata {
      */
     @Deprecated(since = "1.3.0", forRemoval = true)
     default McpParameters meta() {
-        return metadata().orElseGet(() -> parameters().get(META));
+        return metadata()
+                .map(McpJsonBinding::serializeObject)
+                .map(McpParameters::new)
+                .orElseGet(() -> parameters().get(META));
     }
 
     /**

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpRequestBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpRequestBlueprint.java
@@ -22,7 +22,7 @@ import io.helidon.common.context.Context;
  * A representation of an MCP request.
  */
 @Prototype.Blueprint
-interface McpRequestBlueprint {
+interface McpRequestBlueprint extends McpMetadata {
     /**
      * MCP client parameters.
      *
@@ -34,8 +34,12 @@ interface McpRequestBlueprint {
      * MCP client {@value McpMetadata#META} parameter.
      *
      * @return the {@value McpMetadata#META} parameter
+     * @deprecated use {@link #metadata()}
      */
-    McpParameters meta();
+    @Deprecated(since = "1.3.0", forRemoval = true)
+    default McpParameters meta() {
+        return metadata().orElseGet(() -> parameters().get(META));
+    }
 
     /**
      * MCP client features.

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpRequestBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpRequestBlueprint.java
@@ -38,10 +38,7 @@ interface McpRequestBlueprint extends McpMetadata {
      */
     @Deprecated(since = "1.3.0", forRemoval = true)
     default McpParameters meta() {
-        return metadata()
-                .map(McpJsonBinding::serializeObject)
-                .map(McpParameters::new)
-                .orElseGet(() -> parameters().get(META));
+        return metadata().orElseGet(() -> parameters().get(META));
     }
 
     /**

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceRequestImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceRequestImpl.java
@@ -33,7 +33,7 @@ final class McpResourceRequestImpl implements McpResourceRequest {
     }
 
     @Override
-    public Optional<Object> metadata() {
+    public Optional<McpParameters> metadata() {
         return request.metadata();
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceRequestImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceRequestImpl.java
@@ -16,6 +16,7 @@
 package io.helidon.extensions.mcp.server;
 
 import java.net.URI;
+import java.util.Optional;
 
 import io.helidon.common.context.Context;
 
@@ -32,8 +33,8 @@ final class McpResourceRequestImpl implements McpResourceRequest {
     }
 
     @Override
-    public McpParameters meta() {
-        return request.meta();
+    public Optional<McpParameters> metadata() {
+        return request.metadata();
     }
 
     @Override

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceRequestImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceRequestImpl.java
@@ -33,7 +33,7 @@ final class McpResourceRequestImpl implements McpResourceRequest {
     }
 
     @Override
-    public Optional<McpParameters> metadata() {
+    public Optional<Object> metadata() {
         return request.metadata();
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResponse.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResponse.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.server;
+
+import io.helidon.common.context.Context;
+import io.helidon.json.JsonObject;
+
+/**
+ * An MCP client response and the context of the request that delivered it.
+ */
+sealed interface McpResponse permits McpResponseImpl {
+    /**
+     * JSON-RPC response.
+     *
+     * @return response object
+     */
+    JsonObject asJsonObject();
+
+    /**
+     * Context of the request that delivered the response.
+     *
+     * @return request context
+     */
+    Context requestContext();
+}

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResponse.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResponse.java
@@ -23,6 +23,13 @@ import io.helidon.json.JsonObject;
  */
 sealed interface McpResponse permits McpResponseImpl {
     /**
+     * Identifier of the JSON-RPC request.
+     *
+     * @return request identifier
+     */
+    long id();
+
+    /**
      * JSON-RPC response.
      *
      * @return response object

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResponseImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResponseImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.server;
+
+import java.util.Objects;
+
+import io.helidon.common.context.Context;
+import io.helidon.json.JsonObject;
+
+final class McpResponseImpl implements McpResponse {
+    private final JsonObject response;
+    private final Context requestContext;
+
+    McpResponseImpl(JsonObject response, Context requestContext) {
+        this.response = Objects.requireNonNull(response, "response is null");
+        this.requestContext = Objects.requireNonNull(requestContext, "request context is null");
+    }
+
+    @Override
+    public JsonObject asJsonObject() {
+        return response;
+    }
+
+    @Override
+    public Context requestContext() {
+        return requestContext;
+    }
+}

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResponseImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResponseImpl.java
@@ -18,15 +18,31 @@ package io.helidon.extensions.mcp.server;
 import java.util.Objects;
 
 import io.helidon.common.context.Context;
+import io.helidon.json.JsonException;
 import io.helidon.json.JsonObject;
 
 final class McpResponseImpl implements McpResponse {
+    private final long id;
     private final JsonObject response;
     private final Context requestContext;
 
     McpResponseImpl(JsonObject response, Context requestContext) {
         this.response = Objects.requireNonNull(response, "response is null");
         this.requestContext = Objects.requireNonNull(requestContext, "request context is null");
+        try {
+            this.id = response.value("id")
+                    .orElseThrow(() -> new JsonException("Response id is missing"))
+                    .asNumber()
+                    .bigDecimalValue()
+                    .longValueExact();
+        } catch (ArithmeticException e) {
+            throw new JsonException("Response id must be an integer", e);
+        }
+    }
+
+    @Override
+    public long id() {
+        return id;
     }
 
     @Override

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpRole.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpRole.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package io.helidon.extensions.mcp.server;
+
+import java.util.Locale;
 
 /**
  * Prompt Role.
@@ -35,6 +37,6 @@ public enum McpRole {
      * @return name
      */
     String text() {
-        return this.name().toLowerCase();
+        return this.name().toLowerCase(Locale.ROOT);
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpRoots.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpRoots.java
@@ -74,13 +74,18 @@ public final class McpRoots extends McpFeature {
     private List<McpRoot> sendListRoot(Duration timeout) {
         long id = session().jsonRpcId();
         JsonObject request = session().serializer().createJsonRpcRequest(id, METHOD_ROOTS_LIST).build();
-        transport().send(request);
-        JsonObject response = session().pollResponse(id, timeout);
-        List<McpRoot> updatedRoots = session().serializer().parseRoots(response);
-        roots.clear();
-        roots.addAll(updatedRoots);
-        session().context().register(McpRootClassifier.class, false);
-        return roots;
+        session().prepareResponse(id);
+        try {
+            transport().send(request);
+            JsonObject response = session().pollResponse(id, timeout);
+            List<McpRoot> updatedRoots = session().serializer().parseRoots(response);
+            roots.clear();
+            roots.addAll(updatedRoots);
+            session().context().register(McpRootClassifier.class, false);
+            return roots;
+        } finally {
+            session().discardResponse(id);
+        }
     }
 
     static class McpRootClassifier {

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpRoots.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpRoots.java
@@ -77,8 +77,9 @@ public final class McpRoots extends McpFeature {
         session().prepareResponse(id);
         try {
             transport().send(request);
-            JsonObject response = session().pollResponse(id, timeout);
-            List<McpRoot> updatedRoots = session().serializer().parseRoots(response);
+            McpResponse response = session().pollResponse(id, timeout)
+                    .orElseThrow(() -> new McpRootException("response timeout"));
+            List<McpRoot> updatedRoots = session().serializer().parseRoots(response.asJsonObject());
             roots.clear();
             roots.addAll(updatedRoots);
             session().context().register(McpRootClassifier.class, false);

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
@@ -105,7 +105,16 @@ public final class McpSampling extends McpFeature {
      * @throws io.helidon.extensions.mcp.server.McpSamplingException when an error occurs
      */
     public McpSamplingResponse request(McpSamplingRequest request) throws McpSamplingException {
-        validateRequest(request);
+        if (!enabled) {
+            throw new McpSamplingException("Sampling feature is not supported by client");
+        }
+        if (request.usesContext() && !enabledContext) {
+            throw new McpSamplingException("Sampling context is not supported by client");
+        }
+        if (request.usesTool() && !enabledTools) {
+            throw new McpSamplingException("Sampling tools are not supported by client");
+        }
+
         Map<String, McpTool> tools = samplingTools(request.tools());
         List<McpTool> toolDefinitions = List.copyOf(tools.values());
         Set<String> toolUseIds = samplingToolUseIds(request.messages());
@@ -179,18 +188,6 @@ public final class McpSampling extends McpFeature {
         }
         if (features.cancellation().result().isRequested()) {
             throw new McpSamplingException("Sampling request cancelled");
-        }
-    }
-
-    private void validateRequest(McpSamplingRequest request) {
-        if (!enabled) {
-            throw new McpSamplingException("Sampling feature is not supported by client");
-        }
-        if (request.usesContext() && !enabledContext) {
-            throw new McpSamplingException("Sampling context is not supported by client");
-        }
-        if (request.usesTool() && !enabledTools) {
-            throw new McpSamplingException("Sampling tools are not supported by client");
         }
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
@@ -15,6 +15,11 @@
  */
 package io.helidon.extensions.mcp.server;
 
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import io.helidon.json.JsonObject;
@@ -23,13 +28,28 @@ import io.helidon.json.JsonObject;
  * MCP Sampling feature.
  */
 public final class McpSampling extends McpFeature {
+    static final int DEFAULT_MAX_TOOL_ITERATIONS = 10;
+
+    private static final System.Logger LOGGER = System.getLogger(McpSampling.class.getName());
+
+    private final McpFeatures features;
     private final boolean enabled;
     private final boolean enabledContext;
+    private final boolean enabledTools;
+    private final int maxToolIterations;
+    private final List<McpTool> registeredTools;
 
-    McpSampling(McpSession session, McpTransport transport) {
+    McpSampling(McpSession session, McpTransport transport, McpFeatures features) {
         super(session, transport);
+        this.features = features;
         this.enabled = session.capabilities().contains(McpCapability.SAMPLING);
         this.enabledContext = session.capabilities().contains(McpCapability.SAMPLING_CONTEXT);
+        this.enabledTools = session.capabilities().contains(McpCapability.SAMPLING_TOOLS);
+        McpServerConfig config = session.context()
+                .get(McpServerConfigBlueprint.class, McpServerConfig.class)
+                .orElseThrow(() -> new McpInternalException("MCP server configuration not found"));
+        this.maxToolIterations = config.maxSamplingToolIterations();
+        this.registeredTools = config.tools();
     }
 
     /**
@@ -53,7 +73,18 @@ public final class McpSampling extends McpFeature {
     }
 
     /**
-     * Send the provided sampling request to the client and return its response.
+     * Whether the connected client supports sampling with tools.
+     *
+     * @return {@code true} if the connected client supports sampling with tools,
+     * {@code false} otherwise
+     */
+    public boolean enabledTools() {
+        return enabledTools;
+    }
+
+    /**
+     * Send the provided sampling request to the client and return its final response. If a response requests tools,
+     * each matching selected server tool is invoked and its result is submitted automatically before sampling continues.
      *
      * @param request sampling request
      * @return sampling response
@@ -66,26 +97,170 @@ public final class McpSampling extends McpFeature {
     }
 
     /**
-     * Send the provided sampling request to the client and return its response.
+     * Send the provided sampling request to the client and return its final response. If a response requests tools,
+     * each matching selected server tool is invoked and its result is submitted automatically before sampling continues.
      *
      * @param request sampling request
      * @return sampling response
      * @throws io.helidon.extensions.mcp.server.McpSamplingException when an error occurs
      */
     public McpSamplingResponse request(McpSamplingRequest request) throws McpSamplingException {
+        validateRequest(request);
+        Map<String, McpTool> tools = samplingTools(request.tools());
+        List<McpTool> toolDefinitions = List.copyOf(tools.values());
+        Set<String> toolUseIds = samplingToolUseIds(request.messages());
+        McpSamplingRequest currentRequest = request;
+        int toolIterations = 0;
+
+        while (true) {
+            McpSamplingResponse response = requestOnce(currentRequest, toolDefinitions);
+            List<McpSamplingToolUseContent> toolUses = response.message().contents().stream()
+                    .filter(McpSamplingToolUseContent.class::isInstance)
+                    .map(McpSamplingToolUseContent.class::cast)
+                    .toList();
+            if (toolUses.isEmpty()) {
+                if (response.stopReason().filter(reason -> reason == McpStopReason.TOOL_USE).isPresent()) {
+                    throw new McpSamplingException("Sampling response stopped for tool use without tool use content");
+                }
+                if (currentRequest.toolChoice().filter(choice -> choice == McpToolChoice.REQUIRED).isPresent()) {
+                    throw new McpSamplingException("Sampling response did not use a required tool");
+                }
+                return response;
+            }
+            if (!enabledTools) {
+                throw new McpSamplingException("Sampling tools are not supported by client");
+            }
+            if (toolIterations == maxToolIterations) {
+                throw new McpSamplingException("Sampling tool iteration limit reached");
+            }
+            if (currentRequest.toolChoice().filter(choice -> choice == McpToolChoice.NONE).isPresent()) {
+                throw new McpSamplingException("Sampling client returned a tool use when tool choice is none");
+            }
+            for (McpSamplingToolUseContent toolUse : toolUses) {
+                if (!toolUseIds.add(toolUse.id())) {
+                    throw new McpSamplingException("Sampling tool use identifier was reused: " + toolUse.id());
+                }
+            }
+
+            McpSamplingMessage.Builder results = McpSamplingMessage.builder().role(McpRole.USER);
+            for (McpSamplingToolUseContent toolUse : toolUses) {
+                results.addContent(McpSamplingToolResultContent.builder()
+                                           .toolUseId(toolUse.id())
+                                           .result(invokeTool(tools, toolUse))
+                                           .build());
+            }
+
+            McpSamplingRequest.Builder nextRequest = McpSamplingRequest.builder(currentRequest)
+                    .addMessage(response.message())
+                    .addMessage(results.build());
+            toolIterations++;
+            if (toolIterations == maxToolIterations) {
+                nextRequest.toolChoice(McpToolChoice.NONE);
+            } else if (currentRequest.toolChoice()
+                    .filter(choice -> choice == McpToolChoice.REQUIRED)
+                    .isPresent()) {
+                nextRequest.toolChoice(McpToolChoice.AUTO);
+            }
+            currentRequest = nextRequest.build();
+        }
+    }
+
+    private void validateRequest(McpSamplingRequest request) {
         if (!enabled) {
             throw new McpSamplingException("Sampling feature is not supported by client");
         }
-        if (request.includeContext()
-                        .filter(context -> context != McpIncludeContext.NONE)
-                        .isPresent()
-                && !enabledContext) {
+        if (request.usesContext() && !enabledContext) {
             throw new McpSamplingException("Sampling context is not supported by client");
         }
+        if (request.usesTool() && !enabledTools) {
+            throw new McpSamplingException("Sampling tools are not supported by client");
+        }
+    }
+
+    private McpSamplingResponse requestOnce(McpSamplingRequest request, List<McpTool> tools) {
         long id = session().jsonRpcId();
-        JsonObject payload = session().serializer().createSamplingRequest(id, request);
-        transport().send(payload);
-        JsonObject response = session().pollResponse(id, request.timeout());
-        return session().serializer().createSamplingResponse(response);
+        JsonObject payload = session().serializer().createSamplingRequest(id, request, tools);
+        session().prepareResponse(id);
+        try {
+            transport().send(payload);
+            JsonObject response = session().pollResponse(id, request.timeout());
+            return session().serializer().createSamplingResponse(response);
+        } finally {
+            session().discardResponse(id);
+        }
+    }
+
+    private Map<String, McpTool> samplingTools(List<String> toolNames) {
+        Map<String, McpTool> tools = new LinkedHashMap<>();
+        for (String toolName : toolNames) {
+            List<McpTool> matchingTools = registeredTools.stream()
+                    .filter(candidate -> toolName.equals(candidate.name()))
+                    .toList();
+            if (matchingTools.isEmpty()) {
+                throw new McpSamplingException("Sampling tool is not registered: " + toolName);
+            }
+            if (matchingTools.size() > 1) {
+                throw new McpSamplingException("Registered sampling tool names must be unique: " + toolName);
+            }
+            McpTool duplicate = tools.putIfAbsent(toolName, matchingTools.getFirst());
+            if (duplicate != null) {
+                throw new McpSamplingException("Sampling tool names must be unique: " + toolName);
+            }
+        }
+        return tools;
+    }
+
+    private Set<String> samplingToolUseIds(List<McpSamplingMessage> messages) {
+        Set<String> toolUseIds = new HashSet<>();
+        messages.stream()
+                .flatMap(message -> message.contents().stream())
+                .filter(McpSamplingToolUseContent.class::isInstance)
+                .map(McpSamplingToolUseContent.class::cast)
+                .map(McpSamplingToolUseContent::id)
+                .forEach(id -> {
+                    if (!toolUseIds.add(id)) {
+                        throw new McpSamplingException("Sampling tool use identifier was reused: " + id);
+                    }
+                });
+        return toolUseIds;
+    }
+
+    private McpToolResult invokeTool(Map<String, McpTool> tools, McpSamplingToolUseContent toolUse) {
+        McpTool tool = tools.get(toolUse.name());
+        if (tool == null) {
+            return createToolErrorResult("Tool with name " + toolUse.name() + " is not available");
+        }
+
+        JsonObject.Builder parametersBuilder = JsonObject.builder()
+                .set("name", toolUse.name())
+                .set("arguments", toolUse.input().value());
+        toolUse.metadata().ifPresent(metadata -> parametersBuilder.set("_meta", metadata.value()));
+        McpParameters parameters = new McpParameters(parametersBuilder.build());
+        McpRequest request = McpRequest.builder()
+                .parameters(parameters)
+                .meta(parameters.get("_meta"))
+                .features(features)
+                .protocolVersion(session().protocolVersion().text())
+                .sessionContext(session().context())
+                .requestContext(features.requestContext())
+                .build();
+        try {
+            McpToolResult result = tool.tool(new McpToolRequestImpl(request));
+            if (result == null) {
+                return createToolErrorResult("Tool with name " + toolUse.name() + " returned no result");
+            }
+            return result;
+        } catch (RuntimeException e) {
+            LOGGER.log(System.Logger.Level.TRACE, "Sampling tool execution failed: "
+                            + toolUse.name(), e);
+            return createToolErrorResult("Tool with name " + toolUse.name() + " failed");
+        }
+    }
+
+    private McpToolResult createToolErrorResult(String message) {
+        return McpToolResult.builder()
+                .addTextContent(message)
+                .error(true)
+                .build();
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
@@ -230,9 +230,6 @@ public final class McpSampling extends McpFeature {
                                 + toolUse.name(), e);
                         toolResult = createToolErrorResult("Tool with name " + toolUse.name() + " failed");
                     }
-                    if (toolResult == null) {
-                        toolResult = createToolErrorResult("Tool with name " + toolUse.name() + " returned no result");
-                    }
                 }
                 results.addContent(McpSamplingToolResultContent.builder()
                                            .toolUseId(toolUse.id())

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
@@ -219,11 +219,13 @@ public final class McpSampling extends McpFeature {
                             .set("name", toolUse.name())
                             .set("arguments", toolUse.input().asJsonObject().orElseThrow());
                     toolUse.metadata().ifPresent(metadata ->
-                            paramsBuilder.set(META, McpJsonBinding.serializeObject(metadata)));
+                            paramsBuilder.set(META, metadata.asJsonObject().orElseThrow()));
                     McpParameters parameters = new McpParameters(paramsBuilder.build());
                     McpRequest toolRequest = McpRequest.builder()
                             .parameters(parameters)
-                            .update(builder -> parameters.get(META).as(JsonObject.class).ifPresent(builder::metadata))
+                            .update(builder -> parameters.get(META).as(JsonObject.class)
+                                    .map(McpParameters::new)
+                                    .ifPresent(builder::metadata))
                             .features(features)
                             .protocolVersion(session().protocolVersion().text())
                             .sessionContext(session().context())

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
@@ -232,7 +232,7 @@ public final class McpSampling extends McpFeature {
                     McpParameters parameters = new McpParameters(paramsBuilder.build());
                     McpRequest toolRequest = McpRequest.builder()
                             .parameters(parameters)
-                            .meta(parameters.get(META))
+                            .update(builder -> parameters.get(META).ifPresent(builder::metadata))
                             .features(features)
                             .protocolVersion(session().protocolVersion().text())
                             .sessionContext(session().context())

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
@@ -210,11 +210,11 @@ public final class McpSampling extends McpFeature {
                 if (tool == null) {
                     toolResult = createToolErrorResult("Tool with name " + toolUse.name() + " is not available");
                 } else {
-                    JsonObject.Builder parametersBuilder = JsonObject.builder()
+                    JsonObject.Builder paramsBuilder = JsonObject.builder()
                             .set("name", toolUse.name())
-                            .set("arguments", toolUse.input().value());
-                    toolUse.metadata().ifPresent(metadata -> parametersBuilder.set("_meta", metadata.value()));
-                    McpParameters parameters = new McpParameters(parametersBuilder.build());
+                            .set("arguments", toolUse.input().asJsonObject().orElseThrow());
+                    toolUse.metadata().ifPresent(metadata -> paramsBuilder.set("_meta", metadata.asJsonObject().orElseThrow()));
+                    McpParameters parameters = new McpParameters(paramsBuilder.build());
                     McpRequest toolRequest = McpRequest.builder()
                             .parameters(parameters)
                             .meta(parameters.get("_meta"))

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
@@ -114,7 +114,9 @@ public final class McpSampling extends McpFeature {
         int toolExecutions = 0;
 
         while (true) {
+            checkRequestActive();
             McpSamplingResponse response = requestOnce(currentRequest, toolDefinitions);
+            checkRequestActive();
             List<McpSamplingToolUseContent> toolUses = response.message().contents().stream()
                     .filter(McpSamplingToolUseContent.class::isInstance)
                     .map(McpSamplingToolUseContent.class::cast)
@@ -149,6 +151,7 @@ public final class McpSampling extends McpFeature {
 
             McpSamplingMessage.Builder results = McpSamplingMessage.builder().role(McpRole.USER);
             for (McpSamplingToolUseContent toolUse : toolUses) {
+                checkRequestActive();
                 results.addContent(McpSamplingToolResultContent.builder()
                                            .toolUseId(toolUse.id())
                                            .result(invokeTool(tools, toolUse))
@@ -167,6 +170,15 @@ public final class McpSampling extends McpFeature {
                 nextRequest.toolChoice(McpToolChoice.AUTO);
             }
             currentRequest = nextRequest.build();
+        }
+    }
+
+    private void checkRequestActive() {
+        if (session().state() == McpSession.State.DISCONNECTED) {
+            throw new McpInternalException("Session disconnected");
+        }
+        if (features.cancellation().result().isRequested()) {
+            throw new McpSamplingException("Sampling request cancelled");
         }
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
@@ -115,16 +115,60 @@ public final class McpSampling extends McpFeature {
             throw new McpSamplingException("Sampling tools are not supported by client");
         }
 
-        Map<String, McpTool> tools = samplingTools(request.tools());
+        Map<String, McpTool> tools = new LinkedHashMap<>();
+        if (!request.tools().isEmpty()) {
+            Map<String, McpTool> registeredToolsByName = new LinkedHashMap<>();
+            Set<String> duplicateRegisteredToolNames = new HashSet<>();
+            for (McpTool registeredTool : registeredTools) {
+                String registeredToolName = registeredTool.name();
+                McpTool existingTool = registeredToolsByName.putIfAbsent(registeredToolName, registeredTool);
+                if (existingTool != null) {
+                    duplicateRegisteredToolNames.add(registeredToolName);
+                }
+            }
+            for (String toolName : request.tools()) {
+                McpTool tool = registeredToolsByName.get(toolName);
+                if (tool == null) {
+                    throw new McpSamplingException("Sampling tool is not registered: " + toolName);
+                }
+                if (duplicateRegisteredToolNames.contains(toolName)) {
+                    throw new McpSamplingException("Registered sampling tool names must be unique: " + toolName);
+                }
+                McpTool duplicate = tools.putIfAbsent(toolName, tool);
+                if (duplicate != null) {
+                    throw new McpSamplingException("Sampling tool names must be unique: " + toolName);
+                }
+            }
+        }
         List<McpTool> toolDefinitions = List.copyOf(tools.values());
-        Set<String> toolUseIds = samplingToolUseIds(request.messages());
+        Set<String> toolUseIds = new HashSet<>();
+        request.messages().stream()
+                .flatMap(message -> message.contents().stream())
+                .filter(McpSamplingToolUseContent.class::isInstance)
+                .map(McpSamplingToolUseContent.class::cast)
+                .map(McpSamplingToolUseContent::id)
+                .forEach(id -> {
+                    if (!toolUseIds.add(id)) {
+                        throw new McpSamplingException("Sampling tool use identifier was reused: " + id);
+                    }
+                });
         McpSamplingRequest currentRequest = request;
         int toolIterations = 0;
         int toolExecutions = 0;
 
         while (true) {
             checkRequestActive();
-            McpSamplingResponse response = requestOnce(currentRequest, toolDefinitions);
+            long id = session().jsonRpcId();
+            JsonObject payload = session().serializer().createSamplingRequest(id, currentRequest, toolDefinitions);
+            session().prepareResponse(id);
+            McpSamplingResponse response;
+            try {
+                transport().send(payload);
+                JsonObject jsonResponse = session().pollResponse(id, currentRequest.timeout());
+                response = session().serializer().createSamplingResponse(jsonResponse);
+            } finally {
+                session().discardResponse(id);
+            }
             checkRequestActive();
             List<McpSamplingToolUseContent> toolUses = response.message().contents().stream()
                     .filter(McpSamplingToolUseContent.class::isInstance)
@@ -161,9 +205,38 @@ public final class McpSampling extends McpFeature {
             McpSamplingMessage.Builder results = McpSamplingMessage.builder().role(McpRole.USER);
             for (McpSamplingToolUseContent toolUse : toolUses) {
                 checkRequestActive();
+                McpTool tool = tools.get(toolUse.name());
+                McpToolResult toolResult;
+                if (tool == null) {
+                    toolResult = createToolErrorResult("Tool with name " + toolUse.name() + " is not available");
+                } else {
+                    JsonObject.Builder parametersBuilder = JsonObject.builder()
+                            .set("name", toolUse.name())
+                            .set("arguments", toolUse.input().value());
+                    toolUse.metadata().ifPresent(metadata -> parametersBuilder.set("_meta", metadata.value()));
+                    McpParameters parameters = new McpParameters(parametersBuilder.build());
+                    McpRequest toolRequest = McpRequest.builder()
+                            .parameters(parameters)
+                            .meta(parameters.get("_meta"))
+                            .features(features)
+                            .protocolVersion(session().protocolVersion().text())
+                            .sessionContext(session().context())
+                            .requestContext(features.requestContext())
+                            .build();
+                    try {
+                        toolResult = tool.tool(new McpToolRequestImpl(toolRequest));
+                    } catch (RuntimeException e) {
+                        LOGGER.log(System.Logger.Level.TRACE, "Sampling tool execution failed: "
+                                + toolUse.name(), e);
+                        toolResult = createToolErrorResult("Tool with name " + toolUse.name() + " failed");
+                    }
+                    if (toolResult == null) {
+                        toolResult = createToolErrorResult("Tool with name " + toolUse.name() + " returned no result");
+                    }
+                }
                 results.addContent(McpSamplingToolResultContent.builder()
                                            .toolUseId(toolUse.id())
-                                           .result(invokeTool(tools, toolUse))
+                                           .result(toolResult)
                                            .build());
             }
 
@@ -188,98 +261,6 @@ public final class McpSampling extends McpFeature {
         }
         if (features.cancellation().result().isRequested()) {
             throw new McpSamplingException("Sampling request cancelled");
-        }
-    }
-
-    private McpSamplingResponse requestOnce(McpSamplingRequest request, List<McpTool> tools) {
-        long id = session().jsonRpcId();
-        JsonObject payload = session().serializer().createSamplingRequest(id, request, tools);
-        session().prepareResponse(id);
-        try {
-            transport().send(payload);
-            JsonObject response = session().pollResponse(id, request.timeout());
-            return session().serializer().createSamplingResponse(response);
-        } finally {
-            session().discardResponse(id);
-        }
-    }
-
-    private Map<String, McpTool> samplingTools(List<String> toolNames) {
-        Map<String, McpTool> tools = new LinkedHashMap<>();
-        if (toolNames.isEmpty()) {
-            return tools;
-        }
-
-        Map<String, McpTool> registeredToolsByName = new LinkedHashMap<>();
-        Set<String> duplicateRegisteredToolNames = new HashSet<>();
-        for (McpTool registeredTool : registeredTools) {
-            String registeredToolName = registeredTool.name();
-            McpTool existingTool = registeredToolsByName.putIfAbsent(registeredToolName, registeredTool);
-            if (existingTool != null) {
-                duplicateRegisteredToolNames.add(registeredToolName);
-            }
-        }
-
-        for (String toolName : toolNames) {
-            McpTool tool = registeredToolsByName.get(toolName);
-            if (tool == null) {
-                throw new McpSamplingException("Sampling tool is not registered: " + toolName);
-            }
-            if (duplicateRegisteredToolNames.contains(toolName)) {
-                throw new McpSamplingException("Registered sampling tool names must be unique: " + toolName);
-            }
-            McpTool duplicate = tools.putIfAbsent(toolName, tool);
-            if (duplicate != null) {
-                throw new McpSamplingException("Sampling tool names must be unique: " + toolName);
-            }
-        }
-        return tools;
-    }
-
-    private Set<String> samplingToolUseIds(List<McpSamplingMessage> messages) {
-        Set<String> toolUseIds = new HashSet<>();
-        messages.stream()
-                .flatMap(message -> message.contents().stream())
-                .filter(McpSamplingToolUseContent.class::isInstance)
-                .map(McpSamplingToolUseContent.class::cast)
-                .map(McpSamplingToolUseContent::id)
-                .forEach(id -> {
-                    if (!toolUseIds.add(id)) {
-                        throw new McpSamplingException("Sampling tool use identifier was reused: " + id);
-                    }
-                });
-        return toolUseIds;
-    }
-
-    private McpToolResult invokeTool(Map<String, McpTool> tools, McpSamplingToolUseContent toolUse) {
-        McpTool tool = tools.get(toolUse.name());
-        if (tool == null) {
-            return createToolErrorResult("Tool with name " + toolUse.name() + " is not available");
-        }
-
-        JsonObject.Builder parametersBuilder = JsonObject.builder()
-                .set("name", toolUse.name())
-                .set("arguments", toolUse.input().value());
-        toolUse.metadata().ifPresent(metadata -> parametersBuilder.set("_meta", metadata.value()));
-        McpParameters parameters = new McpParameters(parametersBuilder.build());
-        McpRequest request = McpRequest.builder()
-                .parameters(parameters)
-                .meta(parameters.get("_meta"))
-                .features(features)
-                .protocolVersion(session().protocolVersion().text())
-                .sessionContext(session().context())
-                .requestContext(features.requestContext())
-                .build();
-        try {
-            McpToolResult result = tool.tool(new McpToolRequestImpl(request));
-            if (result == null) {
-                return createToolErrorResult("Tool with name " + toolUse.name() + " returned no result");
-            }
-            return result;
-        } catch (RuntimeException e) {
-            LOGGER.log(System.Logger.Level.TRACE, "Sampling tool execution failed: "
-                            + toolUse.name(), e);
-            return createToolErrorResult("Tool with name " + toolUse.name() + " failed");
         }
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
@@ -119,7 +119,7 @@ public final class McpSampling extends McpFeature {
                     .map(McpSamplingToolUseContent.class::cast)
                     .toList();
             if (toolUses.isEmpty()) {
-                if (response.stopReason().filter(reason -> reason == McpStopReason.TOOL_USE).isPresent()) {
+                if (response.rawStopReason().filter(McpStopReason.TOOL_USE.text()::equals).isPresent()) {
                     throw new McpSamplingException("Sampling response stopped for tool use without tool use content");
                 }
                 if (currentRequest.toolChoice().filter(choice -> choice == McpToolChoice.REQUIRED).isPresent()) {

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
@@ -20,6 +20,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
 import io.helidon.json.JsonObject;
@@ -33,11 +35,16 @@ public final class McpSampling extends McpFeature {
     private static final System.Logger LOGGER = System.getLogger(McpSampling.class.getName());
 
     private final McpFeatures features;
+    private final Lock toolBudgetLock = new ReentrantLock();
     private final boolean enabled;
     private final boolean enabledContext;
     private final boolean enabledTools;
     private final int maxToolIterations;
     private final List<McpTool> registeredTools;
+
+    private volatile boolean toolBudgetExhausted;
+    private int toolIterations;
+    private int toolExecutions;
 
     McpSampling(McpSession session, McpTransport transport, McpFeatures features) {
         super(session, transport);
@@ -153,9 +160,6 @@ public final class McpSampling extends McpFeature {
                     }
                 });
         McpSamplingRequest currentRequest = request;
-        int toolIterations = 0;
-        int toolExecutions = 0;
-
         while (true) {
             checkRequestActive();
             long id = session().jsonRpcId();
@@ -186,21 +190,28 @@ public final class McpSampling extends McpFeature {
             if (!enabledTools) {
                 throw new McpSamplingException("Sampling tools are not supported by client");
             }
-            if (toolIterations == maxToolIterations) {
-                throw new McpSamplingException("Sampling tool iteration limit reached");
-            }
-            if (currentRequest.toolChoice().filter(choice -> choice == McpToolChoice.NONE).isPresent()) {
-                throw new McpSamplingException("Sampling client returned a tool use when tool choice is none");
-            }
-            if (toolUses.size() > maxToolIterations - toolExecutions) {
-                throw new McpSamplingException("Sampling tool execution limit reached");
-            }
             for (McpSamplingToolUseContent toolUse : toolUses) {
                 if (!toolUseIds.add(toolUse.id())) {
                     throw new McpSamplingException("Sampling tool use identifier was reused: " + toolUse.id());
                 }
             }
-            toolExecutions += toolUses.size();
+            toolBudgetLock.lock();
+            try {
+                if (toolIterations >= maxToolIterations) {
+                    throw new McpSamplingException("Sampling tool iteration limit reached");
+                }
+                if (currentRequest.toolChoice().filter(choice -> choice == McpToolChoice.NONE).isPresent()) {
+                    throw new McpSamplingException("Sampling client returned a tool use when tool choice is none");
+                }
+                if (toolUses.size() > maxToolIterations - toolExecutions) {
+                    throw new McpSamplingException("Sampling tool execution limit reached");
+                }
+                toolIterations++;
+                toolExecutions += toolUses.size();
+                toolBudgetExhausted = toolIterations >= maxToolIterations || toolExecutions >= maxToolIterations;
+            } finally {
+                toolBudgetLock.unlock();
+            }
 
             McpSamplingMessage.Builder results = McpSamplingMessage.builder().role(McpRole.USER);
             for (McpSamplingToolUseContent toolUse : toolUses) {
@@ -240,8 +251,7 @@ public final class McpSampling extends McpFeature {
             McpSamplingRequest.Builder nextRequest = McpSamplingRequest.builder(currentRequest)
                     .addMessage(response.message())
                     .addMessage(results.build());
-            toolIterations++;
-            if (toolIterations == maxToolIterations || toolExecutions == maxToolIterations) {
+            if (toolBudgetExhausted) {
                 nextRequest.toolChoice(McpToolChoice.NONE);
             } else if (currentRequest.toolChoice()
                     .filter(choice -> choice == McpToolChoice.REQUIRED)

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
@@ -206,17 +206,29 @@ public final class McpSampling extends McpFeature {
 
     private Map<String, McpTool> samplingTools(List<String> toolNames) {
         Map<String, McpTool> tools = new LinkedHashMap<>();
+        if (toolNames.isEmpty()) {
+            return tools;
+        }
+
+        Map<String, McpTool> registeredToolsByName = new LinkedHashMap<>();
+        Set<String> duplicateRegisteredToolNames = new HashSet<>();
+        for (McpTool registeredTool : registeredTools) {
+            String registeredToolName = registeredTool.name();
+            McpTool existingTool = registeredToolsByName.putIfAbsent(registeredToolName, registeredTool);
+            if (existingTool != null) {
+                duplicateRegisteredToolNames.add(registeredToolName);
+            }
+        }
+
         for (String toolName : toolNames) {
-            List<McpTool> matchingTools = registeredTools.stream()
-                    .filter(candidate -> toolName.equals(candidate.name()))
-                    .toList();
-            if (matchingTools.isEmpty()) {
+            McpTool tool = registeredToolsByName.get(toolName);
+            if (tool == null) {
                 throw new McpSamplingException("Sampling tool is not registered: " + toolName);
             }
-            if (matchingTools.size() > 1) {
+            if (duplicateRegisteredToolNames.contains(toolName)) {
                 throw new McpSamplingException("Registered sampling tool names must be unique: " + toolName);
             }
-            McpTool duplicate = tools.putIfAbsent(toolName, matchingTools.getFirst());
+            McpTool duplicate = tools.putIfAbsent(toolName, tool);
             if (duplicate != null) {
                 throw new McpSamplingException("Sampling tool names must be unique: " + toolName);
             }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
@@ -26,6 +26,8 @@ import java.util.function.Consumer;
 
 import io.helidon.json.JsonObject;
 
+import static io.helidon.extensions.mcp.server.McpMetadata.META;
+
 /**
  * MCP Sampling feature.
  */
@@ -225,11 +227,12 @@ public final class McpSampling extends McpFeature {
                     JsonObject.Builder paramsBuilder = JsonObject.builder()
                             .set("name", toolUse.name())
                             .set("arguments", toolUse.input().asJsonObject().orElseThrow());
-                    toolUse.metadata().ifPresent(metadata -> paramsBuilder.set("_meta", metadata.asJsonObject().orElseThrow()));
+                    toolUse.metadata().ifPresent(metadata ->
+                            paramsBuilder.set(META, metadata.asJsonObject().orElseThrow()));
                     McpParameters parameters = new McpParameters(paramsBuilder.build());
                     McpRequest toolRequest = McpRequest.builder()
                             .parameters(parameters)
-                            .meta(parameters.get("_meta"))
+                            .meta(parameters.get(META))
                             .features(features)
                             .protocolVersion(session().protocolVersion().text())
                             .sessionContext(session().context())

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
@@ -111,6 +111,7 @@ public final class McpSampling extends McpFeature {
         Set<String> toolUseIds = samplingToolUseIds(request.messages());
         McpSamplingRequest currentRequest = request;
         int toolIterations = 0;
+        int toolExecutions = 0;
 
         while (true) {
             McpSamplingResponse response = requestOnce(currentRequest, toolDefinitions);
@@ -136,11 +137,15 @@ public final class McpSampling extends McpFeature {
             if (currentRequest.toolChoice().filter(choice -> choice == McpToolChoice.NONE).isPresent()) {
                 throw new McpSamplingException("Sampling client returned a tool use when tool choice is none");
             }
+            if (toolUses.size() > maxToolIterations - toolExecutions) {
+                throw new McpSamplingException("Sampling tool execution limit reached");
+            }
             for (McpSamplingToolUseContent toolUse : toolUses) {
                 if (!toolUseIds.add(toolUse.id())) {
                     throw new McpSamplingException("Sampling tool use identifier was reused: " + toolUse.id());
                 }
             }
+            toolExecutions += toolUses.size();
 
             McpSamplingMessage.Builder results = McpSamplingMessage.builder().role(McpRole.USER);
             for (McpSamplingToolUseContent toolUse : toolUses) {
@@ -154,7 +159,7 @@ public final class McpSampling extends McpFeature {
                     .addMessage(response.message())
                     .addMessage(results.build());
             toolIterations++;
-            if (toolIterations == maxToolIterations) {
+            if (toolIterations == maxToolIterations || toolExecutions == maxToolIterations) {
                 nextRequest.toolChoice(McpToolChoice.NONE);
             } else if (currentRequest.toolChoice()
                     .filter(choice -> choice == McpToolChoice.REQUIRED)

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
@@ -34,12 +34,12 @@ public final class McpSampling extends McpFeature {
 
     private static final System.Logger LOGGER = System.getLogger(McpSampling.class.getName());
 
-    private final McpFeatures features;
-    private final Lock toolBudgetLock = new ReentrantLock();
     private final boolean enabled;
     private final boolean enabledContext;
     private final boolean enabledTools;
     private final int maxToolIterations;
+    private final Lock toolBudgetLock;
+    private final McpFeatures features;
     private final List<McpTool> registeredTools;
 
     private volatile boolean toolBudgetExhausted;
@@ -48,15 +48,16 @@ public final class McpSampling extends McpFeature {
 
     McpSampling(McpSession session, McpTransport transport, McpFeatures features) {
         super(session, transport);
-        this.features = features;
-        this.enabled = session.capabilities().contains(McpCapability.SAMPLING);
-        this.enabledContext = session.capabilities().contains(McpCapability.SAMPLING_CONTEXT);
-        this.enabledTools = session.capabilities().contains(McpCapability.SAMPLING_TOOLS);
         McpServerConfig config = session.context()
                 .get(McpServerConfigBlueprint.class, McpServerConfig.class)
                 .orElseThrow(() -> new McpInternalException("MCP server configuration not found"));
-        this.maxToolIterations = config.maxSamplingToolIterations();
+        this.features = features;
+        this.toolBudgetLock = new ReentrantLock();
         this.registeredTools = config.tools();
+        this.maxToolIterations = config.maxSamplingToolIterations();
+        this.enabled = session.capabilities().contains(McpCapability.SAMPLING);
+        this.enabledContext = session.capabilities().contains(McpCapability.SAMPLING_CONTEXT);
+        this.enabledTools = session.capabilities().contains(McpCapability.SAMPLING_TOOLS);
     }
 
     /**
@@ -121,7 +122,6 @@ public final class McpSampling extends McpFeature {
         if (request.usesTool() && !enabledTools) {
             throw new McpSamplingException("Sampling tools are not supported by client");
         }
-
         Map<String, McpTool> tools = new LinkedHashMap<>();
         if (!request.tools().isEmpty()) {
             Map<String, McpTool> registeredToolsByName = new LinkedHashMap<>();
@@ -165,11 +165,13 @@ public final class McpSampling extends McpFeature {
             long id = session().jsonRpcId();
             JsonObject payload = session().serializer().createSamplingRequest(id, currentRequest, toolDefinitions);
             session().prepareResponse(id);
+            McpResponse mcpResponse;
             McpSamplingResponse response;
             try {
                 transport().send(payload);
-                JsonObject jsonResponse = session().pollResponse(id, currentRequest.timeout());
-                response = session().serializer().createSamplingResponse(jsonResponse);
+                mcpResponse = session().pollResponse(id, currentRequest.timeout())
+                        .orElseThrow(() -> new McpSamplingException("response timeout"));
+                response = session().serializer().createSamplingResponse(mcpResponse.asJsonObject());
             } finally {
                 session().discardResponse(id);
             }
@@ -212,7 +214,6 @@ public final class McpSampling extends McpFeature {
             } finally {
                 toolBudgetLock.unlock();
             }
-
             McpSamplingMessage.Builder results = McpSamplingMessage.builder().role(McpRole.USER);
             for (McpSamplingToolUseContent toolUse : toolUses) {
                 checkRequestActive();
@@ -232,7 +233,7 @@ public final class McpSampling extends McpFeature {
                             .features(features)
                             .protocolVersion(session().protocolVersion().text())
                             .sessionContext(session().context())
-                            .requestContext(features.requestContext())
+                            .requestContext(mcpResponse.requestContext())
                             .build();
                     try {
                         toolResult = tool.tool(new McpToolRequestImpl(toolRequest));
@@ -247,7 +248,6 @@ public final class McpSampling extends McpFeature {
                                            .result(toolResult)
                                            .build());
             }
-
             McpSamplingRequest.Builder nextRequest = McpSamplingRequest.builder(currentRequest)
                     .addMessage(response.message())
                     .addMessage(results.build());

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSampling.java
@@ -34,6 +34,7 @@ import static io.helidon.extensions.mcp.server.McpMetadata.META;
 public final class McpSampling extends McpFeature {
     static final int DEFAULT_MAX_TOOL_ITERATIONS = 10;
 
+    private static final String CANCELLATION_MESSAGE = "Sampling request cancelled";
     private static final System.Logger LOGGER = System.getLogger(McpSampling.class.getName());
 
     private final boolean enabled;
@@ -165,18 +166,8 @@ public final class McpSampling extends McpFeature {
         while (true) {
             checkRequestActive();
             long id = session().jsonRpcId();
-            JsonObject payload = session().serializer().createSamplingRequest(id, currentRequest, toolDefinitions);
-            session().prepareResponse(id);
-            McpResponse mcpResponse;
-            McpSamplingResponse response;
-            try {
-                transport().send(payload);
-                mcpResponse = session().pollResponse(id, currentRequest.timeout())
-                        .orElseThrow(() -> new McpSamplingException("response timeout"));
-                response = session().serializer().createSamplingResponse(mcpResponse.asJsonObject());
-            } finally {
-                session().discardResponse(id);
-            }
+            McpResponse mcpResponse = requestClientResponse(id, currentRequest, toolDefinitions);
+            McpSamplingResponse response = session().serializer().createSamplingResponse(mcpResponse.asJsonObject());
             checkRequestActive();
             List<McpSamplingToolUseContent> toolUses = response.message().contents().stream()
                     .filter(McpSamplingToolUseContent.class::isInstance)
@@ -228,11 +219,11 @@ public final class McpSampling extends McpFeature {
                             .set("name", toolUse.name())
                             .set("arguments", toolUse.input().asJsonObject().orElseThrow());
                     toolUse.metadata().ifPresent(metadata ->
-                            paramsBuilder.set(META, metadata.asJsonObject().orElseThrow()));
+                            paramsBuilder.set(META, McpJsonBinding.serializeObject(metadata)));
                     McpParameters parameters = new McpParameters(paramsBuilder.build());
                     McpRequest toolRequest = McpRequest.builder()
                             .parameters(parameters)
-                            .update(builder -> parameters.get(META).ifPresent(builder::metadata))
+                            .update(builder -> parameters.get(META).as(JsonObject.class).ifPresent(builder::metadata))
                             .features(features)
                             .protocolVersion(session().protocolVersion().text())
                             .sessionContext(session().context())
@@ -265,12 +256,32 @@ public final class McpSampling extends McpFeature {
         }
     }
 
+    private McpResponse requestClientResponse(long id,
+                                              McpSamplingRequest request,
+                                              List<McpTool> toolDefinitions) {
+        JsonObject payload = session().serializer().createSamplingRequest(id, request, toolDefinitions);
+        McpCancellation cancellation = features.cancellation();
+        Runnable cancellationHook = () -> session()
+                .abortResponse(id, new McpSamplingException(CANCELLATION_MESSAGE));
+        try {
+            session().prepareResponse(id);
+            cancellation.registerCancellationHook(cancellationHook);
+            checkRequestActive();
+            transport().send(payload);
+            return session().pollResponse(id, request.timeout())
+                    .orElseThrow(() -> new McpSamplingException("response timeout"));
+        } finally {
+            cancellation.unregisterCancellationHook(cancellationHook);
+            session().discardResponse(id);
+        }
+    }
+
     private void checkRequestActive() {
         if (session().state() == McpSession.State.DISCONNECTED) {
             throw new McpInternalException("Session disconnected");
         }
         if (features.cancellation().result().isRequested()) {
-            throw new McpSamplingException("Sampling request cancelled");
+            throw new McpSamplingException(CANCELLATION_MESSAGE);
         }
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingAnnotatedContent.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingAnnotatedContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,13 @@ package io.helidon.extensions.mcp.server;
 import java.util.Optional;
 
 /**
- * Tool contents that can be returned as part of the tool execution.
+ * Sampling content that supports MCP content annotations.
  */
-interface McpToolContent extends McpContent, McpMetadata {
+public interface McpSamplingAnnotatedContent extends McpSamplingContent {
     /**
-     * Optional annotations for this content block.
+     * Optional content annotations.
      *
      * @return annotations
      */
     Optional<McpAnnotations> annotations();
-
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingAudioContentBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingAudioContentBlueprint.java
@@ -15,17 +15,16 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import java.util.Optional;
+import io.helidon.builder.api.Prototype;
 
 /**
- * Tool contents that can be returned as part of the tool execution.
+ * MCP sampling audio content.
  */
-interface McpToolContent extends McpContent, McpMetadata {
-    /**
-     * Optional annotations for this content block.
-     *
-     * @return annotations
-     */
-    Optional<McpAnnotations> annotations();
+@Prototype.Blueprint
+interface McpSamplingAudioContentBlueprint extends McpSamplingMediaContent {
 
+    @Override
+    default McpSamplingContentType type() {
+        return McpSamplingContentType.AUDIO;
+    }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingContent.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,15 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import io.helidon.builder.api.Prototype;
-
 /**
- * MCP sampling image message.
+ * MCP sampling message content.
  */
-@Prototype.Blueprint
-interface McpSamplingImageMessageBlueprint extends McpSamplingMediaMessage {
+public interface McpSamplingContent extends McpMetadata {
+    /**
+     * Sampling content type.
+     *
+     * @return type
+     */
+    McpSamplingContentType type();
 
-    @Override
-    default McpSamplingMessageType type() {
-        return McpSamplingMessageType.IMAGE;
-    }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingContentType.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingContentType.java
@@ -15,43 +15,39 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import java.util.Base64;
-
-import io.helidon.common.media.type.MediaType;
+import java.util.Locale;
 
 /**
- * MCP sampling media content.
+ * Sampling content types.
  */
-public interface McpSamplingMediaMessage extends McpSamplingMessage {
+public enum McpSamplingContentType {
     /**
-     * Image content raw data.
-     *
-     * @return content
+     * Sampling text content type.
      */
-    byte[] data();
+    TEXT,
+    /**
+     * Sampling image content type.
+     */
+    IMAGE,
+    /**
+     * Sampling audio content type.
+     */
+    AUDIO,
+    /**
+     * Sampling tool use content type.
+     */
+    TOOL_USE,
+    /**
+     * Sampling tool result content type.
+     */
+    TOOL_RESULT;
 
     /**
-     * Image content MIME type.
+     * Returns lower case sampling content type name.
      *
-     * @return MIME type
+     * @return type name
      */
-    MediaType mediaType();
-
-    /**
-     * Returns the decoded image data using base64 decoder.
-     *
-     * @return decoded content.
-     */
-    default byte[] decodeBase64Data() {
-        return Base64.getDecoder().decode(data());
-    }
-
-    /**
-     * Returns the encoded image data using base64 encoder.
-     *
-     * @return content in base64.
-     */
-    default String encodeBase64Data() {
-        return Base64.getEncoder().encodeToString(data());
+    String text() {
+        return this.name().toLowerCase(Locale.ROOT);
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingImageContentBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingImageContentBlueprint.java
@@ -15,17 +15,16 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import java.util.Optional;
+import io.helidon.builder.api.Prototype;
 
 /**
- * Tool contents that can be returned as part of the tool execution.
+ * MCP sampling image content.
  */
-interface McpToolContent extends McpContent, McpMetadata {
-    /**
-     * Optional annotations for this content block.
-     *
-     * @return annotations
-     */
-    Optional<McpAnnotations> annotations();
+@Prototype.Blueprint
+interface McpSamplingImageContentBlueprint extends McpSamplingMediaContent {
 
+    @Override
+    default McpSamplingContentType type() {
+        return McpSamplingContentType.IMAGE;
+    }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingMediaContent.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingMediaContent.java
@@ -15,17 +15,34 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import java.util.Optional;
+import java.util.Base64;
+
+import io.helidon.common.media.type.MediaType;
 
 /**
- * Tool contents that can be returned as part of the tool execution.
+ * MCP sampling media content.
  */
-interface McpToolContent extends McpContent, McpMetadata {
+public interface McpSamplingMediaContent extends McpSamplingAnnotatedContent {
     /**
-     * Optional annotations for this content block.
+     * Media content raw data.
      *
-     * @return annotations
+     * @return content
      */
-    Optional<McpAnnotations> annotations();
+    byte[] data();
 
+    /**
+     * Media content MIME type.
+     *
+     * @return MIME type
+     */
+    MediaType mediaType();
+
+    /**
+     * Returns the encoded media data using a base64 encoder.
+     *
+     * @return content in base64
+     */
+    default String encodeBase64Data() {
+        return Base64.getEncoder().encodeToString(data());
+    }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingMessageBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingMessageBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,29 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import java.util.Optional;
+import java.util.List;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
 
 /**
- * Tool contents that can be returned as part of the tool execution.
+ * MCP sampling message.
  */
-interface McpToolContent extends McpContent, McpMetadata {
+@Prototype.Blueprint
+interface McpSamplingMessageBlueprint extends McpMetadata {
     /**
-     * Optional annotations for this content block.
+     * Sampling message role.
      *
-     * @return annotations
+     * @return role
      */
-    Optional<McpAnnotations> annotations();
+    McpRole role();
+
+    /**
+     * Ordered sampling message content blocks.
+     *
+     * @return content blocks
+     */
+    @Option.Singular
+    List<McpSamplingContent> contents();
 
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingRequestBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingRequestBlueprint.java
@@ -29,28 +29,27 @@ import io.helidon.builder.api.Prototype;
 @Prototype.CustomMethods(McpSamplingSupport.class)
 interface McpSamplingRequestBlueprint {
     /**
-     * Sampling text messages sent to the client.
+     * Ordered sampling messages sent to the client.
      *
-     * @return messages
+     * @return ordered messages
      */
     @Option.Singular
-    List<McpSamplingTextMessage> textMessages();
+    List<McpSamplingMessage> messages();
 
     /**
-     * Sampling image messages sent to the client.
+     * Names of server tools that the model may use during sampling.
      *
-     * @return messages
+     * @return tool names
      */
     @Option.Singular
-    List<McpSamplingImageMessage> imageMessages();
+    List<String> tools();
 
     /**
-     * Sampling audio messages sent to the client.
+     * Tool selection behavior for this sampling request.
      *
-     * @return messages
+     * @return tool choice
      */
-    @Option.Singular
-    List<McpSamplingAudioMessage> audioMessages();
+    Optional<McpToolChoice> toolChoice();
 
     /**
      * Sampling model hints.

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingResponse.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingResponse.java
@@ -15,7 +15,6 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -23,45 +22,43 @@ import java.util.Optional;
  */
 public sealed interface McpSamplingResponse permits McpSamplingResponseImpl {
     /**
-     * First sampling response message.
+     * Sampling response message.
      *
-     * @return response
-     * @throws McpSamplingException if the response does not contain any messages
+     * @return response message
      */
     McpSamplingMessage message();
 
     /**
-     * All sampling response messages in wire order.
+     * Returns the first sampling response content block as text content.
      *
-     * @return immutable response messages
+     * @return text content
+     * @throws McpSamplingException if the message is empty or its first content block is not text
      */
-    default List<McpSamplingMessage> messages() {
-        return List.of(message());
-    }
+    McpSamplingTextContent asTextContent() throws McpSamplingException;
 
     /**
-     * Returns the first sampling response message as a text message.
+     * Returns the first sampling response content block as image content.
      *
-     * @return message as text
-     * @throws McpSamplingException if the response is empty or the first message is not text
+     * @return image content
+     * @throws McpSamplingException if the message is empty or its first content block is not an image
      */
-    McpSamplingTextMessage asTextMessage() throws McpSamplingException;
+    McpSamplingImageContent asImageContent() throws McpSamplingException;
 
     /**
-     * Returns the first sampling response message as an image message.
+     * Returns the first sampling response content block as audio content.
      *
-     * @return message as image
-     * @throws McpSamplingException if the response is empty or the first message is not an image
+     * @return audio content
+     * @throws McpSamplingException if the message is empty or its first content block is not audio
      */
-    McpSamplingImageMessage asImageMessage() throws McpSamplingException;
+    McpSamplingAudioContent asAudioContent() throws McpSamplingException;
 
     /**
-     * Returns the first sampling response message as an audio message.
+     * Returns the first sampling response content block as tool use content.
      *
-     * @return message as audio
-     * @throws McpSamplingException if the response is empty or the first message is not audio
+     * @return tool use content
+     * @throws McpSamplingException if the message is empty or its first content block is not a tool use
      */
-    McpSamplingAudioMessage asAudioMessage() throws McpSamplingException;
+    McpSamplingToolUseContent asToolUseContent() throws McpSamplingException;
 
     /**
      * Sampling model used.

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingResponseImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingResponseImpl.java
@@ -15,68 +15,67 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 final class McpSamplingResponseImpl implements McpSamplingResponse {
     private final String model;
     private final String rawStopReason;
-    private final List<McpSamplingMessage> messages;
+    private final McpSamplingMessage message;
 
     McpSamplingResponseImpl(McpSamplingMessage message, String model, McpStopReason stopReason) {
-        this(List.of(message), model, stopReason.text());
+        this(message, model, stopReason.text());
     }
 
-    McpSamplingResponseImpl(List<McpSamplingMessage> messages, String model) {
-        this.messages = List.copyOf(messages);
-        this.model = model;
-        this.rawStopReason = null;
+    McpSamplingResponseImpl(McpSamplingMessage message, String model) {
+        this(message, model, (String) null);
     }
 
-    McpSamplingResponseImpl(List<McpSamplingMessage> messages, String model, String rawStopReason) {
-        this.messages = List.copyOf(messages);
-        this.model = model;
+    McpSamplingResponseImpl(McpSamplingMessage message, String model, String rawStopReason) {
+        this.message = Objects.requireNonNull(message, "message is null");
+        this.model = Objects.requireNonNull(model, "model is null");
         this.rawStopReason = rawStopReason;
     }
 
     @Override
     public McpSamplingMessage message() {
-        if (messages.isEmpty()) {
-            throw new McpSamplingException("Sampling response does not contain a message");
-        }
-        return messages.getFirst();
+        return message;
     }
 
     @Override
-    public List<McpSamplingMessage> messages() {
-        return messages;
-    }
-
-    @Override
-    public McpSamplingTextMessage asTextMessage() throws McpSamplingException {
-        McpSamplingMessage message = message();
-        if (message instanceof McpSamplingTextMessage text) {
+    public McpSamplingTextContent asTextContent() throws McpSamplingException {
+        McpSamplingContent content = content();
+        if (content instanceof McpSamplingTextContent text) {
             return text;
         }
-        throw new McpSamplingException("Sampling message is not text");
+        throw new McpSamplingException("Sampling content is not text");
     }
 
     @Override
-    public McpSamplingImageMessage asImageMessage() throws McpSamplingException {
-        McpSamplingMessage message = message();
-        if (message instanceof McpSamplingImageMessage image) {
+    public McpSamplingImageContent asImageContent() throws McpSamplingException {
+        McpSamplingContent content = content();
+        if (content instanceof McpSamplingImageContent image) {
             return image;
         }
-        throw new McpSamplingException("Sampling message is not an image");
+        throw new McpSamplingException("Sampling content is not an image");
     }
 
     @Override
-    public McpSamplingAudioMessage asAudioMessage() throws McpSamplingException {
-        McpSamplingMessage message = message();
-        if (message instanceof McpSamplingAudioMessage audio) {
+    public McpSamplingAudioContent asAudioContent() throws McpSamplingException {
+        McpSamplingContent content = content();
+        if (content instanceof McpSamplingAudioContent audio) {
             return audio;
         }
-        throw new McpSamplingException("Sampling message is not an audio");
+        throw new McpSamplingException("Sampling content is not audio");
+    }
+
+    @Override
+    public McpSamplingToolUseContent asToolUseContent() throws McpSamplingException {
+        McpSamplingContent content = content();
+        if (content instanceof McpSamplingToolUseContent toolUse) {
+            return toolUse;
+        }
+        throw new McpSamplingException("Sampling content is not a tool use");
     }
 
     @Override
@@ -92,5 +91,12 @@ final class McpSamplingResponseImpl implements McpSamplingResponse {
     @Override
     public Optional<String> rawStopReason() {
         return Optional.ofNullable(rawStopReason);
+    }
+
+    private McpSamplingContent content() {
+        if (message.contents().isEmpty()) {
+            throw new McpSamplingException("Sampling response message does not contain content");
+        }
+        return message.contents().getFirst();
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingSupport.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingSupport.java
@@ -15,8 +15,6 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 import io.helidon.builder.api.Prototype;
@@ -33,15 +31,53 @@ class McpSamplingSupport {
      */
     @Prototype.BuilderMethod
     static void addTextMessage(McpSamplingRequest.BuilderBase<?, ?> builder, String text) {
-        Objects.requireNonNull(text, "text is null");
-        builder.addTextMessage(b -> b.text(text).role(McpRole.ASSISTANT));
+        addTextMessage(builder, McpRole.ASSISTANT, text);
     }
 
-    static List<McpSamplingMessage> aggregate(McpSamplingRequest request) {
-        List<McpSamplingMessage> messages = new ArrayList<>();
-        messages.addAll(request.textMessages());
-        messages.addAll(request.imageMessages());
-        messages.addAll(request.audioMessages());
-        return messages;
+    /**
+     * Add a sampling text message to the sampling request from the provided role and text.
+     *
+     * @param builder sampling request builder
+     * @param role    message role
+     * @param text    text message
+     */
+    @Prototype.BuilderMethod
+    static void addTextMessage(McpSamplingRequest.BuilderBase<?, ?> builder, McpRole role, String text) {
+        Objects.requireNonNull(role, "role is null");
+        Objects.requireNonNull(text, "text is null");
+        builder.addMessage(McpSamplingMessage.builder()
+                                   .role(role)
+                                   .addContent(McpSamplingTextContent.create(text))
+                                   .build());
+    }
+
+    /**
+     * Whether this request uses sampling tools through tool names, a tool choice, or tool messages.
+     *
+     * @param request sampling request
+     * @return {@code true} if this request uses sampling tools
+     */
+    @Prototype.PrototypeMethod
+    static boolean usesTool(McpSamplingRequest request) {
+        return !request.tools().isEmpty()
+                || request.toolChoice().isPresent()
+                || request.messages().stream()
+                        .flatMap(message -> message.contents().stream())
+                        .map(McpSamplingContent::type)
+                        .anyMatch(type -> type == McpSamplingContentType.TOOL_USE
+                                || type == McpSamplingContentType.TOOL_RESULT);
+    }
+
+    /**
+     * Whether this request uses sampling context inclusion.
+     *
+     * @param request sampling request
+     * @return {@code true} if this request includes context from this or other servers
+     */
+    @Prototype.PrototypeMethod
+    static boolean usesContext(McpSamplingRequest request) {
+        return request.includeContext()
+                .filter(context -> context != McpIncludeContext.NONE)
+                .isPresent();
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingTextContentBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingTextContentBlueprint.java
@@ -18,11 +18,11 @@ package io.helidon.extensions.mcp.server;
 import io.helidon.builder.api.Prototype;
 
 /**
- * MCP sampling text message.
+ * MCP sampling text content.
  */
 @Prototype.Blueprint
-@Prototype.CustomMethods(McpSamplingTextMessageSupport.class)
-interface McpSamplingTextMessageBlueprint extends McpSamplingMessage {
+@Prototype.CustomMethods(McpSamplingTextContentSupport.class)
+interface McpSamplingTextContentBlueprint extends McpSamplingAnnotatedContent {
     /**
      * Text content as string.
      *
@@ -31,7 +31,7 @@ interface McpSamplingTextMessageBlueprint extends McpSamplingMessage {
     String text();
 
     @Override
-    default McpSamplingMessageType type() {
-        return McpSamplingMessageType.TEXT;
+    default McpSamplingContentType type() {
+        return McpSamplingContentType.TEXT;
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingTextContentSupport.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingTextContentSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,18 @@ package io.helidon.extensions.mcp.server;
 
 import io.helidon.builder.api.Prototype;
 
-/**
- * MCP sampling audio message.
- */
-@Prototype.Blueprint
-interface McpSamplingAudioMessageBlueprint extends McpSamplingMediaMessage {
+class McpSamplingTextContentSupport {
+    private McpSamplingTextContentSupport() {
+    }
 
-    @Override
-    default McpSamplingMessageType type() {
-        return McpSamplingMessageType.AUDIO;
+    /**
+     * Create a {@link McpSamplingTextContent} instance from the provided text.
+     *
+     * @param text text content
+     * @return sampling text content instance
+     */
+    @Prototype.PrototypeFactoryMethod
+    static McpSamplingTextContent create(String text) {
+        return McpSamplingTextContent.builder().text(text).build();
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingToolResultContentBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingToolResultContentBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,29 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import java.util.Optional;
+import io.helidon.builder.api.Prototype;
 
 /**
- * Tool contents that can be returned as part of the tool execution.
+ * MCP sampling tool result content.
  */
-interface McpToolContent extends McpContent, McpMetadata {
+@Prototype.Blueprint
+interface McpSamplingToolResultContentBlueprint extends McpSamplingContent {
     /**
-     * Optional annotations for this content block.
+     * Identifier of the tool use that produced this result.
      *
-     * @return annotations
+     * @return tool use identifier
      */
-    Optional<McpAnnotations> annotations();
+    String toolUseId();
 
+    /**
+     * Tool execution result.
+     *
+     * @return tool result
+     */
+    McpToolResult result();
+
+    @Override
+    default McpSamplingContentType type() {
+        return McpSamplingContentType.TOOL_RESULT;
+    }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingToolUseContentBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingToolUseContentBlueprint.java
@@ -37,7 +37,8 @@ interface McpSamplingToolUseContentBlueprint extends McpSamplingContent {
     String name();
 
     /**
-     * Arguments to pass to the tool.
+     * Arguments to pass to the tool. Use {@link McpParameters#create(Object)} to create arguments from a value supported by
+     * Helidon JSON binding.
      *
      * @return tool arguments
      */

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingToolUseContentBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSamplingToolUseContentBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,29 +15,36 @@
  */
 package io.helidon.extensions.mcp.server;
 
+import io.helidon.builder.api.Prototype;
+
 /**
- * Sampling message types.
+ * MCP sampling tool use content.
  */
-public enum McpSamplingMessageType {
+@Prototype.Blueprint
+interface McpSamplingToolUseContentBlueprint extends McpSamplingContent {
     /**
-     * Sampling text message type.
+     * Unique identifier for this tool use.
+     *
+     * @return tool use identifier
      */
-    TEXT,
-    /**
-     * Sampling image message type.
-     */
-    IMAGE,
-    /**
-     * Sampling audio message type.
-     */
-    AUDIO;
+    String id();
 
     /**
-     * Returns lower case sampling message type name.
+     * Name of the tool to invoke.
      *
-     * @return type name
+     * @return tool name
      */
-    String text() {
-        return this.name().toLowerCase();
+    String name();
+
+    /**
+     * Arguments to pass to the tool.
+     *
+     * @return tool arguments
+     */
+    McpParameters input();
+
+    @Override
+    default McpSamplingContentType type() {
+        return McpSamplingContentType.TOOL_USE;
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpServerConfigBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpServerConfigBlueprint.java
@@ -24,14 +24,15 @@ import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 
 import static io.helidon.extensions.mcp.server.McpPagination.DEFAULT_PAGE_SIZE;
+import static io.helidon.extensions.mcp.server.McpSampling.DEFAULT_MAX_TOOL_ITERATIONS;
 
 /**
  * Configuration of an MCP server.
  */
 @Prototype.Blueprint
-@Prototype.IncludeDefaultMethods("websiteUrl")
-@Prototype.Configured(McpServerConfigBlueprint.CONFIG_ROOT)
+@Prototype.IncludeDefaultMethods
 @Prototype.CustomMethods(McpServerFeatureSupport.class)
+@Prototype.Configured(McpServerConfigBlueprint.CONFIG_ROOT)
 interface McpServerConfigBlueprint extends Prototype.Factory<McpServerFeature> {
     String CONFIG_ROOT = "mcp.server";
 
@@ -196,6 +197,18 @@ interface McpServerConfigBlueprint extends Prototype.Factory<McpServerFeature> {
      */
     @Option.Configured
     Optional<String> instructions();
+
+    /**
+     * Maximum number of sampling tool-execution rounds. The value must be greater than zero. Once reached, one additional
+     * request is sent with tool choice {@link McpToolChoice#NONE}. Default is
+     * {@value McpSampling#DEFAULT_MAX_TOOL_ITERATIONS}.
+     *
+     * @return maximum sampling tool iterations
+     */
+    @Option.Configured
+    @Option.DefaultInt(DEFAULT_MAX_TOOL_ITERATIONS)
+    @Option.Decorator(McpDecorators.SamplingToolIterationsDecorator.class)
+    int maxSamplingToolIterations();
 
     /**
      * Maximum number of concurrent request handled by sessions. Default is {@code 1000}.

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpServerConfigBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpServerConfigBlueprint.java
@@ -199,8 +199,8 @@ interface McpServerConfigBlueprint extends Prototype.Factory<McpServerFeature> {
     Optional<String> instructions();
 
     /**
-     * Maximum number of sampling tool-execution rounds. The value must be greater than zero. Once reached, one additional
-     * request is sent with tool choice {@link McpToolChoice#NONE}. Default is
+     * Maximum number of sampling tool-execution rounds and cumulative tool executions. The value must be greater than zero.
+     * Once either limit is reached, one additional request is sent with tool choice {@link McpToolChoice#NONE}. Default is
      * {@value McpSampling#DEFAULT_MAX_TOOL_ITERATIONS}.
      *
      * @return maximum sampling tool iterations

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
@@ -418,7 +418,6 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             res.send();
             return;
         }
-        boolean error = false;
         McpSession session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
         McpParameters parameters = new McpParameters(req.params());
 
@@ -433,7 +432,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             return;
         }
 
-        McpFeatures features = session.createFeatures(requestId, req, res);
+        McpFeatures features = session.createFeatures(requestId);
         session.beforeFeatureRequest(parameters, requestId);
         McpRequest request = McpRequest.builder()
                 .parameters(parameters)
@@ -498,7 +497,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             resource = templates.map(Function.identity());
         }
 
-        McpFeatures features = session.createFeatures(requestId, req, res);
+        McpFeatures features = session.createFeatures(requestId);
         session.beforeFeatureRequest(parameters, requestId);
         McpRequest request = McpRequest.builder()
                 .parameters(parameters)
@@ -548,7 +547,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
                 .filter(r -> resourceUri.equals(r.uri()))
                 .findFirst();
         if (subscriber.isPresent()) {
-            McpFeatures features = session.createFeatures(requestId, req, res);
+            McpFeatures features = session.createFeatures(requestId);
             session.beforeFeatureRequest(parameters, requestId);
             subscriber.get().subscribe(McpSubscribeRequest.builder()
                                                .parameters(parameters)
@@ -592,7 +591,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
                 .findFirst();
         // invoke user method to unsubscribe
         if (unsubscriber.isPresent()) {
-            McpFeatures features = session.createFeatures(requestId, req, res);
+            McpFeatures features = session.createFeatures(requestId);
             session.beforeFeatureRequest(parameters, requestId);
             unsubscriber.get().unsubscribe(McpUnsubscribeRequest.builder()
                                                    .parameters(parameters)
@@ -669,7 +668,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             return;
         }
 
-        McpFeatures features = session.createFeatures(requestId, req, res);
+        McpFeatures features = session.createFeatures(requestId);
         session.beforeFeatureRequest(parameters, requestId);
         McpRequest request = McpRequest.builder()
                 .parameters(parameters)
@@ -700,7 +699,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         if (level.isPresent()) {
             try {
                 McpLogger.Level logLevel = McpLogger.Level.valueOf(level.get().toUpperCase());
-                session.createFeatures(requestId, req, res).logger().setLevel(logLevel);
+                session.createFeatures(requestId).logger().setLevel(logLevel);
                 res.result(JsonObject.empty());
                 session.send(requestId, res);
                 return;
@@ -738,7 +737,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
                         .map(resourceCompletions::get)
                         .orElseThrow(() -> new McpInternalException(INVALID_PARAMS, "No resource completion found"));
             };
-            McpFeatures features = session.createFeatures(requestId, req, res);
+            McpFeatures features = session.createFeatures(requestId);
             session.beforeFeatureRequest(parameters, requestId);
             McpRequest request = McpRequest.builder()
                     .parameters(parameters)
@@ -776,7 +775,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
                 if (LOGGER.isLoggable(Level.DEBUG)) {
                     LOGGER.log(Level.DEBUG, "Client response:\n" + prettyPrint(object));
                 }
-                session.get().acceptResponse(object);
+                session.get().acceptResponse(new McpResponseImpl(object, req.context()));
                 return Optional.empty();
             }
         }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
@@ -216,6 +216,11 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
                 .delete(endpoint, this::disconnect);
     }
 
+    @Override
+    public McpServerConfig prototype() {
+        return config;
+    }
+
     private void mcpMetadata(ServerRequest request, ServerResponse response) {
         var config = Services.get(Config.class);
         var providers = config.get("security.providers").asList(Config.class);
@@ -243,11 +248,6 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         }
         response.status(Status.NOT_FOUND_404);
         response.send();
-    }
-
-    @Override
-    public McpServerConfig prototype() {
-        return config;
     }
 
     private void disconnect(ServerRequest request, ServerResponse response) {

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
@@ -438,7 +438,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         session.beforeFeatureRequest(parameters, requestId);
         McpRequest request = McpRequest.builder()
                 .parameters(parameters)
-                .meta(parameters.get(META))
+                .update(builder -> parameters.get(META).ifPresent(builder::metadata))
                 .features(features)
                 .protocolVersion(session.protocolVersion().text())
                 .sessionContext(session.context())
@@ -477,6 +477,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         McpSession session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
 
         McpParameters parameters = new McpParameters(req.params());
+        McpParameters metadata = parameters.get(META);
         String resourceUri = parameters.get("uri").asString().orElse("");
         Optional<McpResource> resource = resources.content().stream()
                 .filter(r -> resourceUri.equals(r.uri()))
@@ -503,7 +504,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         session.beforeFeatureRequest(parameters, requestId);
         McpRequest request = McpRequest.builder()
                 .parameters(parameters)
-                .meta(parameters.get(META))
+                .update(builder -> metadata.ifPresent(builder::metadata))
                 .features(features)
                 .protocolVersion(session.protocolVersion().text())
                 .sessionContext(session.context())
@@ -553,7 +554,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             session.beforeFeatureRequest(parameters, requestId);
             subscriber.get().subscribe(McpSubscribeRequest.builder()
                                                .parameters(parameters)
-                                               .meta(parameters.get(META))
+                                               .update(builder -> parameters.get(META).ifPresent(builder::metadata))
                                                .features(features)
                                                .protocolVersion(session.protocolVersion().text())
                                                .sessionContext(session.context())
@@ -597,7 +598,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             session.beforeFeatureRequest(parameters, requestId);
             unsubscriber.get().unsubscribe(McpUnsubscribeRequest.builder()
                                                    .parameters(parameters)
-                                                   .meta(parameters.get(META))
+                                                   .update(builder -> parameters.get(META).ifPresent(builder::metadata))
                                                    .features(features)
                                                    .protocolVersion(session.protocolVersion().text())
                                                    .sessionContext(session.context())
@@ -674,7 +675,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         session.beforeFeatureRequest(parameters, requestId);
         McpRequest request = McpRequest.builder()
                 .parameters(parameters)
-                .meta(parameters.get(META))
+                .update(builder -> parameters.get(META).ifPresent(builder::metadata))
                 .features(features)
                 .protocolVersion(session.protocolVersion().text())
                 .sessionContext(session.context())
@@ -743,7 +744,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             session.beforeFeatureRequest(parameters, requestId);
             McpRequest request = McpRequest.builder()
                     .parameters(parameters)
-                    .meta(parameters.get(META))
+                    .update(builder -> parameters.get(META).ifPresent(builder::metadata))
                     .features(features)
                     .protocolVersion(session.protocolVersion().text())
                     .sessionContext(session.context())

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
@@ -35,6 +35,7 @@ import io.helidon.config.Config;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Status;
+import io.helidon.json.JsonException;
 import io.helidon.json.JsonNull;
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonString;
@@ -70,6 +71,7 @@ import static io.helidon.extensions.mcp.server.McpJsonSerializer.METHOD_TOOLS_CA
 import static io.helidon.extensions.mcp.server.McpJsonSerializer.METHOD_TOOLS_LIST;
 import static io.helidon.extensions.mcp.server.McpJsonSerializer.isResponse;
 import static io.helidon.extensions.mcp.server.McpJsonSerializer.prettyPrint;
+import static io.helidon.extensions.mcp.server.McpMetadata.META;
 import static io.helidon.extensions.mcp.server.McpSession.State.INITIALIZING;
 import static io.helidon.extensions.mcp.server.McpStreamableHttpTransportManager.SESSION_ID_HEADER;
 import static io.helidon.jsonrpc.core.JsonRpcError.INTERNAL_ERROR;
@@ -436,7 +438,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         session.beforeFeatureRequest(parameters, requestId);
         McpRequest request = McpRequest.builder()
                 .parameters(parameters)
-                .meta(parameters.get("_meta"))
+                .meta(parameters.get(META))
                 .features(features)
                 .protocolVersion(session.protocolVersion().text())
                 .sessionContext(session.context())
@@ -501,7 +503,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         session.beforeFeatureRequest(parameters, requestId);
         McpRequest request = McpRequest.builder()
                 .parameters(parameters)
-                .meta(parameters.get("_meta"))
+                .meta(parameters.get(META))
                 .features(features)
                 .protocolVersion(session.protocolVersion().text())
                 .sessionContext(session.context())
@@ -551,7 +553,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             session.beforeFeatureRequest(parameters, requestId);
             subscriber.get().subscribe(McpSubscribeRequest.builder()
                                                .parameters(parameters)
-                                               .meta(parameters.get("_meta"))
+                                               .meta(parameters.get(META))
                                                .features(features)
                                                .protocolVersion(session.protocolVersion().text())
                                                .sessionContext(session.context())
@@ -595,7 +597,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             session.beforeFeatureRequest(parameters, requestId);
             unsubscriber.get().unsubscribe(McpUnsubscribeRequest.builder()
                                                    .parameters(parameters)
-                                                   .meta(parameters.get("_meta"))
+                                                   .meta(parameters.get(META))
                                                    .features(features)
                                                    .protocolVersion(session.protocolVersion().text())
                                                    .sessionContext(session.context())
@@ -672,7 +674,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         session.beforeFeatureRequest(parameters, requestId);
         McpRequest request = McpRequest.builder()
                 .parameters(parameters)
-                .meta(parameters.get("_meta"))
+                .meta(parameters.get(META))
                 .features(features)
                 .protocolVersion(session.protocolVersion().text())
                 .sessionContext(session.context())
@@ -741,7 +743,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             session.beforeFeatureRequest(parameters, requestId);
             McpRequest request = McpRequest.builder()
                     .parameters(parameters)
-                    .meta(parameters.get("_meta"))
+                    .meta(parameters.get(META))
                     .features(features)
                     .protocolVersion(session.protocolVersion().text())
                     .sessionContext(session.context())
@@ -775,7 +777,13 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
                 if (LOGGER.isLoggable(Level.DEBUG)) {
                     LOGGER.log(Level.DEBUG, "Client response:\n" + prettyPrint(object));
                 }
-                session.get().acceptResponse(new McpResponseImpl(object, req.context()));
+                try {
+                    session.get().acceptResponse(new McpResponseImpl(object, req.context()));
+                } catch (JsonException e) {
+                    if (LOGGER.isLoggable(Level.TRACE)) {
+                        LOGGER.log(Level.TRACE, "Received a response with an invalid request id", e);
+                    }
+                }
                 return Optional.empty();
             }
         }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
@@ -438,7 +438,9 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         session.beforeFeatureRequest(parameters, requestId);
         McpRequest request = McpRequest.builder()
                 .parameters(parameters)
-                .update(builder -> parameters.get(META).as(JsonObject.class).ifPresent(builder::metadata))
+                .update(builder -> parameters.get(META).as(JsonObject.class)
+                        .map(McpParameters::new)
+                        .ifPresent(builder::metadata))
                 .features(features)
                 .protocolVersion(session.protocolVersion().text())
                 .sessionContext(session.context())
@@ -477,7 +479,9 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         McpSession session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
 
         McpParameters parameters = new McpParameters(req.params());
-        OptionalValue<JsonObject> metadata = parameters.get(META).as(JsonObject.class);
+        Optional<McpParameters> metadata = parameters.get(META)
+                .as(JsonObject.class)
+                .map(McpParameters::new);
         String resourceUri = parameters.get("uri").asString().orElse("");
         Optional<McpResource> resource = resources.content().stream()
                 .filter(r -> resourceUri.equals(r.uri()))
@@ -555,6 +559,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             subscriber.get().subscribe(McpSubscribeRequest.builder()
                                                .parameters(parameters)
                                                .update(builder -> parameters.get(META).as(JsonObject.class)
+                                                       .map(McpParameters::new)
                                                        .ifPresent(builder::metadata))
                                                .features(features)
                                                .protocolVersion(session.protocolVersion().text())
@@ -600,6 +605,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             unsubscriber.get().unsubscribe(McpUnsubscribeRequest.builder()
                                                    .parameters(parameters)
                                                    .update(builder -> parameters.get(META).as(JsonObject.class)
+                                                           .map(McpParameters::new)
                                                            .ifPresent(builder::metadata))
                                                    .features(features)
                                                    .protocolVersion(session.protocolVersion().text())
@@ -677,7 +683,9 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         session.beforeFeatureRequest(parameters, requestId);
         McpRequest request = McpRequest.builder()
                 .parameters(parameters)
-                .update(builder -> parameters.get(META).as(JsonObject.class).ifPresent(builder::metadata))
+                .update(builder -> parameters.get(META).as(JsonObject.class)
+                        .map(McpParameters::new)
+                        .ifPresent(builder::metadata))
                 .features(features)
                 .protocolVersion(session.protocolVersion().text())
                 .sessionContext(session.context())
@@ -746,7 +754,9 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             session.beforeFeatureRequest(parameters, requestId);
             McpRequest request = McpRequest.builder()
                     .parameters(parameters)
-                    .update(builder -> parameters.get(META).as(JsonObject.class).ifPresent(builder::metadata))
+                    .update(builder -> parameters.get(META).as(JsonObject.class)
+                            .map(McpParameters::new)
+                            .ifPresent(builder::metadata))
                     .features(features)
                     .protocolVersion(session.protocolVersion().text())
                     .sessionContext(session.context())

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpServerFeature.java
@@ -438,7 +438,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         session.beforeFeatureRequest(parameters, requestId);
         McpRequest request = McpRequest.builder()
                 .parameters(parameters)
-                .update(builder -> parameters.get(META).ifPresent(builder::metadata))
+                .update(builder -> parameters.get(META).as(JsonObject.class).ifPresent(builder::metadata))
                 .features(features)
                 .protocolVersion(session.protocolVersion().text())
                 .sessionContext(session.context())
@@ -477,7 +477,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         McpSession session = foundSession.orElseThrow(() -> new McpInternalException("Session not found"));
 
         McpParameters parameters = new McpParameters(req.params());
-        McpParameters metadata = parameters.get(META);
+        OptionalValue<JsonObject> metadata = parameters.get(META).as(JsonObject.class);
         String resourceUri = parameters.get("uri").asString().orElse("");
         Optional<McpResource> resource = resources.content().stream()
                 .filter(r -> resourceUri.equals(r.uri()))
@@ -554,7 +554,8 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             session.beforeFeatureRequest(parameters, requestId);
             subscriber.get().subscribe(McpSubscribeRequest.builder()
                                                .parameters(parameters)
-                                               .update(builder -> parameters.get(META).ifPresent(builder::metadata))
+                                               .update(builder -> parameters.get(META).as(JsonObject.class)
+                                                       .ifPresent(builder::metadata))
                                                .features(features)
                                                .protocolVersion(session.protocolVersion().text())
                                                .sessionContext(session.context())
@@ -598,7 +599,8 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             session.beforeFeatureRequest(parameters, requestId);
             unsubscriber.get().unsubscribe(McpUnsubscribeRequest.builder()
                                                    .parameters(parameters)
-                                                   .update(builder -> parameters.get(META).ifPresent(builder::metadata))
+                                                   .update(builder -> parameters.get(META).as(JsonObject.class)
+                                                           .ifPresent(builder::metadata))
                                                    .features(features)
                                                    .protocolVersion(session.protocolVersion().text())
                                                    .sessionContext(session.context())
@@ -675,7 +677,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
         session.beforeFeatureRequest(parameters, requestId);
         McpRequest request = McpRequest.builder()
                 .parameters(parameters)
-                .update(builder -> parameters.get(META).ifPresent(builder::metadata))
+                .update(builder -> parameters.get(META).as(JsonObject.class).ifPresent(builder::metadata))
                 .features(features)
                 .protocolVersion(session.protocolVersion().text())
                 .sessionContext(session.context())
@@ -744,7 +746,7 @@ public final class McpServerFeature implements HttpFeature, RuntimeType.Api<McpS
             session.beforeFeatureRequest(parameters, requestId);
             McpRequest request = McpRequest.builder()
                     .parameters(parameters)
-                    .update(builder -> parameters.get(META).ifPresent(builder::metadata))
+                    .update(builder -> parameters.get(META).as(JsonObject.class).ifPresent(builder::metadata))
                     .features(features)
                     .protocolVersion(session.protocolVersion().text())
                     .sessionContext(session.context())

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSession.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSession.java
@@ -86,6 +86,7 @@ class McpSession {
     }
 
     void onDisconnect(ServerResponse response) {
+        state = State.DISCONNECTED;
         pendingResponses.disconnect();
         sessions.remove(id);
         manager.onDisconnect(response);
@@ -266,6 +267,7 @@ class McpSession {
     }
 
     enum State {
+        DISCONNECTED,
         INITIALIZED,
         INITIALIZING,
         UNINITIALIZED

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSession.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSession.java
@@ -136,6 +136,10 @@ class McpSession {
         pendingResponses.discard(requestId);
     }
 
+    void abortResponse(long requestId, RuntimeException exception) {
+        pendingResponses.abort(requestId, exception);
+    }
+
     McpFeatures createFeatures(JsonValue requestId) {
         String key = requestId.toString();
         var transport = transports.get(key)

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSession.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSession.java
@@ -15,12 +15,10 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import java.lang.System.Logger.Level;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -30,7 +28,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.helidon.common.LazyValue;
 import io.helidon.common.LruCache;
 import io.helidon.common.context.Context;
-import io.helidon.json.JsonException;
 import io.helidon.json.JsonValue;
 import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.jsonrpc.JsonRpcRequest;
@@ -129,14 +126,7 @@ class McpSession {
     }
 
     void acceptResponse(McpResponse response) {
-        try {
-            long requestId = response.asJsonObject().longValue("id").orElseThrow();
-            pendingResponses.accept(requestId, response);
-        } catch (JsonException | NoSuchElementException e) {
-            if (LOGGER.isLoggable(Level.TRACE)) {
-                LOGGER.log(Level.TRACE, "Received a response with wrong request id type", e);
-            }
-        }
+        pendingResponses.accept(response);
     }
 
     void prepareResponse(long requestId) {

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSession.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSession.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -29,6 +28,7 @@ import io.helidon.common.LazyValue;
 import io.helidon.common.LruCache;
 import io.helidon.common.context.Context;
 import io.helidon.json.JsonValue;
+import io.helidon.service.registry.Services;
 import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.jsonrpc.JsonRpcRequest;
 import io.helidon.webserver.jsonrpc.JsonRpcResponse;
@@ -60,11 +60,10 @@ class McpSession {
         this.manager = manager;
         this.sessions = sessions;
         this.clientCapabilities = new HashSet<>();
-        this.featureListeners = new CopyOnWriteArrayList<>();
+        this.featureListeners = Services.all(McpFeatureLifecycle.class);
         this.features = LruCache.create(config.maxRequestsPerSession());
         this.transports = LruCache.create(config.maxRequestsPerSession());
         this.pendingResponses = new McpPendingResponses(config.maxRequestsPerSession());
-        this.featureListeners.add(McpProgress.McpProgressListener.create());
         this.sessionFeatures = LazyValue.create(() -> new McpSessionFeatures(this));
         this.context.register(McpServerConfigBlueprint.class, config);
     }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSession.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSession.java
@@ -20,18 +20,14 @@ import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import io.helidon.common.LazyValue;
 import io.helidon.common.LruCache;
-import io.helidon.common.UncheckedException;
 import io.helidon.common.context.Context;
 import io.helidon.json.JsonException;
 import io.helidon.json.JsonObject;
@@ -56,8 +52,7 @@ class McpSession {
     private final List<McpFeatureLifecycle> featureListeners;
     private final LruCache<String, McpTransport> transports;
     private final LazyValue<McpSessionFeatures> sessionFeatures;
-    private final AtomicBoolean active = new AtomicBoolean(true);
-    private final BlockingQueue<JsonObject> responses = new LinkedBlockingQueue<>();
+    private final McpPendingResponses pendingResponses;
 
     private McpJsonSerializer serializer;
     private volatile State state = UNINITIALIZED;
@@ -71,6 +66,7 @@ class McpSession {
         this.featureListeners = new CopyOnWriteArrayList<>();
         this.features = LruCache.create(config.maxRequestsPerSession());
         this.transports = LruCache.create(config.maxRequestsPerSession());
+        this.pendingResponses = new McpPendingResponses(config.maxRequestsPerSession());
         this.featureListeners.add(McpProgress.McpProgressListener.create());
         this.sessionFeatures = LazyValue.create(() -> new McpSessionFeatures(this));
         this.context.register(McpServerConfigBlueprint.class, config);
@@ -81,7 +77,7 @@ class McpSession {
         McpTransport transport = transports.get(key)
                 .orElseThrow(() -> new McpInternalException("No transport for id " + id));
         transport.send(response);
-        transports.remove(key);
+        clearRequest(id);
     }
 
     void onConnect(ServerResponse response) {
@@ -90,7 +86,7 @@ class McpSession {
     }
 
     void onDisconnect(ServerResponse response) {
-        active.compareAndSet(true, false);
+        pendingResponses.disconnect();
         sessions.remove(id);
         manager.onDisconnect(response);
     }
@@ -133,45 +129,42 @@ class McpSession {
 
     void acceptResponse(JsonObject response) {
         try {
-            responses.put(response);
-        } catch (InterruptedException e) {
-            throw new UncheckedException(e);
+            long requestId = response.longValue("id").orElseThrow();
+            pendingResponses.accept(requestId, response);
+        } catch (JsonException | NoSuchElementException e) {
+            if (LOGGER.isLoggable(Level.TRACE)) {
+                LOGGER.log(Level.TRACE, "Received a response with wrong request id type", e);
+            }
         }
+    }
+
+    void prepareResponse(long requestId) {
+        pendingResponses.prepare(requestId);
+    }
+
+    void discardResponse(long requestId) {
+        pendingResponses.discard(requestId);
     }
 
     McpFeatures createFeatures(JsonValue requestId, JsonRpcRequest request, JsonRpcResponse response) {
         String key = requestId.toString();
         var transport = transports.get(key)
                 .orElseThrow(() -> new McpInternalException("No transport for request id " + requestId));
-        McpFeatures feat = new McpFeatures(this, transport);
+        McpFeatures feat = new McpFeatures(this, transport, request.context());
         features.put(key, feat);
         return feat;
     }
 
     JsonObject pollResponse(long requestId, Duration timeout) {
-        while (active.get()) {
-            try {
-                JsonObject response = responses.poll(timeout.toMillis(), TimeUnit.MILLISECONDS);
-                if (response != null) {
-                    if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
-                        LOGGER.log(System.Logger.Level.DEBUG, "Response:\n" + prettyPrint(response));
-                    }
-                    long id = response.longValue("id").orElseThrow();
-                    if (id == requestId) {
-                        return response;
-                    }
-                } else {
-                    return serializer.jsonrpcErrorTimeoutResponse(requestId);
-                }
-            } catch (JsonException e) {
-                if (LOGGER.isLoggable(Level.TRACE)) {
-                    LOGGER.log(Level.TRACE, "Received a response with wrong request id type", e);
-                }
-            } catch (InterruptedException e) {
-                throw new McpInternalException("Session interrupted.", e);
-            }
+        Optional<JsonObject> response = pendingResponses.poll(requestId, timeout);
+        if (response.isEmpty()) {
+            return serializer.jsonrpcErrorTimeoutResponse(requestId);
         }
-        throw new McpInternalException("Session disconnected");
+        JsonObject jsonResponse = response.get();
+        if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
+            LOGGER.log(System.Logger.Level.DEBUG, "Response:\n" + prettyPrint(jsonResponse));
+        }
+        return jsonResponse;
     }
 
     /**
@@ -209,8 +202,10 @@ class McpSession {
     void initializeClientCapabilities(McpParameters capabilities) {
         var sampling = capabilities.get(McpCapability.SAMPLING.text());
         sampling.ifPresent(it -> clientCapabilities.add(McpCapability.SAMPLING));
-        sampling.get("tools")
-                .ifPresent(it -> clientCapabilities.add(McpCapability.SAMPLING_TOOLS));
+        if (protocolVersion == McpProtocolVersion.VERSION_2025_11_25) {
+            sampling.get("tools")
+                    .ifPresent(it -> clientCapabilities.add(McpCapability.SAMPLING_TOOLS));
+        }
         sampling.get("context")
                 .ifPresent(it -> clientCapabilities.add(McpCapability.SAMPLING_CONTEXT));
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSession.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSession.java
@@ -31,7 +31,6 @@ import io.helidon.common.LazyValue;
 import io.helidon.common.LruCache;
 import io.helidon.common.context.Context;
 import io.helidon.json.JsonException;
-import io.helidon.json.JsonObject;
 import io.helidon.json.JsonValue;
 import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.jsonrpc.JsonRpcRequest;
@@ -129,9 +128,9 @@ class McpSession {
         });
     }
 
-    void acceptResponse(JsonObject response) {
+    void acceptResponse(McpResponse response) {
         try {
-            long requestId = response.longValue("id").orElseThrow();
+            long requestId = response.asJsonObject().longValue("id").orElseThrow();
             pendingResponses.accept(requestId, response);
         } catch (JsonException | NoSuchElementException e) {
             if (LOGGER.isLoggable(Level.TRACE)) {
@@ -148,25 +147,22 @@ class McpSession {
         pendingResponses.discard(requestId);
     }
 
-    McpFeatures createFeatures(JsonValue requestId, JsonRpcRequest request, JsonRpcResponse response) {
+    McpFeatures createFeatures(JsonValue requestId) {
         String key = requestId.toString();
         var transport = transports.get(key)
                 .orElseThrow(() -> new McpInternalException("No transport for request id " + requestId));
-        McpFeatures feat = new McpFeatures(this, transport, request.context());
+        McpFeatures feat = new McpFeatures(this, transport);
         features.put(key, feat);
         return feat;
     }
 
-    JsonObject pollResponse(long requestId, Duration timeout) {
-        Optional<JsonObject> response = pendingResponses.poll(requestId, timeout);
-        if (response.isEmpty()) {
-            return serializer.jsonrpcErrorTimeoutResponse(requestId);
-        }
-        JsonObject jsonResponse = response.get();
+    Optional<McpResponse> pollResponse(long requestId, Duration timeout) {
+        Optional<McpResponse> response = pendingResponses.poll(requestId, timeout);
         if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
-            LOGGER.log(System.Logger.Level.DEBUG, "Response:\n" + prettyPrint(jsonResponse));
+            response.map(McpResponse::asJsonObject)
+                    .ifPresent(it -> LOGGER.log(System.Logger.Level.DEBUG, "Response:\n" + prettyPrint(it)));
         }
-        return jsonResponse;
+        return response;
     }
 
     /**

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpSession.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpSession.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.common.LazyValue;
 import io.helidon.common.LruCache;
@@ -53,9 +54,9 @@ class McpSession {
     private final LruCache<String, McpTransport> transports;
     private final LazyValue<McpSessionFeatures> sessionFeatures;
     private final McpPendingResponses pendingResponses;
+    private final AtomicReference<State> state = new AtomicReference<>(UNINITIALIZED);
 
     private McpJsonSerializer serializer;
-    private volatile State state = UNINITIALIZED;
     private volatile McpProtocolVersion protocolVersion;
 
     McpSession(McpSessions sessions, McpTransportManager manager, McpServerConfig config, String id) {
@@ -86,7 +87,7 @@ class McpSession {
     }
 
     void onDisconnect(ServerResponse response) {
-        state = State.DISCONNECTED;
+        state.set(State.DISCONNECTED);
         pendingResponses.disconnect();
         sessions.remove(id);
         manager.onDisconnect(response);
@@ -259,11 +260,11 @@ class McpSession {
     }
 
     void state(State state) {
-        this.state = state;
+        this.state.updateAndGet(current -> current == State.DISCONNECTED ? current : state);
     }
 
     State state() {
-        return state;
+        return state.get();
     }
 
     enum State {

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpTool.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpTool.java
@@ -48,7 +48,7 @@ public interface McpTool {
      * Tool execution.
      *
      * @param request tool request
-     * @return tool execution result
+     * @return tool execution result, never {@code null}
      */
     McpToolResult tool(McpToolRequest request);
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpToolChoice.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpToolChoice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,33 @@
  */
 package io.helidon.extensions.mcp.server;
 
-import java.util.Optional;
+import java.util.Locale;
 
 /**
- * Tool contents that can be returned as part of the tool execution.
+ * Tool selection behavior for an MCP sampling request.
  */
-interface McpToolContent extends McpContent, McpMetadata {
+public enum McpToolChoice {
     /**
-     * Optional annotations for this content block.
-     *
-     * @return annotations
+     * The model decides whether to use tools.
      */
-    Optional<McpAnnotations> annotations();
+    AUTO,
 
+    /**
+     * The model must use at least one tool.
+     */
+    REQUIRED,
+
+    /**
+     * The model must not use tools.
+     */
+    NONE;
+
+    /**
+     * Returns the protocol representation of this tool choice.
+     *
+     * @return protocol representation
+     */
+    String text() {
+        return name().toLowerCase(Locale.ROOT);
+    }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpToolConfigBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpToolConfigBlueprint.java
@@ -78,7 +78,7 @@ interface McpToolConfigBlueprint {
     /**
      * Tool execution.
      *
-     * @return tool execution result
+     * @return tool execution result, never {@code null}
      */
     Function<McpToolRequest, McpToolResult> tool();
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpToolRequestImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpToolRequestImpl.java
@@ -15,6 +15,8 @@
  */
 package io.helidon.extensions.mcp.server;
 
+import java.util.Optional;
+
 import io.helidon.common.context.Context;
 
 final class McpToolRequestImpl implements McpToolRequest {
@@ -43,8 +45,8 @@ final class McpToolRequestImpl implements McpToolRequest {
     }
 
     @Override
-    public McpParameters meta() {
-        return request.meta();
+    public Optional<McpParameters> metadata() {
+        return request.metadata();
     }
 
     @Override

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpToolRequestImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpToolRequestImpl.java
@@ -45,7 +45,7 @@ final class McpToolRequestImpl implements McpToolRequest {
     }
 
     @Override
-    public Optional<McpParameters> metadata() {
+    public Optional<Object> metadata() {
         return request.metadata();
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpToolRequestImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpToolRequestImpl.java
@@ -45,7 +45,7 @@ final class McpToolRequestImpl implements McpToolRequest {
     }
 
     @Override
-    public Optional<Object> metadata() {
+    public Optional<McpParameters> metadata() {
         return request.metadata();
     }
 

--- a/server/src/test/java/io/helidon/extensions/mcp/server/ConfigurationTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/ConfigurationTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static io.helidon.extensions.mcp.server.McpPagination.DEFAULT_PAGE_SIZE;
+import static io.helidon.extensions.mcp.server.McpSampling.DEFAULT_MAX_TOOL_ITERATIONS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -50,6 +51,7 @@ class ConfigurationTest {
         assertThat(config.instructions().orElse(""), is("instructions"));
         assertThat(config.subscriptionTimeout(), is(Duration.ofSeconds(1)));
         assertThat(config.stateless(), is(true));
+        assertThat(config.maxSamplingToolIterations(), is(3));
         assertThat(config.maxSessionCount(), is(1));
         assertThat(config.maxRequestsPerSession(), is(1));
     }
@@ -71,6 +73,7 @@ class ConfigurationTest {
         assertThat(config.rootListTimeout(), is(Duration.ofSeconds(5)));
         assertThat(config.subscriptionTimeout(), is(Duration.ofMinutes(2)));
         assertThat(config.stateless(), is(false));
+        assertThat(config.maxSamplingToolIterations(), is(DEFAULT_MAX_TOOL_ITERATIONS));
         assertThat(config.maxSessionCount(), is(1000));
         assertThat(config.maxRequestsPerSession(), is(1000));
     }
@@ -101,6 +104,18 @@ class ConfigurationTest {
             fail("negative value are not allowed and must be checked.");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), is("value must be greater than zero"));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0})
+    void testConfigurationInvalidSamplingToolIterations(int value) {
+        try {
+            var configSource = ConfigSources.create(Map.of("max-sampling-tool-iterations", Integer.toString(value)));
+            var config = McpServerConfig.create(Config.just(configSource));
+            fail("Sampling tool iterations must be greater than zero.");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), is("Maximum sampling tool iterations must be greater than zero"));
         }
     }
 }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpCancellationTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpCancellationTest.java
@@ -69,4 +69,45 @@ class McpCancellationTest {
         assertThat(result.reason(), is(Optional.of(reason)));
         assertThat(counter.get(), is(1));
     }
+
+    @Test
+    void testMultipleCancellationHooks() {
+        AtomicInteger firstCounter = new AtomicInteger();
+        AtomicInteger secondCounter = new AtomicInteger();
+        McpCancellation cancellation = new McpCancellation();
+
+        cancellation.registerCancellationHook(firstCounter::incrementAndGet);
+        cancellation.registerCancellationHook(secondCounter::incrementAndGet);
+        cancellation.cancel(JsonNull.instance());
+        cancellation.cancel(JsonNull.instance());
+
+        assertThat(firstCounter.get(), is(1));
+        assertThat(secondCounter.get(), is(1));
+    }
+
+    @Test
+    void testFailingCancellationHookDoesNotSuppressLaterHook() {
+        AtomicInteger counter = new AtomicInteger();
+        McpCancellation cancellation = new McpCancellation();
+
+        cancellation.registerCancellationHook(() -> {
+            throw new IllegalStateException("Hook failed");
+        });
+        cancellation.registerCancellationHook(counter::incrementAndGet);
+        cancellation.cancel(JsonNull.instance());
+
+        assertThat(counter.get(), is(1));
+    }
+
+    @Test
+    void testLateCancellationHookRunsImmediately() {
+        AtomicInteger counter = new AtomicInteger();
+        McpCancellation cancellation = new McpCancellation();
+        cancellation.cancel(JsonNull.instance());
+
+        cancellation.registerCancellationHook(counter::incrementAndGet);
+        cancellation.cancel(JsonNull.instance());
+
+        assertThat(counter.get(), is(1));
+    }
 }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpCancellationTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpCancellationTest.java
@@ -86,6 +86,19 @@ class McpCancellationTest {
     }
 
     @Test
+    void testUnregisteredCancellationHookDoesNotRun() {
+        AtomicInteger counter = new AtomicInteger();
+        McpCancellation cancellation = new McpCancellation();
+        Runnable hook = counter::incrementAndGet;
+        cancellation.registerCancellationHook(hook);
+
+        cancellation.unregisterCancellationHook(hook);
+        cancellation.cancel(JsonNull.instance());
+
+        assertThat(counter.get(), is(0));
+    }
+
+    @Test
     void testFailingCancellationHookDoesNotSuppressLaterHook() {
         AtomicInteger counter = new AtomicInteger();
         McpCancellation cancellation = new McpCancellation();

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3Test.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3Test.java
@@ -28,6 +28,7 @@ import io.helidon.json.schema.SchemaString;
 
 import org.junit.jupiter.api.Test;
 
+import static io.helidon.extensions.mcp.server.McpMetadata.META;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -326,8 +327,8 @@ class McpJsonSerializerV3Test {
 
         JsonObject payload = MJS.toJson(content).orElseThrow().build();
 
-        assertThat(payload.objectValue("_meta").orElseThrow().booleanValue("content").orElseThrow(), is(true));
-        assertThat(payload.objectValue("resource").orElseThrow().objectValue("_meta").isEmpty(), is(true));
+        assertThat(payload.objectValue(META).orElseThrow().booleanValue("content").orElseThrow(), is(true));
+        assertThat(payload.objectValue("resource").orElseThrow().objectValue(META).isEmpty(), is(true));
     }
 
     @Test

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3Test.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3Test.java
@@ -322,7 +322,7 @@ class McpJsonSerializerV3Test {
                 .uri(URI.create("memory://forecast"))
                 .mediaType(MediaTypes.TEXT_PLAIN)
                 .text("sunny")
-                .metadata(new StructuredContent("metadata"))
+                .metadata(McpParameters.create(new StructuredContent("metadata")))
                 .build();
 
         JsonObject payload = MJS.toJson(content).orElseThrow().build();

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3Test.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3Test.java
@@ -322,12 +322,12 @@ class McpJsonSerializerV3Test {
                 .uri(URI.create("memory://forecast"))
                 .mediaType(MediaTypes.TEXT_PLAIN)
                 .text("sunny")
-                .metadata(new McpParameters(JsonObject.builder().set("content", true).build()))
+                .metadata(new StructuredContent("metadata"))
                 .build();
 
         JsonObject payload = MJS.toJson(content).orElseThrow().build();
 
-        assertThat(payload.objectValue(META).orElseThrow().booleanValue("content").orElseThrow(), is(true));
+        assertThat(payload.objectValue(META).orElseThrow().stringValue("foo").orElseThrow(), is("metadata"));
         assertThat(payload.objectValue("resource").orElseThrow().objectValue(META).isEmpty(), is(true));
     }
 

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3Test.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3Test.java
@@ -15,6 +15,8 @@
  */
 package io.helidon.extensions.mcp.server;
 
+import java.net.URI;
+
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.json.JsonArray;
 import io.helidon.json.JsonObject;
@@ -224,7 +226,7 @@ class McpJsonSerializerV3Test {
     @Test
     void testStructuredContentWithContent() {
         McpToolResult result = McpToolResult.builder()
-                .addTextContent("foo")
+                .addTextContent(McpToolTextContent.builder().text("foo").build())
                 .structuredContent(new StructuredContent("bar"))
                 .build();
         McpToolConfig config = McpToolConfig.builder()
@@ -252,6 +254,32 @@ class McpJsonSerializerV3Test {
 
         JsonObject structuredContent = object.objectValue("structuredContent").orElseThrow();
         assertThat(structuredContent.stringValue("foo").orElseThrow(), is("bar"));
+    }
+
+    @Test
+    void testStructuredContentAppendsCompatibilityTextToNonTextContent() {
+        McpToolResult result = McpToolResult.builder()
+                .addImageContent(McpToolImageContent.builder()
+                                         .data(new byte[] {1, 2, 3})
+                                         .mediaType(MediaTypes.create("image/png"))
+                                         .build())
+                .structuredContent(new StructuredContent("bar"))
+                .build();
+        McpToolConfig config = McpToolConfig.builder()
+                .schema("")
+                .name("name")
+                .description("description")
+                .tool(request -> null)
+                .build();
+
+        JsonArray content = MJS.toolCall(new McpToolImpl(config), result)
+                .arrayValue("content")
+                .orElseThrow();
+
+        assertThat(content.size(), is(2));
+        assertThat(content.values().get(0).asObject().stringValue("type").orElseThrow(), is("image"));
+        assertThat(content.values().get(1).asObject().stringValue("type").orElseThrow(), is("text"));
+        assertThat(content.values().get(1).asObject().stringValue("text").orElseThrow(), is("{\"foo\":\"bar\"}"));
     }
 
     @Test
@@ -285,6 +313,21 @@ class McpJsonSerializerV3Test {
         assertThat(payload.stringValue("uri").orElseThrow(), is("https://foo"));
         assertThat(payload.stringValue("description").orElseThrow(), is("description"));
         assertThat(payload.stringValue("mimeType").orElseThrow(), is(MediaTypes.APPLICATION_JSON_VALUE));
+    }
+
+    @Test
+    void testSerializeTextResourceMetadata() {
+        McpToolContent content = McpToolTextResourceContent.builder()
+                .uri(URI.create("memory://forecast"))
+                .mediaType(MediaTypes.TEXT_PLAIN)
+                .text("sunny")
+                .metadata(new McpParameters(JsonObject.builder().set("content", true).build()))
+                .build();
+
+        JsonObject payload = MJS.toJson(content).orElseThrow().build();
+
+        assertThat(payload.objectValue("_meta").orElseThrow().booleanValue("content").orElseThrow(), is(true));
+        assertThat(payload.objectValue("resource").orElseThrow().objectValue("_meta").isEmpty(), is(true));
     }
 
     @Test

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4Test.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4Test.java
@@ -581,7 +581,6 @@ class McpJsonSerializerV4Test {
         McpSamplingToolResultContent firstResult = McpSamplingToolResultContent.builder()
                 .toolUseId("call-1")
                 .result(McpToolResult.builder()
-                                .addTextContent("18 C")
                                 .structuredContent(Map.of("temperature", 18))
                                 .build())
                 .metadata(new McpParameters(JsonParser.create("{\"cached\":true}").readJsonObject()))
@@ -620,9 +619,11 @@ class McpJsonSerializerV4Test {
         assertThat(results.size(), is(2));
         assertThat(first.stringValue("type").orElseThrow(), is("tool_result"));
         assertThat(first.stringValue("toolUseId").orElseThrow(), is("call-1"));
-        assertThat(first.arrayValue("content").orElseThrow().values().getFirst().asObject()
+        JsonArray firstContent = first.arrayValue("content").orElseThrow();
+        assertThat(firstContent.size(), is(1));
+        assertThat(firstContent.values().getFirst().asObject()
                            .stringValue("text").orElseThrow(),
-                   is("18 C"));
+                   is("{\"temperature\":18}"));
         assertThat(first.booleanValue("isError").orElseThrow(), is(false));
         assertThat(first.objectValue("structuredContent").orElseThrow()
                            .intValue("temperature").orElseThrow(),

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4Test.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4Test.java
@@ -242,7 +242,9 @@ class McpJsonSerializerV4Test {
         assertThat(content.id(), is("call-1"));
         assertThat(content.name(), is("weather"));
         assertThat(content.input().get("city").asString().orElse(""), is("Prague"));
-        assertThat(content.metadata().orElseThrow().get("provider").asString().orElse(""), is("test"));
+        Object metadata = content.metadata().orElseThrow();
+        assertThat(metadata, instanceOf(JsonObject.class));
+        assertThat(((JsonObject) metadata).stringValue("provider").orElseThrow(), is("test"));
         assertThrows(McpSamplingException.class, response::asTextContent);
     }
 
@@ -334,18 +336,21 @@ class McpJsonSerializerV4Test {
         assertThat(result.audioContents().getFirst().data(), is("data".getBytes(StandardCharsets.UTF_8)));
         McpToolTextResourceContent textResource = result.textResourceContents().getFirst();
         assertThat(textResource.text(), is("sunny"));
-        assertThat(textResource.metadata().orElseThrow().get("embeddedText").asBoolean().orElseThrow(), is(true));
-        assertThat(textResource.metadata().orElseThrow().get("resourceText").isEmpty(), is(true));
+        JsonObject textResourceMetadata = (JsonObject) textResource.metadata().orElseThrow();
+        assertThat(textResourceMetadata.booleanValue("embeddedText").orElseThrow(), is(true));
+        assertThat(textResourceMetadata.value("resourceText").isEmpty(), is(true));
         McpToolBinaryResourceContent binaryResource = result.binaryResourceContents().getFirst();
         assertThat(binaryResource.data(), is("data".getBytes(StandardCharsets.UTF_8)));
-        assertThat(binaryResource.metadata().orElseThrow().get("embeddedBinary").asBoolean().orElseThrow(), is(true));
-        assertThat(binaryResource.metadata().orElseThrow().get("resourceBinary").isEmpty(), is(true));
+        JsonObject binaryResourceMetadata = (JsonObject) binaryResource.metadata().orElseThrow();
+        assertThat(binaryResourceMetadata.booleanValue("embeddedBinary").orElseThrow(), is(true));
+        assertThat(binaryResourceMetadata.value("resourceBinary").isEmpty(), is(true));
         McpToolResourceLinkContent link = result.resourceLinkContents().getFirst();
         assertThat(link.name(), is("weather"));
         assertThat(link.icons().getFirst().theme().orElseThrow(), is(McpIconTheme.DARK));
         assertThat(result.structuredContent().isPresent(), is(true));
         assertThat(result.error(), is(false));
-        assertThat(content.metadata().orElseThrow().get("cached").asBoolean().orElseThrow(), is(true));
+        JsonObject contentMetadata = (JsonObject) content.metadata().orElseThrow();
+        assertThat(contentMetadata.booleanValue("cached").orElseThrow(), is(true));
 
         McpSamplingRequest replay = McpSamplingRequest.builder()
                 .addMessage(McpSamplingMessage.builder()
@@ -411,12 +416,10 @@ class McpJsonSerializerV4Test {
                 }
                 """).readJsonObject());
 
-        assertThat(response.message().metadata().orElseThrow()
-                           .get("messageKey").asString().orElseThrow(),
-                   is("messageValue"));
-        assertThat(response.asTextContent().metadata().orElseThrow()
-                           .get("contentKey").asString().orElseThrow(),
-                   is("contentValue"));
+        JsonObject messageMetadata = (JsonObject) response.message().metadata().orElseThrow();
+        JsonObject contentMetadata = (JsonObject) response.asTextContent().metadata().orElseThrow();
+        assertThat(messageMetadata.stringValue("messageKey").orElseThrow(), is("messageValue"));
+        assertThat(contentMetadata.stringValue("contentKey").orElseThrow(), is("contentValue"));
         McpAnnotations annotations = response.asTextContent().annotations().orElseThrow();
         assertThat(annotations.audience(), contains(McpRole.USER, McpRole.ASSISTANT));
         assertThat(annotations.priority().orElseThrow(), is(0.8));
@@ -457,7 +460,7 @@ class McpJsonSerializerV4Test {
                                      .priority(0.8)
                                      .lastModified("2026-08-06T10:15:30Z")
                                      .build())
-                .metadata(new McpParameters(JsonObject.builder().set("provider", "test").build()))
+                .metadata(Map.of("provider", "test"))
                 .build();
         McpSamplingRequest request = McpSamplingRequest.builder()
                 .addMessage(McpSamplingMessage.builder()
@@ -584,7 +587,7 @@ class McpJsonSerializerV4Test {
                 .result(McpToolResult.builder()
                                 .structuredContent(Map.of("temperature", 18))
                                 .build())
-                .metadata(new McpParameters(JsonParser.create("{\"cached\":true}").readJsonObject()))
+                .metadata(Map.of("cached", true))
                 .build();
         McpSamplingToolResultContent secondResult = McpSamplingToolResultContent.builder()
                 .toolUseId("call-2")
@@ -926,7 +929,8 @@ class McpJsonSerializerV4Test {
 
     @Test
     void rejectsNonObjectSamplingToolParameters() {
-        McpParameters scalar = new McpParameters(JsonObject.builder().set("value", 1).build()).get("value");
+        McpParameters scalarParameter = new McpParameters(JsonObject.builder().set("value", 1).build()).get("value");
+        int scalarMetadata = 1;
         McpSamplingToolUseContent validUse = McpSamplingToolUseContent.builder()
                 .id("call-1")
                 .name("weather")
@@ -942,7 +946,7 @@ class McpJsonSerializerV4Test {
                                     .addContent(McpSamplingToolUseContent.builder()
                                                         .id("call-1")
                                                         .name("weather")
-                                                        .input(scalar)
+                                                        .input(scalarParameter)
                                                         .build())
                                     .build())
                 .addMessage(McpSamplingMessage.builder()
@@ -954,7 +958,7 @@ class McpJsonSerializerV4Test {
                 .addMessage(McpSamplingMessage.builder()
                                     .role(McpRole.ASSISTANT)
                                     .addContent(McpSamplingToolUseContent.builder(validUse)
-                                                        .metadata(scalar)
+                                                        .metadata(scalarMetadata)
                                                         .build())
                                     .build())
                 .addMessage(McpSamplingMessage.builder()
@@ -970,14 +974,14 @@ class McpJsonSerializerV4Test {
                 .addMessage(McpSamplingMessage.builder()
                                     .role(McpRole.USER)
                                     .addContent(McpSamplingToolResultContent.builder(validResult)
-                                                        .metadata(scalar)
+                                                        .metadata(scalarMetadata)
                                                         .build())
                                     .build())
                 .build();
         McpSamplingRequest scalarMessageMeta = McpSamplingRequest.builder()
                 .addMessage(McpSamplingMessage.builder()
                                     .role(McpRole.ASSISTANT)
-                                    .metadata(scalar)
+                                    .metadata(scalarMetadata)
                                     .addContent(validUse)
                                     .build())
                 .addMessage(McpSamplingMessage.builder()

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4Test.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4Test.java
@@ -1224,16 +1224,16 @@ class McpJsonSerializerV4Test {
     }
 
     @Test
-    void rejectsUserRoleOrdinarySamplingResponse() {
-        McpSamplingException exception = assertThrows(McpSamplingException.class,
-                                                      () -> SERIALIZER.createSamplingResponse(response("""
-                                                              {
-                                                                "type": "text",
-                                                                "text": "user response"
-                                                              }
-                                                              """, "endTurn", "user")));
+    void acceptsUserRoleOrdinarySamplingResponse() {
+        McpSamplingResponse response = SERIALIZER.createSamplingResponse(response("""
+                {
+                  "type": "text",
+                  "text": "user response"
+                }
+                """, "endTurn", "user"));
 
-        assertThat(exception.getMessage(), is("Sampling response must have an assistant message role"));
+        assertThat(response.message().role(), is(McpRole.USER));
+        assertThat(response.asTextContent().text(), is("user response"));
     }
 
     @Test
@@ -1261,7 +1261,7 @@ class McpJsonSerializerV4Test {
                                                                 "content": [],
                                                                 "isError": false
                                                               }
-                                                              """, "endTurn")));
+                                                              """, "endTurn", "user")));
 
         assertThat(exception.getMessage(), is("Sampling response must not contain tool result content"));
     }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4Test.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4Test.java
@@ -15,10 +15,16 @@
  */
 package io.helidon.extensions.mcp.server;
 
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
+import io.helidon.json.JsonArray;
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonParser;
+import io.helidon.json.JsonString;
 import io.helidon.json.JsonValue;
 
 import org.junit.jupiter.api.Test;
@@ -26,6 +32,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -82,6 +90,123 @@ class McpJsonSerializerV4Test {
     }
 
     @Test
+    void serializesSamplingToolsAndToolChoiceExactly() {
+        McpToolConfig toolConfig = McpToolConfig.builder()
+                .name("weather")
+                .title("Weather")
+                .description("Looks up the weather for a city")
+                .schema("""
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "city": {"type": "string"}
+                                  },
+                                  "required": ["city"]
+                                }
+                                """)
+                .outputSchema("""
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "temperature": {"type": "number"}
+                                        },
+                                        "required": ["temperature"]
+                                      }
+                                      """)
+                .tool(request -> McpToolResult.create())
+                .build();
+        McpTool tool = new McpToolImpl(toolConfig);
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTool(tool.name())
+                .toolChoice(McpToolChoice.REQUIRED)
+                .build();
+
+        JsonObject params = SERIALIZER.toJson(request, List.of(tool)).build();
+        JsonObject expected = JsonParser.create("""
+                {
+                  "tools": [
+                    {
+                      "name": "weather",
+                      "title": "Weather",
+                      "description": "Looks up the weather for a city",
+                      "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                          "city": {"type": "string"}
+                        },
+                        "required": ["city"]
+                      },
+                      "outputSchema": {
+                        "type": "object",
+                        "properties": {
+                          "temperature": {"type": "number"}
+                        },
+                        "required": ["temperature"]
+                      }
+                    }
+                  ],
+                  "toolChoice": {"mode": "required"}
+                }
+                """).readJsonObject();
+
+        assertThat(params.value("tools").orElseThrow(), is(expected.value("tools").orElseThrow()));
+        assertThat(params.value("toolChoice").orElseThrow(), is(expected.value("toolChoice").orElseThrow()));
+    }
+
+    @ParameterizedTest
+    @EnumSource(McpToolChoice.class)
+    void serializesEverySamplingToolChoiceMode(McpToolChoice choice) {
+        String expected = switch (choice) {
+            case AUTO -> "auto";
+            case REQUIRED -> "required";
+            case NONE -> "none";
+        };
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .toolChoice(choice)
+                .build();
+
+        JsonObject toolChoice = SERIALIZER.toJson(request, List.of())
+                .build()
+                .objectValue("toolChoice")
+                .orElseThrow();
+
+        assertThat(toolChoice.stringValue("mode").orElseThrow(), is(expected));
+    }
+
+    @Test
+    void serializesSamplingToolChoiceIndependentlyOfDefaultLocale() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr"));
+
+            assertThat(McpToolChoice.REQUIRED.text(), is("required"));
+        } finally {
+            Locale.setDefault(previous);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = McpProtocolVersion.class,
+                names = {"VERSION_2024_11_05", "VERSION_2025_03_26", "VERSION_2025_06_18"})
+    void omitsSamplingToolsAndToolChoiceFromLegacyProtocolVersions(McpProtocolVersion version) {
+        McpToolConfig toolConfig = McpToolConfig.builder()
+                .name("weather")
+                .schema("{\"type\":\"object\"}")
+                .tool(request -> McpToolResult.create())
+                .build();
+        McpTool tool = new McpToolImpl(toolConfig);
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTool(tool.name())
+                .toolChoice(McpToolChoice.NONE)
+                .build();
+
+        JsonObject params = McpJsonSerializer.create(version).toJson(request, List.of(tool)).build();
+
+        assertThat(params.value("tools").isEmpty(), is(true));
+        assertThat(params.value("toolChoice").isEmpty(), is(true));
+    }
+
+    @Test
     void parsesSingleSamplingContentBlock() {
         McpSamplingResponse response = SERIALIZER.createSamplingResponse(response("""
                 {
@@ -90,8 +215,785 @@ class McpJsonSerializerV4Test {
                 }
                 """, "endTurn"));
 
-        assertThat(response.messages().size(), is(1));
-        assertThat(response.asTextMessage().text(), is("first"));
+        assertThat(response.message().role(), is(McpRole.ASSISTANT));
+        assertThat(response.message().contents().size(), is(1));
+        assertThat(response.asTextContent().text(), is("first"));
+        assertThat(response.message().contents().getFirst(), sameInstance(response.asTextContent()));
+    }
+
+    @Test
+    void parsesSingleSamplingToolUseContentBlock() {
+        McpSamplingResponse response = SERIALIZER.createSamplingResponse(response("""
+                {
+                  "type": "tool_use",
+                  "id": "call-1",
+                  "name": "weather",
+                  "input": {"city": "Prague"},
+                  "_meta": {"provider": "test"}
+                }
+                """, "toolUse"));
+
+        McpSamplingToolUseContent content = response.asToolUseContent();
+        assertThat(response.message().role(), is(McpRole.ASSISTANT));
+        assertThat(response.message().contents().size(), is(1));
+        assertThat(response.message().contents().getFirst(), sameInstance(content));
+        assertThat(content.type(), is(McpSamplingContentType.TOOL_USE));
+        assertThat(content.id(), is("call-1"));
+        assertThat(content.name(), is("weather"));
+        assertThat(content.input().get("city").asString().orElse(""), is("Prague"));
+        assertThat(content.metadata().orElseThrow().get("provider").asString().orElse(""), is("test"));
+        assertThrows(McpSamplingException.class, response::asTextContent);
+    }
+
+    @Test
+    void parsesSamplingToolResultContentBlock() {
+        JsonObject wireResponse = response("""
+                {
+                  "type": "tool_result",
+                  "toolUseId": "call-1",
+                  "content": [
+                    {
+                      "type": "image",
+                      "data": "ZGF0YQ==",
+                      "mimeType": "image/png",
+                      "annotations": {"audience": ["assistant"], "priority": 0.6},
+                      "_meta": {"image": true}
+                    },
+                    {
+                      "type": "text",
+                      "text": "18 C",
+                      "annotations": {"lastModified": "2026-08-06T10:15:30Z"},
+                      "_meta": {"text": true}
+                    },
+                    {
+                      "type": "resource_link",
+                      "uri": "https://example.com/weather",
+                      "name": "weather",
+                      "annotations": {"audience": ["user"]},
+                      "_meta": {"link": true},
+                      "icons": [
+                        {
+                          "src": "https://example.com/weather.png",
+                          "mimeType": "image/png",
+                          "sizes": ["48x48", "any"],
+                          "theme": "dark"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "resource",
+                      "resource": {
+                        "uri": "memory://forecast",
+                        "mimeType": "text/plain",
+                        "text": "sunny",
+                        "_meta": {"resourceText": true}
+                      },
+                      "annotations": {"priority": 0.7},
+                      "_meta": {"embeddedText": true}
+                    },
+                    {
+                      "type": "audio",
+                      "data": "ZGF0YQ==",
+                      "mimeType": "audio/wav",
+                      "annotations": {"audience": ["assistant"]},
+                      "_meta": {"audio": true}
+                    },
+                    {
+                      "type": "resource",
+                      "resource": {
+                        "uri": "memory://raw",
+                        "mimeType": "application/octet-stream",
+                        "blob": "ZGF0YQ==",
+                        "_meta": {"resourceBinary": true}
+                      },
+                      "annotations": {"priority": 0.2},
+                      "_meta": {"embeddedBinary": true}
+                    }
+                  ],
+                  "structuredContent": {"temperature": 18},
+                  "isError": false,
+                  "_meta": {"cached": true}
+                }
+                """, "endTurn", "user");
+        JsonArray wireContent = wireResponse.objectValue("result").orElseThrow()
+                .objectValue("content").orElseThrow()
+                .arrayValue("content").orElseThrow();
+        McpSamplingResponse response = SERIALIZER.createSamplingResponse(wireResponse);
+
+        assertThat(response.message().role(), is(McpRole.USER));
+        assertThat(response.message().contents().getFirst(), instanceOf(McpSamplingToolResultContent.class));
+        McpSamplingToolResultContent content = (McpSamplingToolResultContent) response.message().contents().getFirst();
+        McpToolResult result = content.result();
+        assertThat(content.toolUseId(), is("call-1"));
+        assertThat(result.textContents().getFirst().text(), is("18 C"));
+        assertThat(result.imageContents().getFirst().data(), is("data".getBytes(StandardCharsets.UTF_8)));
+        assertThat(result.audioContents().getFirst().data(), is("data".getBytes(StandardCharsets.UTF_8)));
+        McpToolTextResourceContent textResource = result.textResourceContents().getFirst();
+        assertThat(textResource.text(), is("sunny"));
+        assertThat(textResource.metadata().orElseThrow().get("embeddedText").asBoolean().orElseThrow(), is(true));
+        assertThat(textResource.metadata().orElseThrow().get("resourceText").isEmpty(), is(true));
+        McpToolBinaryResourceContent binaryResource = result.binaryResourceContents().getFirst();
+        assertThat(binaryResource.data(), is("data".getBytes(StandardCharsets.UTF_8)));
+        assertThat(binaryResource.metadata().orElseThrow().get("embeddedBinary").asBoolean().orElseThrow(), is(true));
+        assertThat(binaryResource.metadata().orElseThrow().get("resourceBinary").isEmpty(), is(true));
+        McpToolResourceLinkContent link = result.resourceLinkContents().getFirst();
+        assertThat(link.name(), is("weather"));
+        assertThat(link.icons().getFirst().theme().orElseThrow(), is(McpIconTheme.DARK));
+        assertThat(result.structuredContent().isPresent(), is(true));
+        assertThat(result.error(), is(false));
+        assertThat(content.metadata().orElseThrow().get("cached").asBoolean().orElseThrow(), is(true));
+
+        McpSamplingRequest replay = McpSamplingRequest.builder()
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.ASSISTANT)
+                                    .addContent(McpSamplingToolUseContent.builder()
+                                                        .id("call-1")
+                                                        .name("weather")
+                                                        .input(new McpParameters(JsonObject.empty()))
+                                                        .build())
+                                    .build())
+                .addMessage(response.message())
+                .build();
+        JsonArray replayedContent = SERIALIZER.toJson(replay, List.of()).build()
+                .arrayValue("messages").orElseThrow()
+                .values().get(1).asObject()
+                .objectValue("content").orElseThrow()
+                .arrayValue("content").orElseThrow();
+        assertThat(replayedContent.values().stream()
+                           .map(JsonValue::asObject)
+                           .map(block -> block.stringValue("type").orElseThrow())
+                           .toList(),
+                   contains("text", "image", "audio", "resource", "resource", "resource_link"));
+        assertThat(replayedContent.values().get(0).toString(), is(wireContent.values().get(1).toString()));
+        assertThat(replayedContent.values().get(1).toString(), is(wireContent.values().get(0).toString()));
+        assertThat(replayedContent.values().get(2).toString(), is(wireContent.values().get(4).toString()));
+        assertThat(replayedContent.values().get(5).toString(), is(wireContent.values().get(2).toString()));
+        JsonObject replayedTextResource = replayedContent.values().get(3).asObject();
+        assertThat(replayedTextResource.objectValue("_meta").orElseThrow()
+                           .booleanValue("embeddedText").orElseThrow(),
+                   is(true));
+        assertThat(replayedTextResource.objectValue("resource").orElseThrow().objectValue("_meta").isEmpty(), is(true));
+        JsonObject replayedBinaryResource = replayedContent.values().get(4).asObject();
+        assertThat(replayedBinaryResource.objectValue("_meta").orElseThrow()
+                           .booleanValue("embeddedBinary").orElseThrow(),
+                   is(true));
+        assertThat(replayedBinaryResource.objectValue("resource").orElseThrow()
+                           .objectValue("_meta").isEmpty(),
+                   is(true));
+    }
+
+    @Test
+    void preservesSamplingMessageAndContentMetadata() {
+        McpSamplingResponse response = SERIALIZER.createSamplingResponse(JsonParser.create("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "result": {
+                    "model": "test-model",
+                    "role": "assistant",
+                    "content": {
+                      "type": "text",
+                      "text": "hello",
+                      "annotations": {
+                        "audience": ["user", "assistant"],
+                        "priority": 0.8,
+                        "lastModified": "2026-08-06T10:15:30Z"
+                      },
+                      "_meta": {"contentKey": "contentValue"}
+                    },
+                    "_meta": {"messageKey": "messageValue"},
+                    "stopReason": "endTurn"
+                  }
+                }
+                """).readJsonObject());
+
+        assertThat(response.message().metadata().orElseThrow()
+                           .get("messageKey").asString().orElseThrow(),
+                   is("messageValue"));
+        assertThat(response.asTextContent().metadata().orElseThrow()
+                           .get("contentKey").asString().orElseThrow(),
+                   is("contentValue"));
+        McpAnnotations annotations = response.asTextContent().annotations().orElseThrow();
+        assertThat(annotations.audience(), contains(McpRole.USER, McpRole.ASSISTANT));
+        assertThat(annotations.priority().orElseThrow(), is(0.8));
+        assertThat(annotations.lastModified().orElseThrow(), is("2026-08-06T10:15:30Z"));
+
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addMessage(response.message())
+                .build();
+        JsonObject serialized = SERIALIZER.toJson(request, List.of()).build()
+                .arrayValue("messages").orElseThrow()
+                .values().getFirst().asObject();
+
+        assertThat(serialized.objectValue("_meta").orElseThrow()
+                           .stringValue("messageKey").orElseThrow(),
+                   is("messageValue"));
+        assertThat(serialized.objectValue("content").orElseThrow()
+                           .objectValue("_meta").orElseThrow()
+                           .stringValue("contentKey").orElseThrow(),
+                   is("contentValue"));
+        JsonObject serializedAnnotations = serialized.objectValue("content").orElseThrow()
+                .objectValue("annotations").orElseThrow();
+        assertThat(serializedAnnotations.arrayValue("audience").orElseThrow().values().stream()
+                           .map(JsonValue::asString)
+                           .map(JsonString::value)
+                           .toList(),
+                   contains("user", "assistant"));
+        assertThat(serializedAnnotations.doubleValue("priority").orElseThrow(), is(0.8));
+        assertThat(serializedAnnotations.stringValue("lastModified").orElseThrow(),
+                   is("2026-08-06T10:15:30Z"));
+    }
+
+    @Test
+    void preservesSamplingContentAnnotationsAndMetadataIn2025JuneProtocol() {
+        McpSamplingTextContent content = McpSamplingTextContent.builder()
+                .text("hello")
+                .annotations(McpAnnotations.builder()
+                                     .addAudience(McpRole.USER)
+                                     .priority(0.8)
+                                     .lastModified("2026-08-06T10:15:30Z")
+                                     .build())
+                .metadata(new McpParameters(JsonObject.builder().set("provider", "test").build()))
+                .build();
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(content)
+                                    .build())
+                .build();
+
+        JsonObject serialized = LEGACY_SERIALIZER.toJson(request, List.of()).build()
+                .arrayValue("messages").orElseThrow()
+                .values().getFirst().asObject()
+                .objectValue("content").orElseThrow();
+
+        JsonObject annotations = serialized.objectValue("annotations").orElseThrow();
+        assertThat(annotations.arrayValue("audience").orElseThrow().values().getFirst().asString().value(),
+                   is("user"));
+        assertThat(annotations.doubleValue("priority").orElseThrow(), is(0.8));
+        assertThat(annotations.stringValue("lastModified").orElseThrow(), is("2026-08-06T10:15:30Z"));
+        assertThat(serialized.objectValue("_meta").orElseThrow().stringValue("provider").orElseThrow(),
+                   is("test"));
+    }
+
+    @Test
+    void parsesSamplingAnnotationsIndependentlyOfDefaultLocale() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr"));
+            McpSamplingResponse response = SERIALIZER.createSamplingResponse(response("""
+                    {
+                      "type": "text",
+                      "text": "hello",
+                      "annotations": {"audience": ["assistant"]}
+                    }
+                    """, "endTurn"));
+
+            assertThat(response.asTextContent().annotations().orElseThrow().audience(),
+                       contains(McpRole.ASSISTANT));
+        } finally {
+            Locale.setDefault(previous);
+        }
+    }
+
+    @Test
+    void validatesAnnotationPriorityRange() {
+        assertThat(McpAnnotations.builder().priority(0.0).build().priority().orElseThrow(), is(0.0));
+        assertThat(McpAnnotations.builder().priority(1.0).build().priority().orElseThrow(), is(1.0));
+        assertThat(McpAnnotations.builder().priority(0.5).clearPriority().build().priority().isEmpty(), is(true));
+
+        for (double priority : List.of(-0.1, 1.1, Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY)) {
+            assertThrows(IllegalArgumentException.class, () -> McpAnnotations.builder().priority(priority));
+        }
+    }
+
+    @Test
+    void parsesParallelSamplingToolUseContentBlocks() {
+        McpSamplingResponse response = SERIALIZER.createSamplingResponse(response("""
+                [
+                  {
+                    "type": "tool_use",
+                    "id": "call-1",
+                    "name": "weather",
+                    "input": {"city": "Prague"}
+                  },
+                  {
+                    "type": "tool_use",
+                    "id": "call-2",
+                    "name": "weather",
+                    "input": {"city": "London"}
+                  }
+                ]
+                """, "toolUse"));
+
+        List<McpSamplingContent> contents = response.message().contents();
+        assertThat(response.message().role(), is(McpRole.ASSISTANT));
+        assertThat(contents.size(), is(2));
+        assertThat(contents.get(0), instanceOf(McpSamplingToolUseContent.class));
+        assertThat(contents.get(1), instanceOf(McpSamplingToolUseContent.class));
+        McpSamplingToolUseContent first = (McpSamplingToolUseContent) contents.get(0);
+        McpSamplingToolUseContent second = (McpSamplingToolUseContent) contents.get(1);
+        assertThat(first.id(), is("call-1"));
+        assertThat(first.input().get("city").asString().orElse(""), is("Prague"));
+        assertThat(second.id(), is("call-2"));
+        assertThat(second.input().get("city").asString().orElse(""), is("London"));
+        assertThat(response.asToolUseContent(), sameInstance(first));
+    }
+
+    @Test
+    void rejectsDuplicateSamplingToolUseIdentifiersInResponse() {
+        McpSamplingException exception = assertThrows(McpSamplingException.class,
+                                                      () -> SERIALIZER.createSamplingResponse(response("""
+                                                              [
+                                                                {
+                                                                  "type": "tool_use",
+                                                                  "id": "call-1",
+                                                                  "name": "weather",
+                                                                  "input": {}
+                                                                },
+                                                                {
+                                                                  "type": "tool_use",
+                                                                  "id": "call-1",
+                                                                  "name": "weather",
+                                                                  "input": {}
+                                                                }
+                                                              ]
+                                                              """, "toolUse")));
+
+        assertThat(exception.getMessage(), is("Sampling tool use identifiers must be unique within a message"));
+    }
+
+    @Test
+    void groupsSamplingToolResultsWithStructuredContentAndError() {
+        McpSamplingToolUseContent firstUse = McpSamplingToolUseContent.builder()
+                .id("call-1")
+                .name("weather")
+                .input(new McpParameters(JsonParser.create("{\"city\":\"Prague\"}").readJsonObject()))
+                .build();
+        McpSamplingToolUseContent secondUse = McpSamplingToolUseContent.builder()
+                .id("call-2")
+                .name("weather")
+                .input(new McpParameters(JsonParser.create("{\"city\":\"London\"}").readJsonObject()))
+                .build();
+        McpSamplingToolResultContent firstResult = McpSamplingToolResultContent.builder()
+                .toolUseId("call-1")
+                .result(McpToolResult.builder()
+                                .addTextContent("18 C")
+                                .structuredContent(Map.of("temperature", 18))
+                                .build())
+                .metadata(new McpParameters(JsonParser.create("{\"cached\":true}").readJsonObject()))
+                .build();
+        McpSamplingToolResultContent secondResult = McpSamplingToolResultContent.builder()
+                .toolUseId("call-2")
+                .result(McpToolResult.builder()
+                                .addTextContent("Weather provider failed")
+                                .error(true)
+                                .build())
+                .build();
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(McpSamplingTextContent.create("Compare the weather"))
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.ASSISTANT)
+                                    .addContent(firstUse)
+                                    .addContent(secondUse)
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(firstResult)
+                                    .addContent(secondResult)
+                                    .build())
+                .build();
+
+        JsonArray messages = SERIALIZER.toJson(request, List.of()).build().arrayValue("messages").orElseThrow();
+        assertThat(messages.size(), is(3));
+        JsonObject resultGroup = messages.values().get(2).asObject();
+        JsonArray results = resultGroup.arrayValue("content").orElseThrow();
+        JsonObject first = results.values().get(0).asObject();
+        JsonObject second = results.values().get(1).asObject();
+        assertThat(resultGroup.stringValue("role").orElseThrow(), is("user"));
+        assertThat(results.size(), is(2));
+        assertThat(first.stringValue("type").orElseThrow(), is("tool_result"));
+        assertThat(first.stringValue("toolUseId").orElseThrow(), is("call-1"));
+        assertThat(first.arrayValue("content").orElseThrow().values().getFirst().asObject()
+                           .stringValue("text").orElseThrow(),
+                   is("18 C"));
+        assertThat(first.booleanValue("isError").orElseThrow(), is(false));
+        assertThat(first.objectValue("structuredContent").orElseThrow()
+                           .intValue("temperature").orElseThrow(),
+                   is(18));
+        assertThat(first.objectValue("_meta").orElseThrow()
+                           .booleanValue("cached").orElseThrow(),
+                   is(true));
+        assertThat(second.stringValue("type").orElseThrow(), is("tool_result"));
+        assertThat(second.stringValue("toolUseId").orElseThrow(), is("call-2"));
+        assertThat(second.arrayValue("content").orElseThrow().values().getFirst().asObject()
+                           .stringValue("text").orElseThrow(),
+                   is("Weather provider failed"));
+        assertThat(second.booleanValue("isError").orElseThrow(), is(true));
+        assertThat(second.value("structuredContent").isEmpty(), is(true));
+    }
+
+    @Test
+    void preservesOrderedMultiRoundSamplingMessages() {
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(McpSamplingTextContent.create("Weather in Prague?"))
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.ASSISTANT)
+                                    .addContent(McpSamplingToolUseContent.builder()
+                                                        .id("call-1")
+                                                        .name("weather")
+                                                        .input(new McpParameters(JsonParser.create("""
+                                                                {"city":"Prague"}
+                                                                """).readJsonObject()))
+                                                        .build())
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(McpSamplingToolResultContent.builder()
+                                                        .toolUseId("call-1")
+                                                        .result(McpToolResult.create("18 C"))
+                                                        .build())
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.ASSISTANT)
+                                    .addContent(McpSamplingTextContent.create("It is 18 C in Prague"))
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(McpSamplingTextContent.create("And London?"))
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.ASSISTANT)
+                                    .addContent(McpSamplingToolUseContent.builder()
+                                                        .id("call-2")
+                                                        .name("weather")
+                                                        .input(new McpParameters(JsonParser.create("""
+                                                                {"city":"London"}
+                                                                """).readJsonObject()))
+                                                        .build())
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(McpSamplingToolResultContent.builder()
+                                                        .toolUseId("call-2")
+                                                        .result(McpToolResult.create("15 C"))
+                                                        .build())
+                                    .build())
+                .build();
+
+        JsonArray messages = SERIALIZER.toJson(request, List.of()).build().arrayValue("messages").orElseThrow();
+
+        assertThat(messages.values().stream()
+                           .map(JsonValue::asObject)
+                           .map(message -> message.stringValue("role").orElseThrow())
+                           .toList(),
+                   contains("user", "assistant", "user", "assistant", "user", "assistant", "user"));
+        assertThat(messages.values().stream()
+                           .map(JsonValue::asObject)
+                           .map(message -> message.objectValue("content").orElseThrow())
+                           .map(content -> content.stringValue("type").orElseThrow())
+                           .toList(),
+                   contains("text", "tool_use", "tool_result", "text", "text", "tool_use", "tool_result"));
+        assertThat(messages.values().get(1).asObject()
+                           .objectValue("content").orElseThrow()
+                           .stringValue("id").orElseThrow(),
+                   is("call-1"));
+        assertThat(messages.values().get(5).asObject()
+                           .objectValue("content").orElseThrow()
+                           .stringValue("id").orElseThrow(),
+                   is("call-2"));
+    }
+
+    @Test
+    void preservesAdjacentSameRoleSamplingMessageBoundaries() {
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(McpSamplingTextContent.create("first"))
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(McpSamplingTextContent.create("second"))
+                                    .build())
+                .build();
+
+        JsonArray messages = SERIALIZER.toJson(request, List.of()).build().arrayValue("messages").orElseThrow();
+
+        assertThat(messages.size(), is(2));
+        assertThat(messages.values().get(0).asObject()
+                           .objectValue("content").orElseThrow()
+                           .stringValue("text").orElseThrow(),
+                   is("first"));
+        assertThat(messages.values().get(1).asObject()
+                           .objectValue("content").orElseThrow()
+                           .stringValue("text").orElseThrow(),
+                   is("second"));
+    }
+
+    @Test
+    void keepsContentAfterToolUseInTheSameSamplingMessage() {
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.ASSISTANT)
+                                    .addContent(McpSamplingToolUseContent.builder()
+                                                        .id("call-1")
+                                                        .name("weather")
+                                                        .input(new McpParameters(JsonObject.empty()))
+                                                        .build())
+                                    .addContent(McpSamplingTextContent.create("Calling the weather tool"))
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(McpSamplingToolResultContent.builder()
+                                                        .toolUseId("call-1")
+                                                        .result(McpToolResult.create("18 C"))
+                                                        .build())
+                                    .build())
+                .build();
+
+        JsonArray messages = SERIALIZER.toJson(request, List.of()).build().arrayValue("messages").orElseThrow();
+
+        assertThat(messages.size(), is(2));
+        JsonArray assistantContent = messages.values().getFirst().asObject()
+                .arrayValue("content")
+                .orElseThrow();
+        assertThat(assistantContent.values().stream()
+                           .map(JsonValue::asObject)
+                           .map(content -> content.stringValue("type").orElseThrow())
+                           .toList(),
+                   contains("tool_use", "text"));
+        assertThat(messages.values().get(1).asObject()
+                           .objectValue("content").orElseThrow()
+                           .stringValue("type").orElseThrow(),
+                   is("tool_result"));
+    }
+
+    @Test
+    void validatesSamplingToolUseAndResultBalance() {
+        McpSamplingToolUseContent toolUse = McpSamplingToolUseContent.builder()
+                .id("call-1")
+                .name("weather")
+                .input(new McpParameters(JsonObject.empty()))
+                .build();
+        McpSamplingMessage toolUseMessage = McpSamplingMessage.builder()
+                .role(McpRole.ASSISTANT)
+                .addContent(toolUse)
+                .build();
+        McpSamplingRequest missingResult = McpSamplingRequest.builder()
+                .addMessage(toolUseMessage)
+                .build();
+        McpSamplingRequest mismatchedResult = McpSamplingRequest.builder()
+                .addMessage(toolUseMessage)
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(McpSamplingToolResultContent.builder()
+                                                        .toolUseId("call-2")
+                                                        .result(McpToolResult.create("result"))
+                                                        .build())
+                                    .build())
+                .build();
+        McpSamplingRequest orphanResult = McpSamplingRequest.builder()
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(McpSamplingToolResultContent.builder()
+                                                        .toolUseId("call-1")
+                                                        .result(McpToolResult.create("result"))
+                                                        .build())
+                                    .build())
+                .build();
+
+        McpSamplingException missing = assertThrows(McpSamplingException.class,
+                                                    () -> SERIALIZER.toJson(missingResult, List.of()));
+        McpSamplingException mismatched = assertThrows(McpSamplingException.class,
+                                                       () -> SERIALIZER.toJson(mismatchedResult, List.of()));
+        McpSamplingException orphan = assertThrows(McpSamplingException.class,
+                                                   () -> SERIALIZER.toJson(orphanResult, List.of()));
+
+        assertThat(missing.getMessage(), is("Sampling tool uses must be followed by matching tool results"));
+        assertThat(mismatched.getMessage(), is("Sampling tool uses must be followed by matching tool results"));
+        assertThat(orphan.getMessage(), is("Sampling tool result does not match a preceding tool use"));
+    }
+
+    @Test
+    void validatesSamplingToolContentRoles() {
+        McpSamplingToolUseContent toolUse = McpSamplingToolUseContent.builder()
+                .id("call-1")
+                .name("weather")
+                .input(new McpParameters(JsonObject.empty()))
+                .build();
+        McpSamplingToolResultContent toolResult = McpSamplingToolResultContent.builder()
+                .toolUseId("call-1")
+                .result(McpToolResult.create("result"))
+                .build();
+        McpSamplingRequest userToolUse = McpSamplingRequest.builder()
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(toolUse)
+                                    .build())
+                .build();
+        McpSamplingRequest assistantToolResult = McpSamplingRequest.builder()
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.ASSISTANT)
+                                    .addContent(toolUse)
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.ASSISTANT)
+                                    .addContent(toolResult)
+                                    .build())
+                .build();
+
+        McpSamplingException useRole = assertThrows(McpSamplingException.class,
+                                                    () -> SERIALIZER.toJson(userToolUse, List.of()));
+        McpSamplingException resultRole = assertThrows(McpSamplingException.class,
+                                                       () -> SERIALIZER.toJson(assistantToolResult, List.of()));
+
+        assertThat(useRole.getMessage(), is("Sampling tool use content must have an assistant message role"));
+        assertThat(resultRole.getMessage(), is("Sampling tool result content must have a user message role"));
+    }
+
+    @Test
+    void rejectsDuplicateAndInterruptedSamplingToolResults() {
+        McpSamplingToolUseContent firstUse = McpSamplingToolUseContent.builder()
+                .id("call-1")
+                .name("weather")
+                .input(new McpParameters(JsonObject.empty()))
+                .build();
+        McpSamplingToolUseContent secondUse = McpSamplingToolUseContent.builder()
+                .id("call-2")
+                .name("weather")
+                .input(new McpParameters(JsonObject.empty()))
+                .build();
+        McpSamplingToolResultContent firstResult = McpSamplingToolResultContent.builder()
+                .toolUseId("call-1")
+                .result(McpToolResult.create("result"))
+                .build();
+        McpSamplingRequest duplicateUses = McpSamplingRequest.builder()
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.ASSISTANT)
+                                    .addContent(firstUse)
+                                    .addContent(McpSamplingToolUseContent.builder(firstUse).build())
+                                    .build())
+                .build();
+        McpSamplingRequest duplicateResults = McpSamplingRequest.builder()
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.ASSISTANT)
+                                    .addContent(firstUse)
+                                    .addContent(secondUse)
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(firstResult)
+                                    .addContent(McpSamplingToolResultContent.builder(firstResult).build())
+                                    .build())
+                .build();
+        McpSamplingRequest interruptedResults = McpSamplingRequest.builder()
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.ASSISTANT)
+                                    .addContent(firstUse)
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(McpSamplingTextContent.create("intervening message"))
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(firstResult)
+                                    .build())
+                .build();
+
+        McpSamplingException duplicateUse = assertThrows(McpSamplingException.class,
+                                                         () -> SERIALIZER.toJson(duplicateUses, List.of()));
+        McpSamplingException duplicateResult = assertThrows(McpSamplingException.class,
+                                                            () -> SERIALIZER.toJson(duplicateResults, List.of()));
+        McpSamplingException interrupted = assertThrows(McpSamplingException.class,
+                                                        () -> SERIALIZER.toJson(interruptedResults, List.of()));
+
+        assertThat(duplicateUse.getMessage(), is("Sampling tool use identifiers must be unique within a message"));
+        assertThat(duplicateResult.getMessage(), is("Sampling tool uses must be followed by matching tool results"));
+        assertThat(interrupted.getMessage(), is("Sampling tool uses must be followed by matching tool results"));
+    }
+
+    @Test
+    void rejectsNonObjectSamplingToolParameters() {
+        McpParameters scalar = new McpParameters(JsonObject.builder().set("value", 1).build()).get("value");
+        McpSamplingToolUseContent validUse = McpSamplingToolUseContent.builder()
+                .id("call-1")
+                .name("weather")
+                .input(new McpParameters(JsonObject.empty()))
+                .build();
+        McpSamplingToolResultContent validResult = McpSamplingToolResultContent.builder()
+                .toolUseId("call-1")
+                .result(McpToolResult.create("result"))
+                .build();
+        McpSamplingRequest scalarInput = McpSamplingRequest.builder()
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.ASSISTANT)
+                                    .addContent(McpSamplingToolUseContent.builder()
+                                                        .id("call-1")
+                                                        .name("weather")
+                                                        .input(scalar)
+                                                        .build())
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(validResult)
+                                    .build())
+                .build();
+        McpSamplingRequest scalarUseMeta = McpSamplingRequest.builder()
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.ASSISTANT)
+                                    .addContent(McpSamplingToolUseContent.builder(validUse)
+                                                        .metadata(scalar)
+                                                        .build())
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(validResult)
+                                    .build())
+                .build();
+        McpSamplingRequest scalarResultMeta = McpSamplingRequest.builder()
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.ASSISTANT)
+                                    .addContent(validUse)
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(McpSamplingToolResultContent.builder(validResult)
+                                                        .metadata(scalar)
+                                                        .build())
+                                    .build())
+                .build();
+        McpSamplingRequest scalarMessageMeta = McpSamplingRequest.builder()
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.ASSISTANT)
+                                    .metadata(scalar)
+                                    .addContent(validUse)
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(validResult)
+                                    .build())
+                .build();
+
+        McpSamplingException input = assertThrows(McpSamplingException.class,
+                                                  () -> SERIALIZER.toJson(scalarInput, List.of()));
+        McpSamplingException useMeta = assertThrows(McpSamplingException.class,
+                                                    () -> SERIALIZER.toJson(scalarUseMeta, List.of()));
+        McpSamplingException resultMeta = assertThrows(McpSamplingException.class,
+                                                       () -> SERIALIZER.toJson(scalarResultMeta, List.of()));
+        McpSamplingException messageMeta = assertThrows(McpSamplingException.class,
+                                                        () -> SERIALIZER.toJson(scalarMessageMeta, List.of()));
+
+        assertThat(input.getMessage(), is("Sampling tool input must be a JSON object"));
+        assertThat(useMeta.getMessage(), is("Sampling content metadata must be a JSON object"));
+        assertThat(resultMeta.getMessage(), is("Sampling content metadata must be a JSON object"));
+        assertThat(messageMeta.getMessage(), is("Sampling message metadata must be a JSON object"));
     }
 
     @Test
@@ -109,15 +1011,101 @@ class McpJsonSerializerV4Test {
                 ]
                 """, "endTurn"));
 
-        assertThat(response.messages().size(), is(2));
-        assertThat(((McpSamplingTextMessage) response.messages().get(0)).text(), is("first"));
-        assertThat(((McpSamplingTextMessage) response.messages().get(1)).text(), is("second"));
-        assertThat(response.messages().getFirst().role(), is(McpRole.ASSISTANT));
-        assertThat(response.messages().get(1).role(), is(McpRole.ASSISTANT));
+        List<McpSamplingContent> contents = response.message().contents();
+        assertThat(response.message().role(), is(McpRole.ASSISTANT));
+        assertThat(contents.size(), is(2));
+        assertThat(((McpSamplingTextContent) contents.get(0)).text(), is("first"));
+        assertThat(((McpSamplingTextContent) contents.get(1)).text(), is("second"));
         assertThat(response.model(), is("test-model"));
         assertThat(response.rawStopReason().orElseThrow(), is("endTurn"));
         assertThat(response.stopReason().orElseThrow(), is(McpStopReason.END_TURN));
-        assertThrows(UnsupportedOperationException.class, () -> response.messages().clear());
+        assertThrows(UnsupportedOperationException.class, contents::clear);
+    }
+
+    @Test
+    void preservesSamplingMediaThroughToolLoopReplay() {
+        McpSamplingResponse response = SERIALIZER.createSamplingResponse(response("""
+                [
+                  {
+                    "type": "image",
+                    "data": "ZGF0YQ==",
+                    "mimeType": "image/png"
+                  },
+                  {
+                    "type": "audio",
+                    "data": "ZGF0YQ==",
+                    "mimeType": "audio/wav"
+                  }
+                ]
+                """, "endTurn"));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addMessage(response.message())
+                .build();
+
+        assertThat(new String(response.asImageContent().data(), StandardCharsets.UTF_8), is("data"));
+        assertThat(response.asImageContent().encodeBase64Data(), is("ZGF0YQ=="));
+        McpSamplingAudioContent audio = (McpSamplingAudioContent) response.message().contents().get(1);
+        assertThat(new String(audio.data(), StandardCharsets.UTF_8), is("data"));
+        assertThat(audio.encodeBase64Data(), is("ZGF0YQ=="));
+
+        JsonArray replayedMessages = SERIALIZER.toJson(request, List.of())
+                .build()
+                .arrayValue("messages")
+                .orElseThrow();
+        assertThat(replayedMessages.size(), is(1));
+        JsonArray replayedContent = replayedMessages.values().getFirst().asObject()
+                .arrayValue("content")
+                .orElseThrow();
+        assertThat(replayedContent.values().get(0).asObject()
+                           .stringValue("data").orElseThrow(),
+                   is("ZGF0YQ=="));
+        assertThat(replayedContent.values().get(1).asObject()
+                           .stringValue("data").orElseThrow(),
+                   is("ZGF0YQ=="));
+    }
+
+    @Test
+    void preservesMixedSamplingResponseBoundaryDuringReplay() {
+        McpSamplingResponse response = SERIALIZER.createSamplingResponse(response("""
+                [
+                  {
+                    "type": "text",
+                    "text": "I will call the weather tool"
+                  },
+                  {
+                    "type": "tool_use",
+                    "id": "call-1",
+                    "name": "weather",
+                    "input": {"city": "Prague"}
+                  }
+                ]
+                """, "toolUse"));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addMessage(response.message())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(McpSamplingToolResultContent.builder()
+                                                        .toolUseId("call-1")
+                                                        .result(McpToolResult.create("18 C"))
+                                                        .build())
+                                    .build())
+                .build();
+
+        JsonArray messages = SERIALIZER.toJson(request, List.of()).build().arrayValue("messages").orElseThrow();
+
+        assertThat(messages.size(), is(2));
+        JsonArray assistantContent = messages.values().getFirst().asObject()
+                .arrayValue("content")
+                .orElseThrow();
+        assertThat(assistantContent.values().stream()
+                           .map(JsonValue::asObject)
+                           .map(content -> content.stringValue("type").orElseThrow())
+                           .toList(),
+                   contains("text", "tool_use"));
+        assertThat(messages.values().get(1).asObject()
+                           .objectValue("content").orElseThrow()
+                           .stringValue("type").orElseThrow(),
+                   is("tool_result"));
     }
 
     @Test
@@ -135,16 +1123,28 @@ class McpJsonSerializerV4Test {
                 ]
                 """, "endTurn"));
 
-        assertThat(response.message(), sameInstance(response.messages().getFirst()));
-        assertThat(response.asTextMessage().text(), is("first"));
+        assertThat(response.asTextContent(), sameInstance(response.message().contents().getFirst()));
+        assertThat(response.asTextContent().text(), is("first"));
     }
 
     @Test
     void supportsEmptySamplingContentBlockArray() {
         McpSamplingResponse response = SERIALIZER.createSamplingResponse(response("[]", "endTurn"));
 
-        assertThat(response.messages().isEmpty(), is(true));
-        assertThrows(McpSamplingException.class, response::message);
+        assertThat(response.message().role(), is(McpRole.ASSISTANT));
+        assertThat(response.message().contents().isEmpty(), is(true));
+        assertThrows(UnsupportedOperationException.class,
+                     () -> response.message().contents().add(McpSamplingTextContent.create("unexpected")));
+        assertThrows(McpSamplingException.class, response::asTextContent);
+
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addMessage(response.message())
+                .build();
+        JsonArray serializedMessages = SERIALIZER.toJson(request, List.of()).build().arrayValue("messages").orElseThrow();
+        assertThat(serializedMessages.size(), is(1));
+        assertThat(serializedMessages.values().getFirst().asObject()
+                           .arrayValue("content").orElseThrow().size(),
+                   is(0));
     }
 
     @Test
@@ -183,7 +1183,7 @@ class McpJsonSerializerV4Test {
                 }
                 """, "providerSpecificReason"));
 
-        assertThat(response.asTextMessage().text(), is("first"));
+        assertThat(response.asTextContent().text(), is("first"));
         assertThat(response.model(), is("test-model"));
         assertThat(response.rawStopReason().orElseThrow(), is("providerSpecificReason"));
         assertThat(response.stopReason().isPresent(), is(false));
@@ -221,6 +1221,56 @@ class McpJsonSerializerV4Test {
     }
 
     @Test
+    void acceptsUserRoleOrdinarySamplingResponse() {
+        McpSamplingResponse response = SERIALIZER.createSamplingResponse(response("""
+                {
+                  "type": "text",
+                  "text": "user response"
+                }
+                """, "endTurn", "user"));
+
+        assertThat(response.message().role(), is(McpRole.USER));
+        assertThat(response.asTextContent().text(), is("user response"));
+    }
+
+    @Test
+    void rejectsUserRoleSamplingToolUseResponse() {
+        McpSamplingException exception = assertThrows(McpSamplingException.class,
+                                                      () -> SERIALIZER.createSamplingResponse(response("""
+                                                              {
+                                                                "type": "tool_use",
+                                                                "id": "call-1",
+                                                                "name": "weather",
+                                                                "input": {}
+                                                              }
+                                                              """, "toolUse", "user")));
+
+        assertThat(exception.getMessage(), is("Sampling tool use content must have an assistant message role"));
+    }
+
+    @Test
+    void rejectsMixedSamplingToolResultResponse() {
+        McpSamplingException exception = assertThrows(McpSamplingException.class,
+                                                      () -> SERIALIZER.createSamplingResponse(response("""
+                                                              [
+                                                                {
+                                                                  "type": "tool_result",
+                                                                  "toolUseId": "call-1",
+                                                                  "content": [],
+                                                                  "isError": false
+                                                                },
+                                                                {
+                                                                  "type": "text",
+                                                                  "text": "mixed content"
+                                                                }
+                                                              ]
+                                                              """, "endTurn", "user")));
+
+        assertThat(exception.getMessage(),
+                   is("Sampling messages with tool results must contain only tool results"));
+    }
+
+    @Test
     void keepsLegacySamplingContentObjectOnly() {
         McpSamplingException exception = assertThrows(McpSamplingException.class,
                                                       () -> LEGACY_SERIALIZER.createSamplingResponse(response("""
@@ -235,11 +1285,33 @@ class McpJsonSerializerV4Test {
         assertThat(exception.getMessage(), is("Wrong sampling response format"));
     }
 
+    @ParameterizedTest
+    @EnumSource(value = McpProtocolVersion.class,
+                names = {"VERSION_2024_11_05", "VERSION_2025_03_26", "VERSION_2025_06_18"})
+    void rejectsSamplingToolUseResponsesForLegacyProtocolVersions(McpProtocolVersion version) {
+        McpSamplingException exception = assertThrows(McpSamplingException.class,
+                                                      () -> McpJsonSerializer.create(version)
+                                                              .createSamplingResponse(response("""
+                                                                      {
+                                                                        "type": "tool_use",
+                                                                        "id": "call-1",
+                                                                        "name": "weather",
+                                                                        "input": {"city": "Prague"}
+                                                                      }
+                                                                      """, "toolUse")));
+
+        assertThat(exception.getMessage(), is("Wrong sampling response format"));
+    }
+
     private static JsonObject response(String content, String stopReason) {
+        return response(content, stopReason, "assistant");
+    }
+
+    private static JsonObject response(String content, String stopReason, String role) {
         JsonValue parsedContent = JsonParser.create(content).readJsonValue();
         JsonObject result = JsonObject.builder()
                 .set("model", "test-model")
-                .set("role", "assistant")
+                .set("role", role)
                 .set("content", parsedContent)
                 .set("stopReason", stopReason)
                 .build();

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4Test.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4Test.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import static io.helidon.extensions.mcp.server.McpMetadata.META;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
@@ -372,16 +373,16 @@ class McpJsonSerializerV4Test {
         assertThat(replayedContent.values().get(2).toString(), is(wireContent.values().get(4).toString()));
         assertThat(replayedContent.values().get(5).toString(), is(wireContent.values().get(2).toString()));
         JsonObject replayedTextResource = replayedContent.values().get(3).asObject();
-        assertThat(replayedTextResource.objectValue("_meta").orElseThrow()
+        assertThat(replayedTextResource.objectValue(META).orElseThrow()
                            .booleanValue("embeddedText").orElseThrow(),
                    is(true));
-        assertThat(replayedTextResource.objectValue("resource").orElseThrow().objectValue("_meta").isEmpty(), is(true));
+        assertThat(replayedTextResource.objectValue("resource").orElseThrow().objectValue(META).isEmpty(), is(true));
         JsonObject replayedBinaryResource = replayedContent.values().get(4).asObject();
-        assertThat(replayedBinaryResource.objectValue("_meta").orElseThrow()
+        assertThat(replayedBinaryResource.objectValue(META).orElseThrow()
                            .booleanValue("embeddedBinary").orElseThrow(),
                    is(true));
         assertThat(replayedBinaryResource.objectValue("resource").orElseThrow()
-                           .objectValue("_meta").isEmpty(),
+                           .objectValue(META).isEmpty(),
                    is(true));
     }
 
@@ -428,11 +429,11 @@ class McpJsonSerializerV4Test {
                 .arrayValue("messages").orElseThrow()
                 .values().getFirst().asObject();
 
-        assertThat(serialized.objectValue("_meta").orElseThrow()
+        assertThat(serialized.objectValue(META).orElseThrow()
                            .stringValue("messageKey").orElseThrow(),
                    is("messageValue"));
         assertThat(serialized.objectValue("content").orElseThrow()
-                           .objectValue("_meta").orElseThrow()
+                           .objectValue(META).orElseThrow()
                            .stringValue("contentKey").orElseThrow(),
                    is("contentValue"));
         JsonObject serializedAnnotations = serialized.objectValue("content").orElseThrow()
@@ -475,7 +476,7 @@ class McpJsonSerializerV4Test {
                    is("user"));
         assertThat(annotations.doubleValue("priority").orElseThrow(), is(0.8));
         assertThat(annotations.stringValue("lastModified").orElseThrow(), is("2026-08-06T10:15:30Z"));
-        assertThat(serialized.objectValue("_meta").orElseThrow().stringValue("provider").orElseThrow(),
+        assertThat(serialized.objectValue(META).orElseThrow().stringValue("provider").orElseThrow(),
                    is("test"));
     }
 
@@ -628,7 +629,7 @@ class McpJsonSerializerV4Test {
         assertThat(first.objectValue("structuredContent").orElseThrow()
                            .intValue("temperature").orElseThrow(),
                    is(18));
-        assertThat(first.objectValue("_meta").orElseThrow()
+        assertThat(first.objectValue(META).orElseThrow()
                            .booleanValue("cached").orElseThrow(),
                    is(true));
         assertThat(second.stringValue("type").orElseThrow(), is("tool_result"));

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4Test.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4Test.java
@@ -318,11 +318,14 @@ class McpJsonSerializerV4Test {
         JsonArray wireContent = wireResponse.objectValue("result").orElseThrow()
                 .objectValue("content").orElseThrow()
                 .arrayValue("content").orElseThrow();
-        McpSamplingResponse response = SERIALIZER.createSamplingResponse(wireResponse);
+        McpJsonSerializerV4 serializer = (McpJsonSerializerV4) SERIALIZER;
+        McpSamplingToolResultContent content = (McpSamplingToolResultContent) serializer.parseContent(
+                wireResponse.objectValue("result").orElseThrow().objectValue("content").orElseThrow());
+        McpSamplingMessage resultMessage = McpSamplingMessage.builder()
+                .role(McpRole.USER)
+                .addContent(content)
+                .build();
 
-        assertThat(response.message().role(), is(McpRole.USER));
-        assertThat(response.message().contents().getFirst(), instanceOf(McpSamplingToolResultContent.class));
-        McpSamplingToolResultContent content = (McpSamplingToolResultContent) response.message().contents().getFirst();
         McpToolResult result = content.result();
         assertThat(content.toolUseId(), is("call-1"));
         assertThat(result.textContents().getFirst().text(), is("18 C"));
@@ -352,7 +355,7 @@ class McpJsonSerializerV4Test {
                                                         .input(new McpParameters(JsonObject.empty()))
                                                         .build())
                                     .build())
-                .addMessage(response.message())
+                .addMessage(resultMessage)
                 .build();
         JsonArray replayedContent = SERIALIZER.toJson(replay, List.of()).build()
                 .arrayValue("messages").orElseThrow()
@@ -1221,16 +1224,16 @@ class McpJsonSerializerV4Test {
     }
 
     @Test
-    void acceptsUserRoleOrdinarySamplingResponse() {
-        McpSamplingResponse response = SERIALIZER.createSamplingResponse(response("""
-                {
-                  "type": "text",
-                  "text": "user response"
-                }
-                """, "endTurn", "user"));
+    void rejectsUserRoleOrdinarySamplingResponse() {
+        McpSamplingException exception = assertThrows(McpSamplingException.class,
+                                                      () -> SERIALIZER.createSamplingResponse(response("""
+                                                              {
+                                                                "type": "text",
+                                                                "text": "user response"
+                                                              }
+                                                              """, "endTurn", "user")));
 
-        assertThat(response.message().role(), is(McpRole.USER));
-        assertThat(response.asTextContent().text(), is("user response"));
+        assertThat(exception.getMessage(), is("Sampling response must have an assistant message role"));
     }
 
     @Test
@@ -1245,29 +1248,22 @@ class McpJsonSerializerV4Test {
                                                               }
                                                               """, "toolUse", "user")));
 
-        assertThat(exception.getMessage(), is("Sampling tool use content must have an assistant message role"));
+        assertThat(exception.getMessage(), is("Sampling response must have an assistant message role"));
     }
 
     @Test
-    void rejectsMixedSamplingToolResultResponse() {
+    void rejectsSamplingToolResultResponse() {
         McpSamplingException exception = assertThrows(McpSamplingException.class,
                                                       () -> SERIALIZER.createSamplingResponse(response("""
-                                                              [
-                                                                {
-                                                                  "type": "tool_result",
-                                                                  "toolUseId": "call-1",
-                                                                  "content": [],
-                                                                  "isError": false
-                                                                },
-                                                                {
-                                                                  "type": "text",
-                                                                  "text": "mixed content"
-                                                                }
-                                                              ]
-                                                              """, "endTurn", "user")));
+                                                              {
+                                                                "type": "tool_result",
+                                                                "toolUseId": "call-1",
+                                                                "content": [],
+                                                                "isError": false
+                                                              }
+                                                              """, "endTurn")));
 
-        assertThat(exception.getMessage(),
-                   is("Sampling messages with tool results must contain only tool results"));
+        assertThat(exception.getMessage(), is("Sampling response must not contain tool result content"));
     }
 
     @Test

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4Test.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4Test.java
@@ -242,9 +242,7 @@ class McpJsonSerializerV4Test {
         assertThat(content.id(), is("call-1"));
         assertThat(content.name(), is("weather"));
         assertThat(content.input().get("city").asString().orElse(""), is("Prague"));
-        Object metadata = content.metadata().orElseThrow();
-        assertThat(metadata, instanceOf(JsonObject.class));
-        assertThat(((JsonObject) metadata).stringValue("provider").orElseThrow(), is("test"));
+        assertThat(content.metadata().orElseThrow().get("provider").asString().orElse(""), is("test"));
         assertThrows(McpSamplingException.class, response::asTextContent);
     }
 
@@ -336,21 +334,18 @@ class McpJsonSerializerV4Test {
         assertThat(result.audioContents().getFirst().data(), is("data".getBytes(StandardCharsets.UTF_8)));
         McpToolTextResourceContent textResource = result.textResourceContents().getFirst();
         assertThat(textResource.text(), is("sunny"));
-        JsonObject textResourceMetadata = (JsonObject) textResource.metadata().orElseThrow();
-        assertThat(textResourceMetadata.booleanValue("embeddedText").orElseThrow(), is(true));
-        assertThat(textResourceMetadata.value("resourceText").isEmpty(), is(true));
+        assertThat(textResource.metadata().orElseThrow().get("embeddedText").asBoolean().orElseThrow(), is(true));
+        assertThat(textResource.metadata().orElseThrow().get("resourceText").isEmpty(), is(true));
         McpToolBinaryResourceContent binaryResource = result.binaryResourceContents().getFirst();
         assertThat(binaryResource.data(), is("data".getBytes(StandardCharsets.UTF_8)));
-        JsonObject binaryResourceMetadata = (JsonObject) binaryResource.metadata().orElseThrow();
-        assertThat(binaryResourceMetadata.booleanValue("embeddedBinary").orElseThrow(), is(true));
-        assertThat(binaryResourceMetadata.value("resourceBinary").isEmpty(), is(true));
+        assertThat(binaryResource.metadata().orElseThrow().get("embeddedBinary").asBoolean().orElseThrow(), is(true));
+        assertThat(binaryResource.metadata().orElseThrow().get("resourceBinary").isEmpty(), is(true));
         McpToolResourceLinkContent link = result.resourceLinkContents().getFirst();
         assertThat(link.name(), is("weather"));
         assertThat(link.icons().getFirst().theme().orElseThrow(), is(McpIconTheme.DARK));
         assertThat(result.structuredContent().isPresent(), is(true));
         assertThat(result.error(), is(false));
-        JsonObject contentMetadata = (JsonObject) content.metadata().orElseThrow();
-        assertThat(contentMetadata.booleanValue("cached").orElseThrow(), is(true));
+        assertThat(content.metadata().orElseThrow().get("cached").asBoolean().orElseThrow(), is(true));
 
         McpSamplingRequest replay = McpSamplingRequest.builder()
                 .addMessage(McpSamplingMessage.builder()
@@ -416,10 +411,12 @@ class McpJsonSerializerV4Test {
                 }
                 """).readJsonObject());
 
-        JsonObject messageMetadata = (JsonObject) response.message().metadata().orElseThrow();
-        JsonObject contentMetadata = (JsonObject) response.asTextContent().metadata().orElseThrow();
-        assertThat(messageMetadata.stringValue("messageKey").orElseThrow(), is("messageValue"));
-        assertThat(contentMetadata.stringValue("contentKey").orElseThrow(), is("contentValue"));
+        assertThat(response.message().metadata().orElseThrow()
+                           .get("messageKey").asString().orElseThrow(),
+                   is("messageValue"));
+        assertThat(response.asTextContent().metadata().orElseThrow()
+                           .get("contentKey").asString().orElseThrow(),
+                   is("contentValue"));
         McpAnnotations annotations = response.asTextContent().annotations().orElseThrow();
         assertThat(annotations.audience(), contains(McpRole.USER, McpRole.ASSISTANT));
         assertThat(annotations.priority().orElseThrow(), is(0.8));
@@ -460,7 +457,7 @@ class McpJsonSerializerV4Test {
                                      .priority(0.8)
                                      .lastModified("2026-08-06T10:15:30Z")
                                      .build())
-                .metadata(Map.of("provider", "test"))
+                .metadata(McpParameters.create(Map.of("provider", "test")))
                 .build();
         McpSamplingRequest request = McpSamplingRequest.builder()
                 .addMessage(McpSamplingMessage.builder()
@@ -587,7 +584,7 @@ class McpJsonSerializerV4Test {
                 .result(McpToolResult.builder()
                                 .structuredContent(Map.of("temperature", 18))
                                 .build())
-                .metadata(Map.of("cached", true))
+                .metadata(McpParameters.create(Map.of("cached", true)))
                 .build();
         McpSamplingToolResultContent secondResult = McpSamplingToolResultContent.builder()
                 .toolUseId("call-2")
@@ -930,7 +927,6 @@ class McpJsonSerializerV4Test {
     @Test
     void rejectsNonObjectSamplingToolParameters() {
         McpParameters scalarParameter = new McpParameters(JsonObject.builder().set("value", 1).build()).get("value");
-        int scalarMetadata = 1;
         McpSamplingToolUseContent validUse = McpSamplingToolUseContent.builder()
                 .id("call-1")
                 .name("weather")
@@ -958,7 +954,7 @@ class McpJsonSerializerV4Test {
                 .addMessage(McpSamplingMessage.builder()
                                     .role(McpRole.ASSISTANT)
                                     .addContent(McpSamplingToolUseContent.builder(validUse)
-                                                        .metadata(scalarMetadata)
+                                                        .metadata(scalarParameter)
                                                         .build())
                                     .build())
                 .addMessage(McpSamplingMessage.builder()
@@ -974,14 +970,14 @@ class McpJsonSerializerV4Test {
                 .addMessage(McpSamplingMessage.builder()
                                     .role(McpRole.USER)
                                     .addContent(McpSamplingToolResultContent.builder(validResult)
-                                                        .metadata(scalarMetadata)
+                                                        .metadata(scalarParameter)
                                                         .build())
                                     .build())
                 .build();
         McpSamplingRequest scalarMessageMeta = McpSamplingRequest.builder()
                 .addMessage(McpSamplingMessage.builder()
                                     .role(McpRole.ASSISTANT)
-                                    .metadata(scalarMetadata)
+                                    .metadata(scalarParameter)
                                     .addContent(validUse)
                                     .build())
                 .addMessage(McpSamplingMessage.builder()

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpParametersTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpParametersTest.java
@@ -35,8 +35,18 @@ import org.junit.platform.commons.JUnitException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 
 class McpParametersTest {
+    @Test
+    void testAsJsonObject() {
+        JsonObject object = JsonParser.create("{\"foo\":\"bar\"}").readJsonObject();
+        McpParameters parameters = McpParameters.create(object);
+
+        assertThat(parameters.asJsonObject().orElseThrow(), sameInstance(object));
+        assertThat(parameters.get("foo").asJsonObject().isEmpty(), is(true));
+    }
+
     @Test
     void testSimpleString() {
         JsonObject object = JsonParser.create("{\"foo\":\"bar\"}").readJsonObject();

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpParametersTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpParametersTest.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import io.helidon.common.GenericType;
 import io.helidon.common.mapper.OptionalValue;
 import io.helidon.json.JsonArray;
+import io.helidon.json.JsonNull;
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonParser;
 import io.helidon.json.binding.Json;
@@ -36,15 +37,64 @@ import org.junit.platform.commons.JUnitException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class McpParametersTest {
     @Test
     void testAsJsonObject() {
         JsonObject object = JsonParser.create("{\"foo\":\"bar\"}").readJsonObject();
-        McpParameters parameters = new McpParameters(object);
+        McpParameters parameters = McpParameters.create(object);
 
         assertThat(parameters.asJsonObject().orElseThrow(), sameInstance(object));
         assertThat(parameters.get("foo").asJsonObject().isEmpty(), is(true));
+    }
+
+    @Test
+    void createsFromMap() {
+        Map<String, Object> values = new HashMap<>();
+        values.put("name", "metadata");
+        values.put("enabled", true);
+        values.put("count", 2);
+        values.put("nested", List.of("first", 3));
+        values.put("nullable", null);
+
+        McpParameters parameters = McpParameters.create(values);
+        values.put("name", "changed");
+
+        assertThat(parameters.get("name").asString().orElseThrow(), is("metadata"));
+        assertThat(parameters.get("enabled").asBoolean().orElseThrow(), is(true));
+        assertThat(parameters.get("count").asInteger().orElseThrow(), is(2));
+        assertThat(parameters.get("nested").asList().orElseThrow().size(), is(2));
+        assertThat(parameters.get("nullable").isEmpty(), is(true));
+        assertThat(McpParameters.create(Map.of()).asJsonObject().orElseThrow(), is(JsonObject.empty()));
+    }
+
+    @Test
+    void createsFromJsonEntity() {
+        Foo expected = new Foo("value1", "value2");
+
+        Foo actual = McpParameters.create(expected).as(Foo.class).orElseThrow();
+
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    void rejectsNullFactoryValue() {
+        NullPointerException exception = assertThrows(NullPointerException.class, () -> McpParameters.create(null));
+
+        assertThat(exception.getMessage(), is("value is null"));
+    }
+
+    @Test
+    void rejectsNonObjectFactoryValues() {
+        List<Object> values = List.of("text", 1, true, List.of("value"), new int[] {1}, JsonNull.instance(),
+                                      new Unsupported("value"), new McpParameters(JsonObject.empty()));
+
+        for (Object value : values) {
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                               () -> McpParameters.create(value));
+            assertThat(exception.getMessage(), is("value must serialize to a JSON object using Helidon JSON binding"));
+        }
     }
 
     @Test
@@ -486,5 +536,8 @@ class McpParametersTest {
 
     @Json.Entity
     public record Foo(String foo, String bar) {
+    }
+
+    private record Unsupported(String value) {
     }
 }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpParametersTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpParametersTest.java
@@ -41,7 +41,7 @@ class McpParametersTest {
     @Test
     void testAsJsonObject() {
         JsonObject object = JsonParser.create("{\"foo\":\"bar\"}").readJsonObject();
-        McpParameters parameters = McpParameters.create(object);
+        McpParameters parameters = new McpParameters(object);
 
         assertThat(parameters.asJsonObject().orElseThrow(), sameInstance(object));
         assertThat(parameters.get("foo").asJsonObject().isEmpty(), is(true));

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpPendingResponsesTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpPendingResponsesTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.server;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.json.JsonObject;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+class McpPendingResponsesTest {
+
+    @Test
+    void rejectsOverflowWithoutEvictionAndReusesDiscardedSlot() {
+        McpPendingResponses responses = new McpPendingResponses(2);
+        responses.prepare(1);
+        responses.prepare(2);
+
+        McpInternalException exception = assertThrows(McpInternalException.class, () -> responses.prepare(3));
+
+        assertThat(exception.getMessage(), is("Maximum pending response count reached"));
+        JsonObject firstResponse = JsonObject.builder().set("id", 1).build();
+        JsonObject secondResponse = JsonObject.builder().set("id", 2).build();
+        JsonObject thirdResponse = JsonObject.builder().set("id", 3).build();
+        responses.accept(2, secondResponse);
+        responses.accept(1, firstResponse);
+        assertThat(responses.poll(1, Duration.ofSeconds(1)).orElseThrow(), sameInstance(firstResponse));
+
+        responses.prepare(3);
+        responses.accept(3, thirdResponse);
+
+        assertThat(responses.poll(2, Duration.ofSeconds(1)).orElseThrow(), sameInstance(secondResponse));
+        assertThat(responses.poll(3, Duration.ofSeconds(1)).orElseThrow(), sameInstance(thirdResponse));
+    }
+
+    @Test
+    void timeoutReclaimsCapacity() {
+        McpPendingResponses responses = new McpPendingResponses(1);
+        responses.prepare(1);
+
+        assertThat(responses.poll(1, Duration.ZERO).isEmpty(), is(true));
+
+        JsonObject response = JsonObject.builder().set("id", 2).build();
+        responses.prepare(2);
+        responses.accept(2, response);
+        assertThat(responses.poll(2, Duration.ofSeconds(1)).orElseThrow(), sameInstance(response));
+    }
+
+    @Test
+    void disconnectCompletesAllPendingAndRejectsNewRegistrations() throws InterruptedException {
+        McpPendingResponses responses = new McpPendingResponses(2);
+        responses.prepare(1);
+        responses.prepare(2);
+        AtomicReference<Throwable> firstFailure = new AtomicReference<>();
+        AtomicReference<Throwable> secondFailure = new AtomicReference<>();
+        Thread firstPoller = poll(responses, 1, firstFailure);
+        Thread secondPoller = poll(responses, 2, secondFailure);
+        awaitWaiting(firstPoller, secondPoller);
+
+        responses.disconnect();
+        firstPoller.join(1000);
+        secondPoller.join(1000);
+
+        assertThat(firstPoller.isAlive(), is(false));
+        assertThat(secondPoller.isAlive(), is(false));
+        assertDisconnected(firstFailure.get());
+        assertDisconnected(secondFailure.get());
+        McpInternalException exception = assertThrows(McpInternalException.class, () -> responses.prepare(3));
+        assertThat(exception.getMessage(), is("Session disconnected"));
+        responses.accept(1, JsonObject.builder().set("id", 1).build());
+    }
+
+    @Test
+    void concurrentPrepareNeverExceedsCapacity() throws Exception {
+        int capacity = 2;
+        int callers = 8;
+        McpPendingResponses responses = new McpPendingResponses(capacity);
+        CountDownLatch ready = new CountDownLatch(callers);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicInteger rejected = new AtomicInteger();
+        Queue<Long> prepared = new ConcurrentLinkedQueue<>();
+        List<Future<?>> tasks = new ArrayList<>();
+        ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+        try {
+            for (long requestId = 0; requestId < callers; requestId++) {
+                long id = requestId;
+                tasks.add(executor.submit(() -> {
+                    ready.countDown();
+                    try {
+                        start.await();
+                        responses.prepare(id);
+                        prepared.add(id);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new AssertionError(e);
+                    } catch (McpInternalException e) {
+                        if (!"Maximum pending response count reached".equals(e.getMessage())) {
+                            throw e;
+                        }
+                        rejected.incrementAndGet();
+                    }
+                }));
+            }
+            assertThat(ready.await(1, TimeUnit.SECONDS), is(true));
+            start.countDown();
+            for (Future<?> task : tasks) {
+                task.get(1, TimeUnit.SECONDS);
+            }
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(1, TimeUnit.SECONDS), is(true));
+        }
+
+        assertThat(prepared.size(), is(capacity));
+        assertThat(rejected.get(), is(callers - capacity));
+        for (long requestId : prepared) {
+            JsonObject response = JsonObject.builder().set("id", requestId).build();
+            responses.accept(requestId, response);
+            assertThat(responses.poll(requestId, Duration.ofSeconds(1)).orElseThrow(), sameInstance(response));
+        }
+    }
+
+    private static Thread poll(McpPendingResponses responses,
+                               long requestId,
+                               AtomicReference<Throwable> failure) {
+        return Thread.ofVirtual().start(() -> {
+            try {
+                responses.poll(requestId, Duration.ofSeconds(5));
+            } catch (Throwable e) {
+                failure.set(e);
+            }
+        });
+    }
+
+    private static void awaitWaiting(Thread... threads) {
+        assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
+            while (!allWaiting(threads)) {
+                Thread.onSpinWait();
+            }
+        });
+    }
+
+    private static boolean allWaiting(Thread... threads) {
+        for (Thread thread : threads) {
+            if (thread.getState() != Thread.State.WAITING
+                    && thread.getState() != Thread.State.TIMED_WAITING) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void assertDisconnected(Throwable failure) {
+        assertThat(failure, instanceOf(McpInternalException.class));
+        assertThat(failure.getMessage(), is("Session disconnected"));
+    }
+}

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpPendingResponsesTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpPendingResponsesTest.java
@@ -80,6 +80,39 @@ class McpPendingResponsesTest {
     }
 
     @Test
+    void abortWakesPendingPollAndReusesSlot() throws InterruptedException {
+        McpPendingResponses responses = new McpPendingResponses(1);
+        responses.prepare(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        Thread poller = poll(responses, 1, failure);
+        awaitWaiting(poller);
+        McpSamplingException cancellation = new McpSamplingException("Sampling request cancelled");
+
+        responses.abort(1, cancellation);
+        responses.accept(createResponse(1));
+        poller.join(1000);
+
+        assertThat(poller.isAlive(), is(false));
+        assertThat(failure.get(), sameInstance(cancellation));
+        McpResponse response = createResponse(2);
+        responses.prepare(2);
+        responses.accept(response);
+        assertThat(pollAndDiscard(responses, 2, Duration.ofSeconds(1)).orElseThrow(), sameInstance(response));
+    }
+
+    @Test
+    void completedResponseWinsLateAbort() {
+        McpPendingResponses responses = new McpPendingResponses(1);
+        responses.prepare(1);
+        McpResponse response = createResponse(1);
+        responses.accept(response);
+
+        responses.abort(1, new McpSamplingException("Sampling request cancelled"));
+
+        assertThat(pollAndDiscard(responses, 1, Duration.ofSeconds(1)).orElseThrow(), sameInstance(response));
+    }
+
+    @Test
     void disconnectCompletesAllPendingAndRejectsNewRegistrations() throws InterruptedException {
         McpPendingResponses responses = new McpPendingResponses(2);
         responses.prepare(1);

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpPendingResponsesTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpPendingResponsesTest.java
@@ -55,12 +55,12 @@ class McpPendingResponsesTest {
         McpResponse firstResponse = createResponse(1);
         McpResponse secondResponse = createResponse(2);
         McpResponse thirdResponse = createResponse(3);
-        responses.accept(2, secondResponse);
-        responses.accept(1, firstResponse);
+        responses.accept(secondResponse);
+        responses.accept(firstResponse);
         assertThat(pollAndDiscard(responses, 1, Duration.ofSeconds(1)).orElseThrow(), sameInstance(firstResponse));
 
         responses.prepare(3);
-        responses.accept(3, thirdResponse);
+        responses.accept(thirdResponse);
 
         assertThat(pollAndDiscard(responses, 2, Duration.ofSeconds(1)).orElseThrow(), sameInstance(secondResponse));
         assertThat(pollAndDiscard(responses, 3, Duration.ofSeconds(1)).orElseThrow(), sameInstance(thirdResponse));
@@ -75,7 +75,7 @@ class McpPendingResponsesTest {
 
         McpResponse response = createResponse(2);
         responses.prepare(2);
-        responses.accept(2, response);
+        responses.accept(response);
         assertThat(pollAndDiscard(responses, 2, Duration.ofSeconds(1)).orElseThrow(), sameInstance(response));
     }
 
@@ -100,7 +100,7 @@ class McpPendingResponsesTest {
         assertDisconnected(secondFailure.get());
         McpInternalException exception = assertThrows(McpInternalException.class, () -> responses.prepare(3));
         assertThat(exception.getMessage(), is("Session disconnected"));
-        responses.accept(1, createResponse(1));
+        responses.accept(createResponse(1));
     }
 
     @Test
@@ -149,7 +149,7 @@ class McpPendingResponsesTest {
         assertThat(rejected.get(), is(callers - capacity));
         for (long requestId : prepared) {
             McpResponse response = createResponse(requestId);
-            responses.accept(requestId, response);
+            responses.accept(response);
             McpResponse polled = pollAndDiscard(responses, requestId, Duration.ofSeconds(1)).orElseThrow();
             assertThat(polled, sameInstance(response));
         }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpPendingResponsesTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpPendingResponsesTest.java
@@ -18,6 +18,7 @@ package io.helidon.extensions.mcp.server;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
@@ -55,13 +56,13 @@ class McpPendingResponsesTest {
         JsonObject thirdResponse = JsonObject.builder().set("id", 3).build();
         responses.accept(2, secondResponse);
         responses.accept(1, firstResponse);
-        assertThat(responses.poll(1, Duration.ofSeconds(1)).orElseThrow(), sameInstance(firstResponse));
+        assertThat(pollAndDiscard(responses, 1, Duration.ofSeconds(1)).orElseThrow(), sameInstance(firstResponse));
 
         responses.prepare(3);
         responses.accept(3, thirdResponse);
 
-        assertThat(responses.poll(2, Duration.ofSeconds(1)).orElseThrow(), sameInstance(secondResponse));
-        assertThat(responses.poll(3, Duration.ofSeconds(1)).orElseThrow(), sameInstance(thirdResponse));
+        assertThat(pollAndDiscard(responses, 2, Duration.ofSeconds(1)).orElseThrow(), sameInstance(secondResponse));
+        assertThat(pollAndDiscard(responses, 3, Duration.ofSeconds(1)).orElseThrow(), sameInstance(thirdResponse));
     }
 
     @Test
@@ -69,12 +70,12 @@ class McpPendingResponsesTest {
         McpPendingResponses responses = new McpPendingResponses(1);
         responses.prepare(1);
 
-        assertThat(responses.poll(1, Duration.ZERO).isEmpty(), is(true));
+        assertThat(pollAndDiscard(responses, 1, Duration.ZERO).isEmpty(), is(true));
 
         JsonObject response = JsonObject.builder().set("id", 2).build();
         responses.prepare(2);
         responses.accept(2, response);
-        assertThat(responses.poll(2, Duration.ofSeconds(1)).orElseThrow(), sameInstance(response));
+        assertThat(pollAndDiscard(responses, 2, Duration.ofSeconds(1)).orElseThrow(), sameInstance(response));
     }
 
     @Test
@@ -148,7 +149,7 @@ class McpPendingResponsesTest {
         for (long requestId : prepared) {
             JsonObject response = JsonObject.builder().set("id", requestId).build();
             responses.accept(requestId, response);
-            assertThat(responses.poll(requestId, Duration.ofSeconds(1)).orElseThrow(), sameInstance(response));
+            assertThat(pollAndDiscard(responses, requestId, Duration.ofSeconds(1)).orElseThrow(), sameInstance(response));
         }
     }
 
@@ -157,11 +158,21 @@ class McpPendingResponsesTest {
                                AtomicReference<Throwable> failure) {
         return Thread.ofVirtual().start(() -> {
             try {
-                responses.poll(requestId, Duration.ofSeconds(5));
+                pollAndDiscard(responses, requestId, Duration.ofSeconds(5));
             } catch (Throwable e) {
                 failure.set(e);
             }
         });
+    }
+
+    private static Optional<JsonObject> pollAndDiscard(McpPendingResponses responses,
+                                                       long requestId,
+                                                       Duration timeout) {
+        try {
+            return responses.poll(requestId, timeout);
+        } finally {
+            responses.discard(requestId);
+        }
     }
 
     private static void awaitWaiting(Thread... threads) {

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpPendingResponsesTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpPendingResponsesTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.helidon.common.context.Context;
 import io.helidon.json.JsonObject;
 
 import org.junit.jupiter.api.Test;
@@ -51,9 +52,9 @@ class McpPendingResponsesTest {
         McpInternalException exception = assertThrows(McpInternalException.class, () -> responses.prepare(3));
 
         assertThat(exception.getMessage(), is("Maximum pending response count reached"));
-        JsonObject firstResponse = JsonObject.builder().set("id", 1).build();
-        JsonObject secondResponse = JsonObject.builder().set("id", 2).build();
-        JsonObject thirdResponse = JsonObject.builder().set("id", 3).build();
+        McpResponse firstResponse = createResponse(1);
+        McpResponse secondResponse = createResponse(2);
+        McpResponse thirdResponse = createResponse(3);
         responses.accept(2, secondResponse);
         responses.accept(1, firstResponse);
         assertThat(pollAndDiscard(responses, 1, Duration.ofSeconds(1)).orElseThrow(), sameInstance(firstResponse));
@@ -72,7 +73,7 @@ class McpPendingResponsesTest {
 
         assertThat(pollAndDiscard(responses, 1, Duration.ZERO).isEmpty(), is(true));
 
-        JsonObject response = JsonObject.builder().set("id", 2).build();
+        McpResponse response = createResponse(2);
         responses.prepare(2);
         responses.accept(2, response);
         assertThat(pollAndDiscard(responses, 2, Duration.ofSeconds(1)).orElseThrow(), sameInstance(response));
@@ -99,7 +100,7 @@ class McpPendingResponsesTest {
         assertDisconnected(secondFailure.get());
         McpInternalException exception = assertThrows(McpInternalException.class, () -> responses.prepare(3));
         assertThat(exception.getMessage(), is("Session disconnected"));
-        responses.accept(1, JsonObject.builder().set("id", 1).build());
+        responses.accept(1, createResponse(1));
     }
 
     @Test
@@ -147,10 +148,16 @@ class McpPendingResponsesTest {
         assertThat(prepared.size(), is(capacity));
         assertThat(rejected.get(), is(callers - capacity));
         for (long requestId : prepared) {
-            JsonObject response = JsonObject.builder().set("id", requestId).build();
+            McpResponse response = createResponse(requestId);
             responses.accept(requestId, response);
-            assertThat(pollAndDiscard(responses, requestId, Duration.ofSeconds(1)).orElseThrow(), sameInstance(response));
+            McpResponse polled = pollAndDiscard(responses, requestId, Duration.ofSeconds(1)).orElseThrow();
+            assertThat(polled, sameInstance(response));
         }
+    }
+
+    private static McpResponse createResponse(long requestId) {
+        JsonObject response = JsonObject.builder().set("id", requestId).build();
+        return new McpResponseImpl(response, Context.create());
     }
 
     private static Thread poll(McpPendingResponses responses,
@@ -165,9 +172,9 @@ class McpPendingResponsesTest {
         });
     }
 
-    private static Optional<JsonObject> pollAndDiscard(McpPendingResponses responses,
-                                                       long requestId,
-                                                       Duration timeout) {
+    private static Optional<McpResponse> pollAndDiscard(McpPendingResponses responses,
+                                                        long requestId,
+                                                        Duration timeout) {
         try {
             return responses.poll(requestId, timeout);
         } finally {

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpRequestTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpRequestTest.java
@@ -15,7 +15,10 @@
  */
 package io.helidon.extensions.mcp.server;
 
+import java.util.Map;
+
 import io.helidon.common.context.Context;
+import io.helidon.json.JsonException;
 import io.helidon.json.JsonObject;
 
 import org.junit.jupiter.api.Test;
@@ -23,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 class McpRequestTest {
@@ -35,9 +39,7 @@ class McpRequestTest {
                                                                     .set("trace", "legacy")
                                                                     .build())
                                                             .build());
-        McpParameters metadata = new McpParameters(JsonObject.builder()
-                                                            .set("trace", "test")
-                                                            .build());
+        Map<String, String> metadata = Map.of("trace", "test");
         McpRequest request = McpRequest.builder()
                 .parameters(parameters)
                 .metadata(metadata)
@@ -49,12 +51,21 @@ class McpRequestTest {
 
         McpMetadata requestMetadata = request;
         assertThat(requestMetadata.metadata().orElseThrow(), sameInstance(metadata));
-        assertThat(request.meta(), sameInstance(metadata));
+        assertThat(request.meta().get("trace").asString().orElseThrow(), is("test"));
 
         McpRequest requestWithoutMetadata = McpRequest.builder(request)
                 .clearMetadata()
                 .build();
         assertThat(requestWithoutMetadata.metadata().isEmpty(), is(true));
         assertThat(requestWithoutMetadata.meta().get("trace").asString().orElseThrow(), is("legacy"));
+    }
+
+    @Test
+    void rejectsNonObjectProtocolMetadata() {
+        McpParameters parameters = new McpParameters(JsonObject.builder()
+                                                            .set(McpMetadata.META, 1)
+                                                            .build());
+
+        assertThrows(JsonException.class, () -> parameters.get(McpMetadata.META).as(JsonObject.class));
     }
 }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpRequestTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpRequestTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.server;
+
+import io.helidon.common.context.Context;
+import io.helidon.json.JsonObject;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
+
+class McpRequestTest {
+
+    @Test
+    @SuppressWarnings("removal")
+    void exposesProtocolMetadata() {
+        McpParameters parameters = new McpParameters(JsonObject.builder()
+                                                            .set(McpMetadata.META, JsonObject.builder()
+                                                                    .set("trace", "legacy")
+                                                                    .build())
+                                                            .build());
+        McpParameters metadata = new McpParameters(JsonObject.builder()
+                                                            .set("trace", "test")
+                                                            .build());
+        McpRequest request = McpRequest.builder()
+                .parameters(parameters)
+                .metadata(metadata)
+                .features(mock(McpFeatures.class))
+                .protocolVersion(McpProtocolVersion.VERSION_2025_11_25.text())
+                .sessionContext(Context.create())
+                .requestContext(Context.create())
+                .build();
+
+        McpMetadata requestMetadata = request;
+        assertThat(requestMetadata.metadata().orElseThrow(), sameInstance(metadata));
+        assertThat(request.meta(), sameInstance(metadata));
+
+        McpRequest requestWithoutMetadata = McpRequest.builder(request)
+                .clearMetadata()
+                .build();
+        assertThat(requestWithoutMetadata.metadata().isEmpty(), is(true));
+        assertThat(requestWithoutMetadata.meta().get("trace").asString().orElseThrow(), is("legacy"));
+    }
+}

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpRequestTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpRequestTest.java
@@ -32,13 +32,8 @@ import static org.mockito.Mockito.mock;
 class McpRequestTest {
 
     @Test
-    @SuppressWarnings("removal")
     void exposesProtocolMetadata() {
-        McpParameters parameters = new McpParameters(JsonObject.builder()
-                                                            .set(McpMetadata.META, JsonObject.builder()
-                                                                    .set("trace", "legacy")
-                                                                    .build())
-                                                            .build());
+        McpParameters parameters = new McpParameters(JsonObject.empty());
         McpParameters metadata = McpParameters.create(Map.of("trace", "test"));
         McpRequest request = McpRequest.builder()
                 .parameters(parameters)
@@ -51,13 +46,11 @@ class McpRequestTest {
 
         McpMetadata requestMetadata = request;
         assertThat(requestMetadata.metadata().orElseThrow(), sameInstance(metadata));
-        assertThat(request.meta().get("trace").asString().orElseThrow(), is("test"));
 
         McpRequest requestWithoutMetadata = McpRequest.builder(request)
                 .clearMetadata()
                 .build();
         assertThat(requestWithoutMetadata.metadata().isEmpty(), is(true));
-        assertThat(requestWithoutMetadata.meta().get("trace").asString().orElseThrow(), is("legacy"));
     }
 
     @Test
@@ -68,4 +61,13 @@ class McpRequestTest {
 
         assertThrows(JsonException.class, () -> parameters.get(McpMetadata.META).as(JsonObject.class));
     }
+
+    @Test
+    void removesLegacyMetaMethods() {
+        assertThrows(NoSuchMethodException.class, () -> McpRequest.class.getMethod("meta"));
+        assertThrows(NoSuchMethodException.class, () -> McpRequest.BuilderBase.class.getMethod("meta"));
+        assertThrows(NoSuchMethodException.class,
+                     () -> McpRequest.BuilderBase.class.getMethod("meta", McpParameters.class));
+    }
+
 }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpRequestTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpRequestTest.java
@@ -39,7 +39,7 @@ class McpRequestTest {
                                                                     .set("trace", "legacy")
                                                                     .build())
                                                             .build());
-        Map<String, String> metadata = Map.of("trace", "test");
+        McpParameters metadata = McpParameters.create(Map.of("trace", "test"));
         McpRequest request = McpRequest.builder()
                 .parameters(parameters)
                 .metadata(metadata)

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpResponseTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpResponseTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.server;
+
+import io.helidon.common.context.Context;
+import io.helidon.json.JsonObject;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class McpResponseTest {
+
+    @Test
+    void containsResponseAndRequestContext() {
+        JsonObject json = JsonObject.builder().set("id", 1).build();
+        Context requestContext = Context.create();
+
+        McpResponse response = new McpResponseImpl(json, requestContext);
+
+        assertThat(response.asJsonObject(), sameInstance(json));
+        assertThat(response.requestContext(), sameInstance(requestContext));
+    }
+
+    @Test
+    void rejectsMissingValues() {
+        JsonObject json = JsonObject.builder().set("id", 1).build();
+        Context requestContext = Context.create();
+
+        assertThrows(NullPointerException.class, () -> new McpResponseImpl(null, requestContext));
+        assertThrows(NullPointerException.class, () -> new McpResponseImpl(json, null));
+    }
+}

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpResponseTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpResponseTest.java
@@ -15,12 +15,16 @@
  */
 package io.helidon.extensions.mcp.server;
 
+import java.math.BigDecimal;
+
 import io.helidon.common.context.Context;
+import io.helidon.json.JsonException;
 import io.helidon.json.JsonObject;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -33,6 +37,7 @@ class McpResponseTest {
 
         McpResponse response = new McpResponseImpl(json, requestContext);
 
+        assertThat(response.id(), is(1L));
         assertThat(response.asJsonObject(), sameInstance(json));
         assertThat(response.requestContext(), sameInstance(requestContext));
     }
@@ -44,5 +49,19 @@ class McpResponseTest {
 
         assertThrows(NullPointerException.class, () -> new McpResponseImpl(null, requestContext));
         assertThrows(NullPointerException.class, () -> new McpResponseImpl(json, null));
+    }
+
+    @Test
+    void rejectsInvalidIdentifiers() {
+        Context requestContext = Context.create();
+        JsonObject missing = JsonObject.empty();
+        JsonObject string = JsonObject.builder().set("id", "1").build();
+        JsonObject fractional = JsonObject.builder().set("id", 1.5).build();
+        JsonObject outOfRange = JsonObject.builder().set("id", new BigDecimal("9223372036854775808")).build();
+
+        assertThrows(JsonException.class, () -> new McpResponseImpl(missing, requestContext));
+        assertThrows(JsonException.class, () -> new McpResponseImpl(string, requestContext));
+        assertThrows(JsonException.class, () -> new McpResponseImpl(fractional, requestContext));
+        assertThrows(JsonException.class, () -> new McpResponseImpl(outOfRange, requestContext));
     }
 }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingRequestTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingRequestTest.java
@@ -39,11 +39,11 @@ class McpSamplingRequestTest {
         assertThat(request.hints().isEmpty(), is(true));
         assertThat(request.metadata().isEmpty(), is(true));
         assertThat(request.temperature().isEmpty(), is(true));
-        assertThat(request.textMessages().isEmpty(), is(true));
+        assertThat(request.messages().isEmpty(), is(true));
         assertThat(request.costPriority().isEmpty(), is(true));
         assertThat(request.systemPrompt().isEmpty(), is(true));
-        assertThat(request.imageMessages().isEmpty(), is(true));
-        assertThat(request.audioMessages().isEmpty(), is(true));
+        assertThat(request.tools().isEmpty(), is(true));
+        assertThat(request.toolChoice().isEmpty(), is(true));
         assertThat(request.stopSequences().isEmpty(), is(true));
         assertThat(request.speedPriority().isEmpty(), is(true));
         assertThat(request.includeContext().isEmpty(), is(true));
@@ -66,9 +66,25 @@ class McpSamplingRequestTest {
                 .timeout(Duration.ofSeconds(10))
                 .stopSequences(List.of("stop1"))
                 .includeContext(McpIncludeContext.NONE)
-                .addTextMessage(message -> message.text("text").role(McpRole.USER))
-                .addImageMessage(message -> message.data(new byte[0]).mediaType(MediaTypes.TEXT_PLAIN).role(McpRole.ASSISTANT))
-                .addAudioMessage(message -> message.data(new byte[0]).mediaType(MediaTypes.TEXT_PLAIN).role(McpRole.ASSISTANT))
+                .addTool("weather")
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.USER)
+                                    .addContent(McpSamplingTextContent.create("text"))
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.ASSISTANT)
+                                    .addContent(McpSamplingImageContent.builder()
+                                                        .data(new byte[0])
+                                                        .mediaType(MediaTypes.TEXT_PLAIN)
+                                                        .build())
+                                    .build())
+                .addMessage(McpSamplingMessage.builder()
+                                    .role(McpRole.ASSISTANT)
+                                    .addContent(McpSamplingAudioContent.builder()
+                                                        .data(new byte[0])
+                                                        .mediaType(MediaTypes.TEXT_PLAIN)
+                                                        .build())
+                                    .build())
                 .build();
 
         assertThat(request.maxTokens(), is(1));
@@ -77,38 +93,30 @@ class McpSamplingRequestTest {
         assertThat(request.hints().isEmpty(), is(false));
         assertThat(request.hints().get(), is(List.of("hint1")));
 
-        assertThat(request.textMessages().isEmpty(), is(false));
-        assertThat(request.textMessages().size(), is(1));
+        assertThat(request.messages().size(), is(3));
 
-        McpSamplingTextMessage message = request.textMessages().getFirst();
-        assertThat(message.text(), is("text"));
+        McpSamplingMessage message = request.messages().getFirst();
+        assertThat(((McpSamplingTextContent) message.contents().getFirst()).text(), is("text"));
         assertThat(message.role(), is(McpRole.USER));
 
-        assertThat(request.imageMessages().isEmpty(), is(false));
-        assertThat(request.imageMessages().size(), is(1));
-
-        McpSamplingImageMessage image = request.imageMessages().getFirst();
+        McpSamplingImageContent image = (McpSamplingImageContent) request.messages().get(1).contents().getFirst();
         assertThat(image.data(), is(new byte[0]));
-        assertThat(image.role(), is(McpRole.ASSISTANT));
         assertThat(image.mediaType(), is(MediaTypes.TEXT_PLAIN));
 
-        assertThat(request.audioMessages().isEmpty(), is(false));
-        assertThat(request.audioMessages().size(), is(1));
-
-        McpSamplingAudioMessage audio = request.audioMessages().getFirst();
+        McpSamplingAudioContent audio = (McpSamplingAudioContent) request.messages().get(2).contents().getFirst();
         assertThat(audio.data(), is(new byte[0]));
-        assertThat(audio.role(), is(McpRole.ASSISTANT));
         assertThat(audio.mediaType(), is(MediaTypes.TEXT_PLAIN));
 
         assertThat(request.metadata().isEmpty(), is(false));
         assertThat(request.metadata().get(), is(metadata));
 
-        JsonObject serialized = new McpJsonSerializerV1().toJson(request).build();
+        JsonObject serialized = new McpJsonSerializerV1().toJson(request, List.of()).build();
         JsonObject serializedMetadata = serialized.objectValue("metadata").orElseThrow();
         assertThat(serializedMetadata.booleanValue("enabled").orElseThrow(), is(true));
 
         assertThat(request.includeContext().isEmpty(), is(false));
         assertThat(request.includeContext().get(), is(McpIncludeContext.NONE));
+        assertThat(request.tools(), is(List.of("weather")));
 
         assertThat(request.systemPrompt().isEmpty(), is(false));
         assertThat(request.systemPrompt().get(), is("system prompt"));

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingResponseTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingResponseTest.java
@@ -18,80 +18,113 @@ package io.helidon.extensions.mcp.server;
 import java.nio.charset.StandardCharsets;
 
 import io.helidon.common.media.type.MediaTypes;
+import io.helidon.json.JsonObject;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class McpSamplingResponseTest {
 
     @Test
-    void testSamplingResponseTextMessage() {
-        var message = McpSamplingTextMessage.builder().text("text").role(McpRole.USER).build();
+    void testSamplingResponseTextContent() {
+        McpSamplingTextContent content = McpSamplingTextContent.create("text");
+        McpSamplingMessage message = message(McpRole.USER, content);
         McpSamplingResponse response = new McpSamplingResponseImpl(message, "helidon-model", McpStopReason.END_TURN);
 
-        assertThat(response.model(), is("helidon-model"));
-        assertThat(response.rawStopReason().orElseThrow(), is("endTurn"));
-        assertThat(response.stopReason().isPresent(), is(true));
-        assertThat(response.stopReason().get(), is(McpStopReason.END_TURN));
-        assertThat(response.message(), instanceOf(McpSamplingTextMessage.class));
+        assertResponse(response, message);
+        assertThat(response.message().role(), is(McpRole.USER));
+        assertThat(response.asTextContent(), sameInstance(content));
+        assertThat(response.asTextContent().text(), is("text"));
 
-        McpSamplingTextMessage text = response.asTextMessage();
-        assertThat(text.role(), is(McpRole.USER));
-        assertThat(text.text(), is("text"));
-
-        assertThrows(McpSamplingException.class, response::asImageMessage);
-        assertThrows(McpSamplingException.class, response::asAudioMessage);
+        assertThrows(McpSamplingException.class, response::asImageContent);
+        assertThrows(McpSamplingException.class, response::asAudioContent);
+        assertThrows(McpSamplingException.class, response::asToolUseContent);
     }
 
     @Test
-    void testSamplingResponseImageMessage() {
-        var data = "data".getBytes(StandardCharsets.UTF_8);
-        var message = McpSamplingImageMessage.builder()
+    void testSamplingResponseImageContent() {
+        byte[] data = "data".getBytes(StandardCharsets.UTF_8);
+        McpSamplingImageContent content = McpSamplingImageContent.builder()
                 .data(data)
                 .mediaType(MediaTypes.TEXT_PLAIN)
-                .role(McpRole.USER)
                 .build();
+        McpSamplingMessage message = message(McpRole.USER, content);
         McpSamplingResponse response = new McpSamplingResponseImpl(message, "helidon-model", McpStopReason.END_TURN);
 
-        assertThat(response.model(), is("helidon-model"));
-        assertThat(response.rawStopReason().orElseThrow(), is("endTurn"));
-        assertThat(response.stopReason().isPresent(), is(true));
-        assertThat(response.stopReason().get(), is(McpStopReason.END_TURN));
-        assertThat(response.message(), instanceOf(McpSamplingImageMessage.class));
+        assertResponse(response, message);
+        assertThat(response.asImageContent(), sameInstance(content));
+        assertThat(response.asImageContent().data(), is(data));
 
-        McpSamplingImageMessage image = response.asImageMessage();
-        assertThat(image.role(), is(McpRole.USER));
-        assertThat(image.data(), is(data));
-
-        assertThrows(McpSamplingException.class, response::asTextMessage);
-        assertThrows(McpSamplingException.class, response::asAudioMessage);
+        assertThrows(McpSamplingException.class, response::asTextContent);
+        assertThrows(McpSamplingException.class, response::asAudioContent);
+        assertThrows(McpSamplingException.class, response::asToolUseContent);
     }
 
     @Test
-    void testSamplingResponseAudioMessage() {
-        var data = "data".getBytes(StandardCharsets.UTF_8);
-        var message = McpSamplingAudioMessage.builder()
+    void testSamplingResponseAudioContent() {
+        byte[] data = "data".getBytes(StandardCharsets.UTF_8);
+        McpSamplingAudioContent content = McpSamplingAudioContent.builder()
                 .data(data)
                 .mediaType(MediaTypes.TEXT_PLAIN)
-                .role(McpRole.USER)
                 .build();
+        McpSamplingMessage message = message(McpRole.USER, content);
         McpSamplingResponse response = new McpSamplingResponseImpl(message, "helidon-model", McpStopReason.END_TURN);
 
+        assertResponse(response, message);
+        assertThat(response.asAudioContent(), sameInstance(content));
+        assertThat(response.asAudioContent().data(), is(data));
+
+        assertThrows(McpSamplingException.class, response::asTextContent);
+        assertThrows(McpSamplingException.class, response::asImageContent);
+        assertThrows(McpSamplingException.class, response::asToolUseContent);
+    }
+
+    @Test
+    void testSamplingResponseToolUseContent() {
+        McpSamplingToolUseContent content = McpSamplingToolUseContent.builder()
+                .id("call-1")
+                .name("weather")
+                .input(new McpParameters(JsonObject.empty()))
+                .build();
+        McpSamplingMessage message = message(McpRole.ASSISTANT, content);
+        McpSamplingResponse response = new McpSamplingResponseImpl(message, "helidon-model", McpStopReason.TOOL_USE);
+
+        assertThat(response.model(), is("helidon-model"));
+        assertThat(response.rawStopReason().orElseThrow(), is("toolUse"));
+        assertThat(response.stopReason().orElseThrow(), is(McpStopReason.TOOL_USE));
+        assertThat(response.message(), sameInstance(message));
+        assertThat(response.asToolUseContent(), sameInstance(content));
+
+        assertThrows(McpSamplingException.class, response::asTextContent);
+        assertThrows(McpSamplingException.class, response::asImageContent);
+        assertThrows(McpSamplingException.class, response::asAudioContent);
+    }
+
+    @Test
+    void testEmptySamplingResponseContent() {
+        McpSamplingResponse response = new McpSamplingResponseImpl(McpSamplingMessage.builder()
+                                                                          .role(McpRole.ASSISTANT)
+                                                                          .build(),
+                                                                  "helidon-model");
+
+        assertThrows(McpSamplingException.class, response::asTextContent);
+    }
+
+    private static McpSamplingMessage message(McpRole role, McpSamplingContent content) {
+        return McpSamplingMessage.builder()
+                .role(role)
+                .addContent(content)
+                .build();
+    }
+
+    private static void assertResponse(McpSamplingResponse response, McpSamplingMessage message) {
         assertThat(response.model(), is("helidon-model"));
         assertThat(response.rawStopReason().orElseThrow(), is("endTurn"));
-        assertThat(response.stopReason().isPresent(), is(true));
-        assertThat(response.stopReason().get(), is(McpStopReason.END_TURN));
-        assertThat(response.message(), instanceOf(McpSamplingAudioMessage.class));
-
-        McpSamplingAudioMessage image = response.asAudioMessage();
-        assertThat(image.role(), is(McpRole.USER));
-        assertThat(image.data(), is(data));
-
-        assertThrows(McpSamplingException.class, response::asTextMessage);
-        assertThrows(McpSamplingException.class, response::asImageMessage);
+        assertThat(response.stopReason().orElseThrow(), is(McpStopReason.END_TURN));
+        assertThat(response.message(), sameInstance(message));
     }
 }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
@@ -247,7 +247,7 @@ class McpSamplingTest {
         assertThat(samplingResponse.stopReason().orElseThrow(), is(McpStopReason.END_TURN));
         assertThat(toolRequest.get().name(), is("weather"));
         assertThat(toolRequest.get().arguments().get("city").asString().get(), is("Prague"));
-        assertThat(toolRequest.get().meta().get("trace").asString().get(), is("sample-1"));
+        assertThat(toolRequest.get().metadata().orElseThrow().get("trace").asString().get(), is("sample-1"));
         assertThat(toolRequest.get().features(), sameInstance(features));
         assertThat(toolRequest.get().sessionContext(), sameInstance(session.context()));
         assertThat(toolRequest.get().requestContext(), sameInstance(toolUseResponseContext));

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
@@ -762,6 +762,27 @@ class McpSamplingTest {
     }
 
     @Test
+    void acceptsExtensionStopReasonThatDiffersFromToolUseCase() {
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {}}
+                """);
+        acceptSamplingResponse(session, 0, """
+                {"type": "text", "text": "Extension response"}
+                """, "TOOLUSE");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+
+        McpSamplingResponse samplingResponse = sampling.request(req -> req.addTextMessage("Hello"));
+
+        assertThat(samplingResponse.asTextContent().text(), is("Extension response"));
+        assertThat(samplingResponse.rawStopReason().orElseThrow(), is("TOOLUSE"));
+        assertThat(samplingResponse.stopReason().orElseThrow(), is(McpStopReason.TOOL_USE));
+        sentSamplingRequests(sink, 1);
+    }
+
+    @Test
     void rejectsToolNamesWithoutSamplingToolsCapability() {
         JsonRpcResponse response = mock(JsonRpcResponse.class);
         McpSampling sampling = sampling(session(McpProtocolVersion.VERSION_2025_11_25, """

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
@@ -251,9 +251,7 @@ class McpSamplingTest {
         assertThat(samplingResponse.stopReason().orElseThrow(), is(McpStopReason.END_TURN));
         assertThat(toolRequest.get().name(), is("weather"));
         assertThat(toolRequest.get().arguments().get("city").asString().get(), is("Prague"));
-        Object metadata = toolRequest.get().metadata().orElseThrow();
-        assertThat(metadata, instanceOf(JsonObject.class));
-        assertThat(((JsonObject) metadata).stringValue("trace").orElseThrow(), is("sample-1"));
+        assertThat(toolRequest.get().metadata().orElseThrow().get("trace").asString().get(), is("sample-1"));
         assertThat(toolRequest.get().features(), sameInstance(features));
         assertThat(toolRequest.get().sessionContext(), sameInstance(session.context()));
         assertThat(toolRequest.get().requestContext(), sameInstance(toolUseResponseContext));

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
@@ -329,7 +329,7 @@ class McpSamplingTest {
     }
 
     @Test
-    void executesParallelToolUsesAndContinuesAfterToolErrors() {
+    void continuesAfterSamplingToolErrors() {
         AtomicInteger workingInvocations = new AtomicInteger();
         McpTool broken = new TestTool("broken", "Fails", "", request -> {
             throw new IllegalStateException("provider unavailable");
@@ -338,17 +338,15 @@ class McpSamplingTest {
             workingInvocations.incrementAndGet();
             return McpToolResult.create("success");
         });
-        McpTool empty = new TestTool("empty", "Returns null", "", request -> null);
         McpTool unselected = new TestTool("missing", "Not selected", "");
         McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
                 {"sampling": {"tools": {}}}
-                """, broken, working, empty, unselected);
+                """, broken, working, unselected);
         acceptSamplingResponse(session, 0, """
                 [
                   {"type": "tool_use", "id": "call-1", "name": "broken", "input": {}},
                   {"type": "tool_use", "id": "call-2", "name": "working", "input": {}},
-                  {"type": "tool_use", "id": "call-3", "name": "missing", "input": {}},
-                  {"type": "tool_use", "id": "call-4", "name": "empty", "input": {}}
+                  {"type": "tool_use", "id": "call-3", "name": "missing", "input": {}}
                 ]
                 """, "toolUse");
         acceptSamplingResponse(session, 1, """
@@ -362,7 +360,6 @@ class McpSamplingTest {
                 .addTextMessage(McpRole.USER, "Use the tools")
                 .addTool(broken.name())
                 .addTool(working.name())
-                .addTool(empty.name())
                 .build();
 
         McpSamplingResponse samplingResponse = sampling.request(request);
@@ -373,11 +370,29 @@ class McpSamplingTest {
         var messages = sent.get(1).objectValue("params").orElseThrow()
                 .arrayValue("messages").orElseThrow().values();
         var results = messages.get(2).asObject().arrayValue("content").orElseThrow().values();
-        assertThat(results.size(), is(4));
+        assertThat(results.size(), is(3));
         assertToolResult(results.get(0).asObject(), "call-1", true, "failed");
         assertToolResult(results.get(1).asObject(), "call-2", false, "success");
         assertToolResult(results.get(2).asObject(), "call-3", true, "is not available");
-        assertToolResult(results.get(3).asObject(), "call-4", true, "returned no result");
+    }
+
+    @Test
+    void rejectsNullSamplingToolResult() {
+        McpTool empty = new TestTool("empty", "Returns null", "", request -> null);
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, empty);
+        acceptSamplingResponse(session, 0, """
+                {"type": "tool_use", "id": "call-1", "name": "empty", "input": {}}
+                """, "toolUse");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+
+        assertThrows(NullPointerException.class, () -> sampling.request(req -> req.addTool(empty.name())));
+
+        sentSamplingRequests(sink, 1);
     }
 
     @Test
@@ -425,6 +440,7 @@ class McpSamplingTest {
         AtomicReference<McpSession> sessionRef = new AtomicReference<>();
         McpTool disconnect = new TestTool("disconnect", "Disconnects", "", request -> {
             sessionRef.get().onDisconnect(mock(ServerResponse.class));
+            sessionRef.get().state(McpSession.State.INITIALIZED);
             return McpToolResult.create("disconnected");
         });
         McpTool remaining = new TestTool("remaining", "Must not run", "", request -> {

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
@@ -15,7 +15,15 @@
  */
 package io.helidon.extensions.mcp.server;
 
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import io.helidon.common.context.Context;
 import io.helidon.http.sse.SseEvent;
+import io.helidon.json.JsonObject;
 import io.helidon.json.JsonParser;
 import io.helidon.jsonrpc.core.JsonRpcParams;
 import io.helidon.webserver.jsonrpc.JsonRpcResponse;
@@ -27,24 +35,864 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class McpSamplingTest {
 
+    @Test
+    void samplingRequestBuilderDefaultsToolOptions() {
+        McpSamplingRequest request = McpSamplingRequest.builder().build();
+
+        assertThat(request.messages().isEmpty(), is(true));
+        assertThat(request.tools().isEmpty(), is(true));
+        assertThat(request.toolChoice().isEmpty(), is(true));
+        assertThat(request.usesTool(), is(false));
+        assertThat(request.usesContext(), is(false));
+    }
+
+    @Test
+    void samplingRequestBuilderKeepsCustomToolOptions() {
+        McpSamplingMessage message = message(McpRole.USER,
+                                             McpSamplingTextContent.create("What is the weather?"));
+
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addMessage(message)
+                .addTool("weather")
+                .toolChoice(McpToolChoice.REQUIRED)
+                .build();
+
+        assertThat(request.messages().size(), is(1));
+        assertThat(request.messages().getFirst(), sameInstance(message));
+        assertThat(request.tools().size(), is(1));
+        assertThat(request.tools().getFirst(), is("weather"));
+        assertThat(request.toolChoice().orElseThrow(), is(McpToolChoice.REQUIRED));
+        assertThat(request.usesTool(), is(true));
+    }
+
+    @Test
+    void samplingRequestDetectsToolChoiceAndToolMessages() {
+        McpSamplingRequest ordinary = McpSamplingRequest.builder()
+                .addMessage(message(McpRole.USER, McpSamplingTextContent.create("Hello")))
+                .build();
+        McpSamplingRequest withChoice = McpSamplingRequest.builder()
+                .toolChoice(McpToolChoice.NONE)
+                .build();
+        McpSamplingRequest withToolMessage = McpSamplingRequest.builder()
+                .addMessage(message(McpRole.ASSISTANT, McpSamplingToolUseContent.builder()
+                        .id("call-1")
+                        .name("weather")
+                        .input(new McpParameters(JsonObject.empty()))
+                        .build()))
+                .build();
+        McpSamplingRequest withToolResult = McpSamplingRequest.builder()
+                .addMessage(message(McpRole.USER, McpSamplingToolResultContent.builder()
+                        .toolUseId("call-1")
+                        .result(McpToolResult.create("18 C"))
+                        .build()))
+                .build();
+
+        assertThat(ordinary.usesTool(), is(false));
+        assertThat(withChoice.usesTool(), is(true));
+        assertThat(withToolMessage.usesTool(), is(true));
+        assertThat(withToolResult.usesTool(), is(true));
+    }
+
     @ParameterizedTest
-    @EnumSource(value = McpIncludeContext.class, names = {"THIS_SERVER", "ALL_SERVERS"})
-    void rejectsUndeclaredSamplingContext(McpIncludeContext includeContext) {
-        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, false);
-        JsonRpcResponse response = mock(JsonRpcResponse.class);
-        McpSampling sampling = new McpSampling(session, new McpStreamableHttpTransport(response));
+    @EnumSource(McpIncludeContext.class)
+    void samplingRequestDetectsContextUse(McpIncludeContext includeContext) {
         McpSamplingRequest request = McpSamplingRequest.builder()
                 .includeContext(includeContext)
                 .build();
+
+        assertThat(request.usesContext(), is(includeContext != McpIncludeContext.NONE));
+    }
+
+    @Test
+    void reportsSamplingToolsCapability() {
+        McpSampling basic = sampling(session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {}}
+                """), new McpStreamableHttpTransport(mock(JsonRpcResponse.class)));
+        McpSampling withTools = sampling(session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """), new McpStreamableHttpTransport(mock(JsonRpcResponse.class)));
+
+        assertThat(basic.enabledTools(), is(false));
+        assertThat(withTools.enabledTools(), is(true));
+    }
+
+    @Test
+    void reportsSamplingContextCapability() {
+        McpSampling basic = sampling(session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {}}
+                """), new McpStreamableHttpTransport(mock(JsonRpcResponse.class)));
+        McpSampling withContext = sampling(session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"context": {}}}
+                """), new McpStreamableHttpTransport(mock(JsonRpcResponse.class)));
+
+        assertThat(basic.enabledContext(), is(false));
+        assertThat(withContext.enabledContext(), is(true));
+    }
+
+    @Test
+    void sendsDeclaredSamplingToolsAndToolChoice() {
+        McpTool weather = new TestTool("weather", "Looks up the weather", "{\"type\":\"object\"}");
+        McpTool time = new TestTool("time", "Looks up the time", "{\"type\":\"object\"}");
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, time, weather);
+        session.prepareResponse(0);
+        session.acceptResponse(JsonParser.create("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": 0,
+                  "result": {
+                    "model": "test-model",
+                    "role": "assistant",
+                    "content": {
+                      "type": "text",
+                      "text": "response"
+                    },
+                    "stopReason": "endTurn"
+                  }
+                }
+                """).readJsonObject());
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTool(weather.name())
+                .addTool(time.name())
+                .toolChoice(McpToolChoice.AUTO)
+                .build();
+
+        McpSamplingResponse samplingResponse = sampling.request(request);
+
+        ArgumentCaptor<SseEvent> eventCaptor = ArgumentCaptor.forClass(SseEvent.class);
+        verify(sink).emit(eventCaptor.capture());
+        JsonObject params = JsonParser.create((String) eventCaptor.getValue().data())
+                .readJsonObject()
+                .objectValue("params")
+                .orElseThrow();
+        var serializedTools = params.arrayValue("tools").orElseThrow().values();
+        JsonObject serializedWeather = serializedTools.getFirst().asObject();
+        JsonObject serializedTime = serializedTools.getLast().asObject();
+        assertThat(samplingResponse.model(), is("test-model"));
+        assertThat(serializedTools.size(), is(2));
+        assertThat(serializedWeather.stringValue("name").orElseThrow(), is("weather"));
+        assertThat(serializedWeather.stringValue("description").orElseThrow(), is("Looks up the weather"));
+        assertThat(serializedTime.stringValue("name").orElseThrow(), is("time"));
+        assertThat(serializedTime.stringValue("description").orElseThrow(), is("Looks up the time"));
+        assertThat(params.objectValue("toolChoice").orElseThrow()
+                           .stringValue("mode").orElseThrow(),
+                   is("auto"));
+    }
+
+    @Test
+    void executesSamplingToolAndReturnsFinalResponse() {
+        AtomicReference<McpToolRequest> toolRequest = new AtomicReference<>();
+        McpTool tool = new TestTool("weather", "Looks up the weather", "{\"type\":\"object\"}", request -> {
+            toolRequest.set(request);
+            return McpToolResult.create("18 C");
+        });
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, tool);
+        acceptSamplingResponse(session, 0, """
+                [
+                  {"type": "text", "text": "Checking the weather"},
+                  {
+                    "type": "tool_use",
+                    "id": "call-1",
+                    "name": "weather",
+                    "input": {"city": "Prague"},
+                    "_meta": {"trace": "sample-1"}
+                  }
+                ]
+                """, "toolUse");
+        acceptSamplingResponse(session, 1, """
+                {"type": "text", "text": "It is 18 C in Prague"}
+                """, "endTurn");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpTransport transport = new McpStreamableHttpTransport(response);
+        Context requestContext = Context.create();
+        McpFeatures features = new McpFeatures(session, transport, requestContext);
+        McpSampling sampling = features.sampling();
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTextMessage(McpRole.USER, "What is the weather in Prague?")
+                .addTool(tool.name())
+                .toolChoice(McpToolChoice.REQUIRED)
+                .build();
+
+        McpSamplingResponse samplingResponse = sampling.request(request);
+
+        assertThat(samplingResponse.asTextContent().text(), is("It is 18 C in Prague"));
+        assertThat(samplingResponse.stopReason().orElseThrow(), is(McpStopReason.END_TURN));
+        assertThat(toolRequest.get().name(), is("weather"));
+        assertThat(toolRequest.get().arguments().get("city").asString().get(), is("Prague"));
+        assertThat(toolRequest.get().meta().get("trace").asString().get(), is("sample-1"));
+        assertThat(toolRequest.get().features(), sameInstance(features));
+        assertThat(toolRequest.get().sessionContext(), sameInstance(session.context()));
+        assertThat(toolRequest.get().requestContext(), sameInstance(requestContext));
+        assertThat(request.messages().size(), is(1));
+        assertThat(request.toolChoice().orElseThrow(), is(McpToolChoice.REQUIRED));
+
+        List<JsonObject> sent = sentSamplingRequests(sink, 2);
+        assertThat(sent.get(0).longValue("id").orElseThrow(), is(0L));
+        assertThat(sent.get(1).longValue("id").orElseThrow(), is(1L));
+        JsonObject secondParams = sent.get(1).objectValue("params").orElseThrow();
+        assertThat(secondParams.objectValue("toolChoice").orElseThrow()
+                           .stringValue("mode").orElseThrow(),
+                   is("auto"));
+        var messages = secondParams.arrayValue("messages").orElseThrow().values();
+        assertThat(messages.size(), is(3));
+        JsonObject assistantMessage = messages.get(1).asObject();
+        assertThat(assistantMessage.stringValue("role").orElseThrow(), is("assistant"));
+        assertThat(assistantMessage.arrayValue("content").orElseThrow().size(), is(2));
+        JsonObject resultMessage = messages.get(2).asObject();
+        assertThat(resultMessage.stringValue("role").orElseThrow(), is("user"));
+        JsonObject result = resultMessage.objectValue("content").orElseThrow();
+        assertThat(result.stringValue("toolUseId").orElseThrow(), is("call-1"));
+        assertThat(result.booleanValue("isError").orElseThrow(), is(false));
+        assertThat(result.arrayValue("content").orElseThrow().values().get(0).asObject()
+                           .stringValue("text").orElseThrow(),
+                   is("18 C"));
+    }
+
+    @Test
+    void preservesSamplingRequestOptionsAcrossToolRounds() {
+        McpTool tool = new TestTool("weather", "Looks up the weather", "");
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}, "context": {}}}
+                """, tool);
+        acceptSamplingResponse(session, 0, """
+                {"type": "tool_use", "id": "call-1", "name": "weather", "input": {}}
+                """, "toolUse");
+        acceptSamplingResponse(session, 1, """
+                {"type": "text", "text": "Final response"}
+                """, "endTurn");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTextMessage(McpRole.USER, "Use every request option")
+                .addTool(tool.name())
+                .toolChoice(McpToolChoice.AUTO)
+                .hints(List.of("test-model"))
+                .costPriority(0.1)
+                .speedPriority(0.2)
+                .intelligencePriority(0.3)
+                .systemPrompt("Test system prompt")
+                .temperature(0.4)
+                .maxTokens(42)
+                .stopSequences(List.of("stop"))
+                .includeContext(McpIncludeContext.THIS_SERVER)
+                .metadata(Map.of("requestId", "test-request"))
+                .build();
+
+        McpSamplingResponse samplingResponse = sampling.request(request);
+
+        assertThat(samplingResponse.asTextContent().text(), is("Final response"));
+        List<JsonObject> sent = sentSamplingRequests(sink, 2);
+        JsonObject first = sent.get(0).objectValue("params").orElseThrow();
+        JsonObject second = sent.get(1).objectValue("params").orElseThrow();
+        for (String key : List.of("modelPreference",
+                                  "maxTokens",
+                                  "systemPrompt",
+                                  "temperature",
+                                  "includeContext",
+                                  "stopSequences",
+                                  "metadata",
+                                  "tools",
+                                  "toolChoice")) {
+            assertThat(second.value(key).orElseThrow().toString(),
+                       is(first.value(key).orElseThrow().toString()));
+        }
+        assertThat(first.arrayValue("messages").orElseThrow().size(), is(1));
+        assertThat(second.arrayValue("messages").orElseThrow().size(), is(3));
+        assertThat(second.arrayValue("messages").orElseThrow().values().getFirst().toString(),
+                   is(first.arrayValue("messages").orElseThrow().values().getFirst().toString()));
+        assertThat(request.messages().size(), is(1));
+    }
+
+    @Test
+    void executesParallelToolUsesAndContinuesAfterToolErrors() {
+        AtomicInteger workingInvocations = new AtomicInteger();
+        McpTool broken = new TestTool("broken", "Fails", "", request -> {
+            throw new IllegalStateException("provider unavailable");
+        });
+        McpTool working = new TestTool("working", "Works", "", request -> {
+            workingInvocations.incrementAndGet();
+            return McpToolResult.create("success");
+        });
+        McpTool empty = new TestTool("empty", "Returns null", "", request -> null);
+        McpTool unselected = new TestTool("missing", "Not selected", "");
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, broken, working, empty, unselected);
+        acceptSamplingResponse(session, 0, """
+                [
+                  {"type": "tool_use", "id": "call-1", "name": "broken", "input": {}},
+                  {"type": "tool_use", "id": "call-2", "name": "working", "input": {}},
+                  {"type": "tool_use", "id": "call-3", "name": "missing", "input": {}},
+                  {"type": "tool_use", "id": "call-4", "name": "empty", "input": {}}
+                ]
+                """, "toolUse");
+        acceptSamplingResponse(session, 1, """
+                {"type": "text", "text": "Recovered from the tool errors"}
+                """, "endTurn");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTextMessage(McpRole.USER, "Use the tools")
+                .addTool(broken.name())
+                .addTool(working.name())
+                .addTool(empty.name())
+                .build();
+
+        McpSamplingResponse samplingResponse = sampling.request(request);
+
+        assertThat(samplingResponse.asTextContent().text(), is("Recovered from the tool errors"));
+        assertThat(workingInvocations.get(), is(1));
+        List<JsonObject> sent = sentSamplingRequests(sink, 2);
+        var messages = sent.get(1).objectValue("params").orElseThrow()
+                .arrayValue("messages").orElseThrow().values();
+        var results = messages.get(2).asObject().arrayValue("content").orElseThrow().values();
+        assertThat(results.size(), is(4));
+        assertToolResult(results.get(0).asObject(), "call-1", true, "failed");
+        assertToolResult(results.get(1).asObject(), "call-2", false, "success");
+        assertToolResult(results.get(2).asObject(), "call-3", true, "is not available");
+        assertToolResult(results.get(3).asObject(), "call-4", true, "returned no result");
+    }
+
+    @Test
+    void executesMultipleSamplingToolRounds() {
+        AtomicInteger invocations = new AtomicInteger();
+        McpTool tool = new TestTool("counter", "Counts", "", request ->
+                McpToolResult.create(Integer.toString(invocations.incrementAndGet())));
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, tool);
+        acceptSamplingResponse(session, 0, """
+                {"type": "tool_use", "id": "call-1", "name": "counter", "input": {}}
+                """, "toolUse");
+        acceptSamplingResponse(session, 1, """
+                {"type": "tool_use", "id": "call-2", "name": "counter", "input": {}}
+                """, "toolUse");
+        acceptSamplingResponse(session, 2, """
+                {"type": "text", "text": "All tools completed"}
+                """, "endTurn");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTextMessage(McpRole.USER, "Count twice")
+                .addTool(tool.name())
+                .build();
+
+        McpSamplingResponse samplingResponse = sampling.request(request);
+
+        assertThat(samplingResponse.asTextContent().text(), is("All tools completed"));
+        assertThat(invocations.get(), is(2));
+        List<JsonObject> sent = sentSamplingRequests(sink, 3);
+        var messages = sent.get(2).objectValue("params").orElseThrow()
+                .arrayValue("messages").orElseThrow().values();
+        assertThat(messages.size(), is(5));
+        assertThat(messages.get(0).asObject().stringValue("role").orElseThrow(), is("user"));
+        assertThat(messages.get(1).asObject().stringValue("role").orElseThrow(), is("assistant"));
+        assertThat(messages.get(2).asObject().stringValue("role").orElseThrow(), is("user"));
+        assertThat(messages.get(3).asObject().stringValue("role").orElseThrow(), is("assistant"));
+        assertThat(messages.get(4).asObject().stringValue("role").orElseThrow(), is("user"));
+        assertThat(request.messages().size(), is(1));
+    }
+
+    @Test
+    void rejectsReplayedSamplingToolUseIdentifier() {
+        AtomicInteger invocations = new AtomicInteger();
+        McpTool tool = new TestTool("counter", "Counts", "", request ->
+                McpToolResult.create(Integer.toString(invocations.incrementAndGet())));
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, tool);
+        acceptSamplingResponse(session, 0, """
+                {"type": "tool_use", "id": "call-1", "name": "counter", "input": {}}
+                """, "toolUse");
+        acceptSamplingResponse(session, 1, """
+                {"type": "tool_use", "id": "call-1", "name": "counter", "input": {}}
+                """, "toolUse");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTool(tool.name())
+                .build();
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class, () -> sampling.request(request));
+
+        assertThat(exception.getMessage(), is("Sampling tool use identifier was reused: call-1"));
+        assertThat(invocations.get(), is(1));
+        sentSamplingRequests(sink, 2);
+    }
+
+    @Test
+    void rejectsSamplingToolUseIdentifierReplayedFromRequestHistory() {
+        AtomicInteger invocations = new AtomicInteger();
+        McpTool tool = new TestTool("counter", "Counts", "", request ->
+                McpToolResult.create(Integer.toString(invocations.incrementAndGet())));
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, tool);
+        acceptSamplingResponse(session, 0, """
+                {"type": "tool_use", "id": "call-1", "name": "counter", "input": {}}
+                """, "toolUse");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTextMessage(McpRole.USER, "Continue the conversation")
+                .addMessage(message(McpRole.ASSISTANT, McpSamplingToolUseContent.builder()
+                        .id("call-1")
+                        .name("counter")
+                        .input(new McpParameters(JsonObject.empty()))
+                        .build()))
+                .addMessage(message(McpRole.USER, McpSamplingToolResultContent.builder()
+                        .toolUseId("call-1")
+                        .result(McpToolResult.create("previous result"))
+                        .build()))
+                .addTool(tool.name())
+                .build();
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class, () -> sampling.request(request));
+
+        assertThat(exception.getMessage(), is("Sampling tool use identifier was reused: call-1"));
+        assertThat(invocations.get(), is(0));
+        sentSamplingRequests(sink, 1);
+    }
+
+    @Test
+    void rejectsDuplicateSamplingToolUseIdentifiersBeforeInvocation() {
+        AtomicInteger invocations = new AtomicInteger();
+        McpTool tool = new TestTool("counter", "Counts", "", request ->
+                McpToolResult.create(Integer.toString(invocations.incrementAndGet())));
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, tool);
+        acceptSamplingResponse(session, 0, """
+                [
+                  {"type": "tool_use", "id": "call-1", "name": "counter", "input": {}},
+                  {"type": "tool_use", "id": "call-1", "name": "counter", "input": {}}
+                ]
+                """, "toolUse");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class,
+                                                      () -> sampling.request(req -> req.addTool(tool.name())));
+
+        assertThat(exception.getMessage(), is("Sampling tool use identifiers must be unique within a message"));
+        assertThat(invocations.get(), is(0));
+        sentSamplingRequests(sink, 1);
+    }
+
+    @Test
+    void rejectsDuplicateSamplingToolNamesBeforeSending() {
+        McpTool tool = new TestTool("duplicate", "Duplicate", "");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        McpSampling sampling = sampling(session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, tool), new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTool(tool.name())
+                .addTool(tool.name())
+                .build();
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class, () -> sampling.request(request));
+
+        assertThat(exception.getMessage(), is("Sampling tool names must be unique: duplicate"));
+        verifyNoInteractions(response);
+    }
+
+    @Test
+    void rejectsUnregisteredSamplingToolNameBeforeSending() {
+        McpTool tool = new TestTool("weather", "Looks up the weather", "");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        McpSampling sampling = sampling(session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, tool), new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTool("missing")
+                .build();
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class, () -> sampling.request(request));
+
+        assertThat(exception.getMessage(), is("Sampling tool is not registered: missing"));
+        verifyNoInteractions(response);
+    }
+
+    @Test
+    void rejectsAmbiguousRegisteredSamplingToolNameBeforeSending() {
+        McpTool first = new TestTool("duplicate", "First", "");
+        McpTool second = new TestTool("duplicate", "Second", "");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        McpSampling sampling = sampling(session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, first, second), new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTool("duplicate")
+                .build();
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class, () -> sampling.request(request));
+
+        assertThat(exception.getMessage(), is("Registered sampling tool names must be unique: duplicate"));
+        verifyNoInteractions(response);
+    }
+
+    @Test
+    void doesNotOfferRegisteredToolsForEmptySelection() {
+        McpTool tool = new TestTool("weather", "Looks up the weather", "");
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, tool);
+        acceptSamplingResponse(session, 0, """
+                {"type": "text", "text": "No tools needed"}
+                """, "endTurn");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .tools(List.of())
+                .build();
+
+        McpSamplingResponse samplingResponse = sampling.request(request);
+
+        assertThat(samplingResponse.asTextContent().text(), is("No tools needed"));
+        assertThat(request.usesTool(), is(false));
+        JsonObject params = sentSamplingRequests(sink, 1).getFirst().objectValue("params").orElseThrow();
+        assertThat(params.value("tools").isEmpty(), is(true));
+    }
+
+    @Test
+    void rejectsToolUseWhenToolChoiceIsNone() {
+        AtomicInteger invocations = new AtomicInteger();
+        McpTool tool = new TestTool("weather", "Looks up the weather", "", request -> {
+            invocations.incrementAndGet();
+            return McpToolResult.create("unused");
+        });
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, tool);
+        acceptSamplingResponse(session, 0, """
+                {"type": "tool_use", "id": "call-1", "name": "weather", "input": {}}
+                """, "toolUse");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTool(tool.name())
+                .toolChoice(McpToolChoice.NONE)
+                .build();
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class, () -> sampling.request(request));
+
+        assertThat(exception.getMessage(), is("Sampling client returned a tool use when tool choice is none"));
+        assertThat(invocations.get(), is(0));
+        sentSamplingRequests(sink, 1);
+    }
+
+    @Test
+    void limitsSamplingToolIterationsAndRequestsFinalResponse() {
+        AtomicInteger invocations = new AtomicInteger();
+        McpTool tool = new TestTool("counter", "Counts", "", request ->
+                McpToolResult.create(Integer.toString(invocations.incrementAndGet())));
+        McpServerConfig config = McpServerFeature.builder()
+                .maxSamplingToolIterations(1)
+                .addTool(tool)
+                .buildPrototype();
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25,
+                                     """
+                                             {"sampling": {"tools": {}}}
+                                             """,
+                                     config);
+        for (int id = 0; id <= 1; id++) {
+            acceptSamplingResponse(session, id, """
+                    {"type": "tool_use", "id": "call-%d", "name": "counter", "input": {}}
+                    """.formatted(id), "toolUse");
+        }
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTool(tool.name())
+                .build();
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class, () -> sampling.request(request));
+
+        assertThat(exception.getMessage(), is("Sampling tool iteration limit reached"));
+        assertThat(invocations.get(), is(1));
+        List<JsonObject> sent = sentSamplingRequests(sink, 2);
+        assertThat(sent.getLast().objectValue("params").orElseThrow()
+                           .objectValue("toolChoice").orElseThrow()
+                           .stringValue("mode").orElseThrow(),
+                   is("none"));
+    }
+
+    @Test
+    void returnsFinalResponseAfterMaximumSamplingToolIterations() {
+        AtomicInteger invocations = new AtomicInteger();
+        McpTool tool = new TestTool("counter", "Counts", "", request ->
+                McpToolResult.create(Integer.toString(invocations.incrementAndGet())));
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, tool);
+        for (int id = 0; id < 10; id++) {
+            acceptSamplingResponse(session, id, """
+                    {"type": "tool_use", "id": "call-%d", "name": "counter", "input": {}}
+                    """.formatted(id), "toolUse");
+        }
+        acceptSamplingResponse(session, 10, """
+                {"type": "text", "text": "Reached the final response"}
+                """, "endTurn");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTool(tool.name())
+                .build();
+
+        McpSamplingResponse samplingResponse = sampling.request(request);
+
+        assertThat(samplingResponse.asTextContent().text(), is("Reached the final response"));
+        assertThat(invocations.get(), is(10));
+        List<JsonObject> sent = sentSamplingRequests(sink, 11);
+        assertThat(sent.getLast().objectValue("params").orElseThrow()
+                           .objectValue("toolChoice").orElseThrow()
+                           .stringValue("mode").orElseThrow(),
+                   is("none"));
+    }
+
+    @Test
+    void rejectsToolUseResponseWithoutSamplingToolsCapability() {
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {}}
+                """);
+        acceptSamplingResponse(session, 0, """
+                {"type": "tool_use", "id": "call-1", "name": "weather", "input": {}}
+                """, "toolUse");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTextMessage(McpRole.USER, "Hello")
+                .build();
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class, () -> sampling.request(request));
+
+        assertThat(exception.getMessage(), is("Sampling tools are not supported by client"));
+        sentSamplingRequests(sink, 1);
+    }
+
+    @Test
+    void rejectsResponseThatOmitsRequiredToolUse() {
+        McpTool tool = new TestTool("weather", "Looks up the weather", "");
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, tool);
+        acceptSamplingResponse(session, 0, """
+                {"type": "text", "text": "No tool was used"}
+                """, "endTurn");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTool(tool.name())
+                .toolChoice(McpToolChoice.REQUIRED)
+                .build();
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class, () -> sampling.request(request));
+
+        assertThat(exception.getMessage(), is("Sampling response did not use a required tool"));
+        sentSamplingRequests(sink, 1);
+    }
+
+    @Test
+    void rejectsToolUseStopReasonWithoutToolUseContent() {
+        McpTool tool = new TestTool("weather", "Looks up the weather", "");
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, tool);
+        acceptSamplingResponse(session, 0, """
+                {"type": "text", "text": "Malformed response"}
+                """, "toolUse");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTool(tool.name())
+                .build();
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class, () -> sampling.request(request));
+
+        assertThat(exception.getMessage(), is("Sampling response stopped for tool use without tool use content"));
+        sentSamplingRequests(sink, 1);
+    }
+
+    @Test
+    void rejectsToolNamesWithoutSamplingToolsCapability() {
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        McpSampling sampling = sampling(session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {}}
+                """), new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTool("weather")
+                .build();
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class, () -> sampling.request(request));
+
+        assertThat(exception.getMessage(), is("Sampling tools are not supported by client"));
+        verifyNoInteractions(response);
+    }
+
+    @Test
+    void rejectsRequestWithoutSamplingCapability() {
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        McpSampling sampling = sampling(session(McpProtocolVersion.VERSION_2025_11_25, "{}"),
+                                        new McpStreamableHttpTransport(response));
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class,
+                                                       () -> sampling.request(McpSamplingRequest.builder().build()));
+
+        assertThat(sampling.enabled(), is(false));
+        assertThat(exception.getMessage(), is("Sampling feature is not supported by client"));
+        verifyNoInteractions(response);
+    }
+
+    @Test
+    void rejectsToolChoiceWithoutSamplingToolsCapability() {
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        McpSampling sampling = sampling(session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {}}
+                """), new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .toolChoice(McpToolChoice.NONE)
+                .build();
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class, () -> sampling.request(request));
+
+        assertThat(exception.getMessage(), is("Sampling tools are not supported by client"));
+        verifyNoInteractions(response);
+    }
+
+    @Test
+    void rejectsToolMessagesWithoutSamplingToolsCapability() {
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        McpSampling sampling = sampling(session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {}}
+                """), new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addMessage(message(McpRole.ASSISTANT, McpSamplingToolUseContent.builder()
+                        .id("call-1")
+                        .name("weather")
+                        .input(new McpParameters(JsonParser.create("{}").readJsonObject()))
+                        .build()))
+                .build();
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class, () -> sampling.request(request));
+
+        assertThat(exception.getMessage(), is("Sampling tools are not supported by client"));
+        verifyNoInteractions(response);
+    }
+
+    @Test
+    void rejectsToolResponseWithoutSamplingToolsCapability() {
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        McpSampling sampling = sampling(session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {}}
+                """), new McpStreamableHttpTransport(response));
+        McpSamplingMessage responseMessage = McpSamplingMessage.builder()
+                .role(McpRole.ASSISTANT)
+                .addContent(McpSamplingTextContent.create("Calling a tool"))
+                .addContent(McpSamplingToolUseContent.builder()
+                                    .id("call-1")
+                                    .name("weather")
+                                    .input(new McpParameters(JsonObject.empty()))
+                                    .build())
+                .build();
+        McpSamplingResponse samplingResponse = new McpSamplingResponseImpl(responseMessage, "test-model", "toolUse");
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addMessage(samplingResponse.message())
+                .build();
+
+        var contents = request.messages().getFirst().contents();
+        assertThat(contents.size(), is(2));
+        assertThat(contents.get(0), instanceOf(McpSamplingTextContent.class));
+        assertThat(contents.get(1), instanceOf(McpSamplingToolUseContent.class));
+        assertThat(request.usesTool(), is(true));
+        assertThrows(UnsupportedOperationException.class,
+                     () -> request.messages().getFirst().contents().clear());
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class, () -> sampling.request(request));
+
+        assertThat(exception.getMessage(), is("Sampling tools are not supported by client"));
+        verifyNoInteractions(response);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = McpProtocolVersion.class,
+                names = {"VERSION_2024_11_05", "VERSION_2025_03_26", "VERSION_2025_06_18"})
+    void rejectsSamplingToolsForLegacyProtocolVersions(McpProtocolVersion protocolVersion) {
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        McpSampling sampling = sampling(session(protocolVersion, """
+                {"sampling": {"tools": {}}}
+                """), new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTool("weather")
+                .build();
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class, () -> sampling.request(request));
+
+        assertThat(sampling.enabledTools(), is(false));
+        assertThat(exception.getMessage(), is("Sampling tools are not supported by client"));
+        verifyNoInteractions(response);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = McpIncludeContext.class, names = {"THIS_SERVER", "ALL_SERVERS"})
+    void rejectsUndeclaredSamplingContext(McpIncludeContext includeContext) {
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {}}
+                """);
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .includeContext(includeContext)
+                .build();
+
+        assertThat(request.usesContext(), is(true));
 
         McpSamplingException exception = assertThrows(McpSamplingException.class, () -> sampling.request(request));
 
@@ -82,7 +930,15 @@ class McpSamplingTest {
     private static McpSamplingResponse requestContext(McpProtocolVersion protocolVersion,
                                                       boolean contextSupported,
                                                       McpIncludeContext includeContext) {
-        McpSession session = session(protocolVersion, contextSupported);
+        String capabilities = contextSupported
+                ? """
+                        {"sampling": {"context": {}}}
+                        """
+                : """
+                        {"sampling": {}}
+                        """;
+        McpSession session = session(protocolVersion, capabilities);
+        session.prepareResponse(0);
         session.acceptResponse(JsonParser.create("""
                 {
                   "jsonrpc": "2.0",
@@ -101,7 +957,7 @@ class McpSamplingTest {
         JsonRpcResponse response = mock(JsonRpcResponse.class);
         SseSink sink = mock(SseSink.class);
         when(response.sink(SseSink.TYPE)).thenReturn(sink);
-        McpSampling sampling = new McpSampling(session, new McpStreamableHttpTransport(response));
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
         McpSamplingRequest request = McpSamplingRequest.builder()
                 .includeContext(includeContext)
                 .build();
@@ -119,23 +975,94 @@ class McpSamplingTest {
         return samplingResponse;
     }
 
-    private static McpSession session(McpProtocolVersion protocolVersion, boolean contextSupported) {
+    private static McpSession session(McpProtocolVersion protocolVersion, String capabilities) {
         McpServerConfig config = McpServerConfig.create();
+        return session(protocolVersion, capabilities, config);
+    }
+
+    private static McpSession session(McpProtocolVersion protocolVersion,
+                                      String capabilities,
+                                      McpTool... tools) {
+        McpServerConfig config = McpServerFeature.builder()
+                .addTools(List.of(tools))
+                .buildPrototype();
+        return session(protocolVersion, capabilities, config);
+    }
+
+    private static McpSession session(McpProtocolVersion protocolVersion,
+                                      String capabilities,
+                                      McpServerConfig config) {
         McpSessions sessions = new McpSessions(config.maxSessionCount());
         McpSession session = new McpSession(sessions,
                                             mock(McpTransportManager.class),
                                             config,
                                             "test-session");
         session.protocolVersion(protocolVersion);
-        String capabilities = contextSupported
-                ? """
-                        {"sampling": {"context": {}}}
-                        """
-                : """
-                        {"sampling": {}}
-                        """;
         session.initializeClientCapabilities(new McpParameters(
                 JsonRpcParams.create(JsonParser.create(capabilities).readJsonObject())));
         return session;
+    }
+
+    private static McpSampling sampling(McpSession session, McpTransport transport) {
+        return new McpFeatures(session, transport).sampling();
+    }
+
+    private static void acceptSamplingResponse(McpSession session, long id, String content, String stopReason) {
+        session.prepareResponse(id);
+        session.acceptResponse(JsonParser.create("""
+                {
+                  "jsonrpc": "2.0",
+                  "id": %d,
+                  "result": {
+                    "model": "test-model-%d",
+                    "role": "assistant",
+                    "content": %s,
+                    "stopReason": "%s"
+                  }
+                }
+                """.formatted(id, id, content, stopReason)).readJsonObject());
+    }
+
+    private static List<JsonObject> sentSamplingRequests(SseSink sink, int count) {
+        ArgumentCaptor<SseEvent> eventCaptor = ArgumentCaptor.forClass(SseEvent.class);
+        verify(sink, times(count)).emit(eventCaptor.capture());
+        return eventCaptor.getAllValues().stream()
+                .map(SseEvent::data)
+                .map(String.class::cast)
+                .map(JsonParser::create)
+                .map(JsonParser::readJsonObject)
+                .toList();
+    }
+
+    private static void assertToolResult(JsonObject result,
+                                         String toolUseId,
+                                         boolean error,
+                                         String messageFragment) {
+        assertThat(result.stringValue("toolUseId").orElseThrow(), is(toolUseId));
+        assertThat(result.booleanValue("isError").orElseThrow(), is(error));
+        String text = result.arrayValue("content").orElseThrow().values().get(0).asObject()
+                .stringValue("text").orElseThrow();
+        assertThat(text.contains(messageFragment), is(true));
+    }
+
+    private static McpSamplingMessage message(McpRole role, McpSamplingContent content) {
+        return McpSamplingMessage.builder()
+                .role(role)
+                .addContent(content)
+                .build();
+    }
+
+    private record TestTool(String name,
+                            String description,
+                            String schema,
+                            Function<McpToolRequest, McpToolResult> invocation) implements McpTool {
+        private TestTool(String name, String description, String schema) {
+            this(name, description, schema, request -> McpToolResult.create());
+        }
+
+        @Override
+        public McpToolResult tool(McpToolRequest request) {
+            return invocation.apply(request);
+        }
     }
 }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 
 import io.helidon.common.context.Context;
 import io.helidon.http.sse.SseEvent;
+import io.helidon.json.JsonNull;
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonParser;
 import io.helidon.jsonrpc.core.JsonRpcParams;
@@ -435,6 +436,38 @@ class McpSamplingTest {
     }
 
     @Test
+    void retainsParentCancellationHookWhenSamplingToolRegistersAnother() {
+        AtomicInteger parentCancellations = new AtomicInteger();
+        AtomicInteger toolCancellations = new AtomicInteger();
+        McpTool tool = new TestTool("tool", "Registers cancellation", "", request -> {
+            request.features().cancellation().registerCancellationHook(toolCancellations::incrementAndGet);
+            return McpToolResult.create("complete");
+        });
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, tool);
+        acceptSamplingResponse(session, 0, """
+                {"type": "tool_use", "id": "call-1", "name": "tool", "input": {}}
+                """, "toolUse");
+        acceptSamplingResponse(session, 1, """
+                {"type": "text", "text": "complete"}
+                """, "endTurn");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpFeatures features = new McpFeatures(session, new McpStreamableHttpTransport(response));
+        features.cancellation().registerCancellationHook(parentCancellations::incrementAndGet);
+
+        McpSamplingResponse samplingResponse = features.sampling().request(request -> request.addTool(tool.name()));
+        features.cancellation().cancel(JsonNull.instance());
+
+        assertThat(samplingResponse.asTextContent().text(), is("complete"));
+        assertThat(parentCancellations.get(), is(1));
+        assertThat(toolCancellations.get(), is(1));
+        sentSamplingRequests(sink, 2);
+    }
+
+    @Test
     void stopsRemainingSamplingToolsAfterSessionDisconnect() {
         AtomicInteger remainingInvocations = new AtomicInteger();
         AtomicReference<McpSession> sessionRef = new AtomicReference<>();
@@ -783,6 +816,55 @@ class McpSamplingTest {
                            .objectValue("toolChoice").orElseThrow()
                            .stringValue("mode").orElseThrow(),
                    is("none"));
+    }
+
+    @Test
+    void sharesSamplingToolBudgetWithReentrantRequests() {
+        AtomicInteger invocations = new AtomicInteger();
+        AtomicReference<McpSamplingException> nestedFailure = new AtomicReference<>();
+        McpTool recursive = new TestTool("recursive", "Samples recursively", "", request -> {
+            if (invocations.incrementAndGet() == 1) {
+                try {
+                    request.features().sampling().request(builder -> builder.addTool("recursive"));
+                } catch (McpSamplingException e) {
+                    nestedFailure.set(e);
+                }
+            }
+            return McpToolResult.create("complete");
+        });
+        McpServerConfig config = McpServerFeature.builder()
+                .maxSamplingToolIterations(1)
+                .addTool(recursive)
+                .buildPrototype();
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25,
+                                     """
+                                             {"sampling": {"tools": {}}}
+                                             """,
+                                     config);
+        acceptSamplingResponse(session, 0, """
+                {"type": "tool_use", "id": "call-outer", "name": "recursive", "input": {}}
+                """, "toolUse");
+        acceptSamplingResponse(session, 1, """
+                {"type": "tool_use", "id": "call-nested", "name": "recursive", "input": {}}
+                """, "toolUse");
+        acceptSamplingResponse(session, 2, """
+                {"type": "text", "text": "complete"}
+                """, "endTurn");
+        acceptSamplingResponse(session, 3, """
+                {"type": "text", "text": "complete"}
+                """, "endTurn");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+
+        McpSamplingResponse samplingResponse = sampling.request(builder -> builder.addTool(recursive.name()));
+
+        assertThat(samplingResponse.asTextContent().text(), is("complete"));
+        assertThat(invocations.get(), is(1));
+        assertThat(nestedFailure.get(), instanceOf(McpSamplingException.class));
+        assertThat(nestedFailure.get().getMessage(), is("Sampling tool iteration limit reached"));
+        sentSamplingRequests(sink, 3);
     }
 
     @Test

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
@@ -1252,7 +1253,7 @@ class McpSamplingTest {
         assertThat(result.booleanValue("isError").orElseThrow(), is(error));
         String text = result.arrayValue("content").orElseThrow().values().get(0).asObject()
                 .stringValue("text").orElseThrow();
-        assertThat(text.contains(messageFragment), is(true));
+        assertThat(text, containsString(messageFragment));
     }
 
     private static McpSamplingMessage message(McpRole role, McpSamplingContent content) {

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
@@ -15,6 +15,8 @@
  */
 package io.helidon.extensions.mcp.server;
 
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -152,7 +154,7 @@ class McpSamplingTest {
                 {"sampling": {"tools": {}}}
                 """, time, weather);
         session.prepareResponse(0);
-        session.acceptResponse(JsonParser.create("""
+        JsonObject responseObject = JsonParser.create("""
                 {
                   "jsonrpc": "2.0",
                   "id": 0,
@@ -166,7 +168,8 @@ class McpSamplingTest {
                     "stopReason": "endTurn"
                   }
                 }
-                """).readJsonObject());
+                """).readJsonObject();
+        session.acceptResponse(new McpResponseImpl(responseObject, Context.create()));
         JsonRpcResponse response = mock(JsonRpcResponse.class);
         SseSink sink = mock(SseSink.class);
         when(response.sink(SseSink.TYPE)).thenReturn(sink);
@@ -209,6 +212,8 @@ class McpSamplingTest {
         McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
                 {"sampling": {"tools": {}}}
                 """, tool);
+        Context toolUseResponseContext = Context.create();
+        Context finalResponseContext = Context.create();
         acceptSamplingResponse(session, 0, """
                 [
                   {"type": "text", "text": "Checking the weather"},
@@ -220,16 +225,15 @@ class McpSamplingTest {
                     "_meta": {"trace": "sample-1"}
                   }
                 ]
-                """, "toolUse");
+                """, "toolUse", toolUseResponseContext);
         acceptSamplingResponse(session, 1, """
                 {"type": "text", "text": "It is 18 C in Prague"}
-                """, "endTurn");
+                """, "endTurn", finalResponseContext);
         JsonRpcResponse response = mock(JsonRpcResponse.class);
         SseSink sink = mock(SseSink.class);
         when(response.sink(SseSink.TYPE)).thenReturn(sink);
         McpTransport transport = new McpStreamableHttpTransport(response);
-        Context requestContext = Context.create();
-        McpFeatures features = new McpFeatures(session, transport, requestContext);
+        McpFeatures features = new McpFeatures(session, transport);
         McpSampling sampling = features.sampling();
         McpSamplingRequest request = McpSamplingRequest.builder()
                 .addTextMessage(McpRole.USER, "What is the weather in Prague?")
@@ -246,7 +250,7 @@ class McpSamplingTest {
         assertThat(toolRequest.get().meta().get("trace").asString().get(), is("sample-1"));
         assertThat(toolRequest.get().features(), sameInstance(features));
         assertThat(toolRequest.get().sessionContext(), sameInstance(session.context()));
-        assertThat(toolRequest.get().requestContext(), sameInstance(requestContext));
+        assertThat(toolRequest.get().requestContext(), sameInstance(toolUseResponseContext));
         assertThat(request.messages().size(), is(1));
         assertThat(request.toolChoice().orElseThrow(), is(McpToolChoice.REQUIRED));
 
@@ -514,17 +518,22 @@ class McpSamplingTest {
     @Test
     void executesMultipleSamplingToolRounds() {
         AtomicInteger invocations = new AtomicInteger();
-        McpTool tool = new TestTool("counter", "Counts", "", request ->
-                McpToolResult.create(Integer.toString(invocations.incrementAndGet())));
+        List<Context> requestContexts = new ArrayList<>();
+        McpTool tool = new TestTool("counter", "Counts", "", request -> {
+            requestContexts.add(request.requestContext());
+            return McpToolResult.create(Integer.toString(invocations.incrementAndGet()));
+        });
         McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
                 {"sampling": {"tools": {}}}
                 """, tool);
+        Context firstResponseContext = Context.create();
+        Context secondResponseContext = Context.create();
         acceptSamplingResponse(session, 0, """
                 {"type": "tool_use", "id": "call-1", "name": "counter", "input": {}}
-                """, "toolUse");
+                """, "toolUse", firstResponseContext);
         acceptSamplingResponse(session, 1, """
                 {"type": "tool_use", "id": "call-2", "name": "counter", "input": {}}
-                """, "toolUse");
+                """, "toolUse", secondResponseContext);
         acceptSamplingResponse(session, 2, """
                 {"type": "text", "text": "All tools completed"}
                 """, "endTurn");
@@ -541,6 +550,8 @@ class McpSamplingTest {
 
         assertThat(samplingResponse.asTextContent().text(), is("All tools completed"));
         assertThat(invocations.get(), is(2));
+        assertThat(requestContexts.get(0), sameInstance(firstResponseContext));
+        assertThat(requestContexts.get(1), sameInstance(secondResponseContext));
         List<JsonObject> sent = sentSamplingRequests(sink, 3);
         var messages = sent.get(2).objectValue("params").orElseThrow()
                 .arrayValue("messages").orElseThrow().values();
@@ -1071,6 +1082,25 @@ class McpSamplingTest {
     }
 
     @Test
+    void reportsSamplingResponseTimeout() {
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {}}
+                """);
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .timeout(Duration.ZERO)
+                .build();
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class, () -> sampling.request(request));
+
+        assertThat(exception.getMessage(), is("response timeout"));
+        sentSamplingRequests(sink, 1);
+    }
+
+    @Test
     void rejectsToolNamesWithoutSamplingToolsCapability() {
         JsonRpcResponse response = mock(JsonRpcResponse.class);
         McpSampling sampling = sampling(session(McpProtocolVersion.VERSION_2025_11_25, """
@@ -1248,7 +1278,7 @@ class McpSamplingTest {
                         """;
         McpSession session = session(protocolVersion, capabilities);
         session.prepareResponse(0);
-        session.acceptResponse(JsonParser.create("""
+        JsonObject responseObject = JsonParser.create("""
                 {
                   "jsonrpc": "2.0",
                   "id": 0,
@@ -1262,7 +1292,8 @@ class McpSamplingTest {
                     "stopReason": "endTurn"
                   }
                 }
-                """).readJsonObject());
+                """).readJsonObject();
+        session.acceptResponse(new McpResponseImpl(responseObject, Context.create()));
         JsonRpcResponse response = mock(JsonRpcResponse.class);
         SseSink sink = mock(SseSink.class);
         when(response.sink(SseSink.TYPE)).thenReturn(sink);
@@ -1317,8 +1348,17 @@ class McpSamplingTest {
     }
 
     private static void acceptSamplingResponse(McpSession session, long id, String content, String stopReason) {
+        Context requestContext = Context.create();
+        acceptSamplingResponse(session, id, content, stopReason, requestContext);
+    }
+
+    private static void acceptSamplingResponse(McpSession session,
+                                               long id,
+                                               String content,
+                                               String stopReason,
+                                               Context requestContext) {
         session.prepareResponse(id);
-        session.acceptResponse(JsonParser.create("""
+        JsonObject response = JsonParser.create("""
                 {
                   "jsonrpc": "2.0",
                   "id": %d,
@@ -1329,7 +1369,8 @@ class McpSamplingTest {
                     "stopReason": "%s"
                   }
                 }
-                """.formatted(id, id, content, stopReason)).readJsonObject());
+                """.formatted(id, id, content, stopReason)).readJsonObject();
+        session.acceptResponse(new McpResponseImpl(response, requestContext));
     }
 
     private static List<JsonObject> sentSamplingRequests(SseSink sink, int count) {

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
@@ -649,6 +649,34 @@ class McpSamplingTest {
     }
 
     @Test
+    void ignoresAmbiguousUnselectedRegisteredSamplingToolName() {
+        McpTool weather = new TestTool("weather", "Looks up the weather", "");
+        McpTool first = new TestTool("duplicate", "First", "");
+        McpTool second = new TestTool("duplicate", "Second", "");
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, weather, first, second);
+        acceptSamplingResponse(session, 0, """
+                {"type": "text", "text": "No duplicate tool selected"}
+                """, "endTurn");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+
+        McpSamplingResponse samplingResponse = sampling.request(req -> req.addTool(weather.name()));
+
+        assertThat(samplingResponse.asTextContent().text(), is("No duplicate tool selected"));
+        var serializedTools = sentSamplingRequests(sink, 1).getFirst()
+                .objectValue("params").orElseThrow()
+                .arrayValue("tools").orElseThrow();
+        assertThat(serializedTools.size(), is(1));
+        assertThat(serializedTools.values().getFirst().asObject()
+                           .stringValue("name").orElseThrow(),
+                   is(weather.name()));
+    }
+
+    @Test
     void doesNotOfferRegisteredToolsForEmptySelection() {
         McpTool tool = new TestTool("weather", "Looks up the weather", "");
         McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
@@ -19,6 +19,8 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -44,6 +46,8 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -247,7 +251,9 @@ class McpSamplingTest {
         assertThat(samplingResponse.stopReason().orElseThrow(), is(McpStopReason.END_TURN));
         assertThat(toolRequest.get().name(), is("weather"));
         assertThat(toolRequest.get().arguments().get("city").asString().get(), is("Prague"));
-        assertThat(toolRequest.get().metadata().orElseThrow().get("trace").asString().get(), is("sample-1"));
+        Object metadata = toolRequest.get().metadata().orElseThrow();
+        assertThat(metadata, instanceOf(JsonObject.class));
+        assertThat(((JsonObject) metadata).stringValue("trace").orElseThrow(), is("sample-1"));
         assertThat(toolRequest.get().features(), sameInstance(features));
         assertThat(toolRequest.get().sessionContext(), sameInstance(session.context()));
         assertThat(toolRequest.get().requestContext(), sameInstance(toolUseResponseContext));
@@ -437,6 +443,43 @@ class McpSamplingTest {
         assertThat(exception.getMessage(), is("Sampling request cancelled"));
         assertThat(remainingInvocations.get(), is(0));
         sentSamplingRequests(sink, 1);
+    }
+
+    @Test
+    void cancellationWakesActiveSamplingWait() throws InterruptedException {
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {}}
+                """);
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        CountDownLatch requestSent = new CountDownLatch(1);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        doAnswer(invocation -> {
+            requestSent.countDown();
+            return null;
+        }).when(sink).emit(any());
+        McpFeatures features = new McpFeatures(session, new McpStreamableHttpTransport(response));
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        Thread samplingThread = Thread.ofVirtual().start(() -> {
+            try {
+                features.sampling().request(request -> request
+                        .addTextMessage("Wait for cancellation")
+                        .timeout(Duration.ofMinutes(1)));
+            } catch (Throwable e) {
+                failure.set(e);
+            }
+        });
+        assertThat(requestSent.await(1, TimeUnit.SECONDS), is(true));
+
+        features.cancellation().cancel(JsonNull.instance());
+        samplingThread.join(1000);
+
+        assertThat(samplingThread.isAlive(), is(false));
+        assertThat(failure.get(), instanceOf(McpSamplingException.class));
+        assertThat(failure.get().getMessage(), is("Sampling request cancelled"));
+        McpInternalException exception = assertThrows(McpInternalException.class,
+                                                      () -> session.pollResponse(0, Duration.ZERO));
+        assertThat(exception.getMessage(), is("No pending response for request id 0"));
     }
 
     @Test

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
@@ -26,6 +26,7 @@ import io.helidon.http.sse.SseEvent;
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonParser;
 import io.helidon.jsonrpc.core.JsonRpcParams;
+import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.jsonrpc.JsonRpcResponse;
 import io.helidon.webserver.sse.SseSink;
 
@@ -376,6 +377,88 @@ class McpSamplingTest {
         assertToolResult(results.get(1).asObject(), "call-2", false, "success");
         assertToolResult(results.get(2).asObject(), "call-3", true, "is not available");
         assertToolResult(results.get(3).asObject(), "call-4", true, "returned no result");
+    }
+
+    @Test
+    void stopsRemainingSamplingToolsAfterCancellation() {
+        AtomicInteger remainingInvocations = new AtomicInteger();
+        McpTool cancel = new TestTool("cancel", "Cancels", "", request -> {
+            request.features().cancellation().cancel(JsonObject.builder()
+                                                         .set("id", 1)
+                                                         .build()
+                                                         .value("id")
+                                                         .orElseThrow());
+            return McpToolResult.create("cancelled");
+        });
+        McpTool remaining = new TestTool("remaining", "Must not run", "", request -> {
+            remainingInvocations.incrementAndGet();
+            return McpToolResult.create("unexpected");
+        });
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """, cancel, remaining);
+        acceptSamplingResponse(session, 0, """
+                [
+                  {"type": "tool_use", "id": "call-1", "name": "cancel", "input": {}},
+                  {"type": "tool_use", "id": "call-2", "name": "remaining", "input": {}}
+                ]
+                """, "toolUse");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class,
+                                                      () -> sampling.request(req -> req
+                                                              .addTool(cancel.name())
+                                                              .addTool(remaining.name())));
+
+        assertThat(exception.getMessage(), is("Sampling request cancelled"));
+        assertThat(remainingInvocations.get(), is(0));
+        sentSamplingRequests(sink, 1);
+    }
+
+    @Test
+    void stopsRemainingSamplingToolsAfterSessionDisconnect() {
+        AtomicInteger remainingInvocations = new AtomicInteger();
+        AtomicReference<McpSession> sessionRef = new AtomicReference<>();
+        McpTool disconnect = new TestTool("disconnect", "Disconnects", "", request -> {
+            sessionRef.get().onDisconnect(mock(ServerResponse.class));
+            return McpToolResult.create("disconnected");
+        });
+        McpTool remaining = new TestTool("remaining", "Must not run", "", request -> {
+            remainingInvocations.incrementAndGet();
+            return McpToolResult.create("unexpected");
+        });
+        McpServerConfig config = McpServerFeature.builder()
+                .addTool(disconnect)
+                .addTool(remaining)
+                .buildPrototype();
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25,
+                                     """
+                                             {"sampling": {"tools": {}}}
+                                             """,
+                                     config);
+        sessionRef.set(session);
+        acceptSamplingResponse(session, 0, """
+                [
+                  {"type": "tool_use", "id": "call-1", "name": "disconnect", "input": {}},
+                  {"type": "tool_use", "id": "call-2", "name": "remaining", "input": {}}
+                ]
+                """, "toolUse");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+
+        McpInternalException exception = assertThrows(McpInternalException.class,
+                                                      () -> sampling.request(req -> req
+                                                              .addTool(disconnect.name())
+                                                              .addTool(remaining.name())));
+
+        assertThat(exception.getMessage(), is("Session disconnected"));
+        assertThat(remainingInvocations.get(), is(0));
+        sentSamplingRequests(sink, 1);
     }
 
     @Test

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingTest.java
@@ -693,6 +693,84 @@ class McpSamplingTest {
     }
 
     @Test
+    void rejectsToolUseBatchBeyondRemainingExecutionBudgetBeforeInvocation() {
+        AtomicInteger invocations = new AtomicInteger();
+        McpTool tool = new TestTool("counter", "Counts", "", request ->
+                McpToolResult.create(Integer.toString(invocations.incrementAndGet())));
+        McpServerConfig config = McpServerFeature.builder()
+                .maxSamplingToolIterations(3)
+                .addTool(tool)
+                .buildPrototype();
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25,
+                                     """
+                                             {"sampling": {"tools": {}}}
+                                             """,
+                                     config);
+        acceptSamplingResponse(session, 0, """
+                [
+                  {"type": "tool_use", "id": "call-1", "name": "counter", "input": {}},
+                  {"type": "tool_use", "id": "call-2", "name": "counter", "input": {}}
+                ]
+                """, "toolUse");
+        acceptSamplingResponse(session, 1, """
+                [
+                  {"type": "tool_use", "id": "call-3", "name": "counter", "input": {}},
+                  {"type": "tool_use", "id": "call-4", "name": "counter", "input": {}}
+                ]
+                """, "toolUse");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+
+        McpSamplingException exception = assertThrows(McpSamplingException.class,
+                                                      () -> sampling.request(req -> req.addTool(tool.name())));
+
+        assertThat(exception.getMessage(), is("Sampling tool execution limit reached"));
+        assertThat(invocations.get(), is(2));
+        sentSamplingRequests(sink, 2);
+    }
+
+    @Test
+    void requestsFinalResponseWhenParallelToolUsesExhaustExecutionBudget() {
+        AtomicInteger invocations = new AtomicInteger();
+        McpTool tool = new TestTool("counter", "Counts", "", request ->
+                McpToolResult.create(Integer.toString(invocations.incrementAndGet())));
+        McpServerConfig config = McpServerFeature.builder()
+                .maxSamplingToolIterations(2)
+                .addTool(tool)
+                .buildPrototype();
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25,
+                                     """
+                                             {"sampling": {"tools": {}}}
+                                             """,
+                                     config);
+        acceptSamplingResponse(session, 0, """
+                [
+                  {"type": "tool_use", "id": "call-1", "name": "counter", "input": {}},
+                  {"type": "tool_use", "id": "call-2", "name": "counter", "input": {}}
+                ]
+                """, "toolUse");
+        acceptSamplingResponse(session, 1, """
+                {"type": "text", "text": "Execution budget reached"}
+                """, "endTurn");
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        SseSink sink = mock(SseSink.class);
+        when(response.sink(SseSink.TYPE)).thenReturn(sink);
+        McpSampling sampling = sampling(session, new McpStreamableHttpTransport(response));
+
+        McpSamplingResponse samplingResponse = sampling.request(req -> req.addTool(tool.name()));
+
+        assertThat(samplingResponse.asTextContent().text(), is("Execution budget reached"));
+        assertThat(invocations.get(), is(2));
+        List<JsonObject> sent = sentSamplingRequests(sink, 2);
+        assertThat(sent.getLast().objectValue("params").orElseThrow()
+                           .objectValue("toolChoice").orElseThrow()
+                           .stringValue("mode").orElseThrow(),
+                   is("none"));
+    }
+
+    @Test
     void rejectsToolUseResponseWithoutSamplingToolsCapability() {
         McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, """
                 {"sampling": {}}

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingToolsTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingToolsTest.java
@@ -16,6 +16,7 @@
 package io.helidon.extensions.mcp.server;
 
 import java.net.URI;
+import java.util.Map;
 
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.json.JsonObject;
@@ -42,9 +43,7 @@ class McpSamplingToolsTest {
         McpSamplingToolResultContent toolResult = McpSamplingToolResultContent.builder()
                 .toolUseId(toolUse.id())
                 .result(McpToolResult.create("18 C"))
-                .metadata(new McpParameters(JsonObject.builder()
-                                                .set("cached", true)
-                                                .build()))
+                .metadata(Map.of("cached", true))
                 .build();
         McpSamplingMessage message = McpSamplingMessage.builder()
                 .role(McpRole.ASSISTANT)
@@ -56,9 +55,7 @@ class McpSamplingToolsTest {
                                                          .build())
                                     .build())
                 .addContent(toolUse)
-                .metadata(new McpParameters(JsonObject.builder()
-                                                .set("traceId", "trace-1")
-                                                .build()))
+                .metadata(Map.of("traceId", "trace-1"))
                 .build();
 
         assertThat(toolUse.input().get("city").asString().orElseThrow(), is("Prague"));
@@ -67,29 +64,29 @@ class McpSamplingToolsTest {
         assertThat(((McpSamplingTextContent) message.contents().getFirst()).annotations().orElseThrow()
                            .audience().getFirst(),
                    is(McpRole.USER));
-        assertThat(message.metadata().orElseThrow().get("traceId").asString().orElseThrow(), is("trace-1"));
-        assertThat(toolResult.metadata().orElseThrow().get("cached").asBoolean().orElseThrow(), is(true));
+        assertThat(message.metadata().orElseThrow(), is(Map.of("traceId", "trace-1")));
+        assertThat(toolResult.metadata().orElseThrow(), is(Map.of("cached", true)));
         assertThat(McpSamplingRequest.builder().addMessage(message).build().usesTool(), is(true));
         assertThrows(UnsupportedOperationException.class, () -> message.contents().clear());
 
         McpToolTextContent textContent = McpToolTextContent.builder()
                 .text("text")
-                .metadata(new McpParameters(JsonObject.builder().set("source", "tool").build()))
+                .metadata(Map.of("source", "tool"))
                 .build();
         McpToolResult result = McpToolResult.builder()
                 .addTextContent(textContent)
                 .build();
         assertThat(result.textContents().getFirst().type(), is(McpContentType.TEXT));
-        assertThat(textContent.metadata().orElseThrow().get("source").asString().orElseThrow(), is("tool"));
+        assertThat(textContent.metadata().orElseThrow(), is(Map.of("source", "tool")));
         assertThat(McpToolTextContent.builder(textContent).clearMetadata().build().metadata().isEmpty(), is(true));
 
         McpToolTextResourceContent resourceContent = McpToolTextResourceContent.builder()
                 .uri(URI.create("memory://forecast"))
                 .mediaType(MediaTypes.TEXT_PLAIN)
                 .text("sunny")
-                .metadata(new McpParameters(JsonObject.builder().set("source", "resource").build()))
+                .metadata(Map.of("source", "resource"))
                 .build();
-        assertThat(resourceContent.metadata().orElseThrow().get("source").asString().orElseThrow(), is("resource"));
+        assertThat(resourceContent.metadata().orElseThrow(), is(Map.of("source", "resource")));
     }
 
     @Test

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingToolsTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingToolsTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.server;
+
+import java.net.URI;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.json.JsonObject;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class McpSamplingToolsTest {
+
+    @Test
+    void constructsToolContent() {
+        McpParameters input = new McpParameters(JsonObject.builder()
+                                                         .set("city", "Prague")
+                                                         .build());
+        McpSamplingToolUseContent toolUse = McpSamplingToolUseContent.builder()
+                .id("call-1")
+                .name("weather")
+                .input(input)
+                .build();
+        McpSamplingToolResultContent toolResult = McpSamplingToolResultContent.builder()
+                .toolUseId(toolUse.id())
+                .result(McpToolResult.create("18 C"))
+                .metadata(new McpParameters(JsonObject.builder()
+                                                .set("cached", true)
+                                                .build()))
+                .build();
+        McpSamplingMessage message = McpSamplingMessage.builder()
+                .role(McpRole.ASSISTANT)
+                .addContent(McpSamplingTextContent.builder()
+                                    .text("Checking the weather")
+                                    .annotations(McpAnnotations.builder()
+                                                         .addAudience(McpRole.USER)
+                                                         .priority(0.8)
+                                                         .build())
+                                    .build())
+                .addContent(toolUse)
+                .metadata(new McpParameters(JsonObject.builder()
+                                                .set("traceId", "trace-1")
+                                                .build()))
+                .build();
+
+        assertThat(toolUse.input().get("city").asString().orElseThrow(), is("Prague"));
+        assertThat(message.contents().size(), is(2));
+        assertThat(message.contents().get(1), sameInstance(toolUse));
+        assertThat(((McpSamplingTextContent) message.contents().getFirst()).annotations().orElseThrow()
+                           .audience().getFirst(),
+                   is(McpRole.USER));
+        assertThat(message.metadata().orElseThrow().get("traceId").asString().orElseThrow(), is("trace-1"));
+        assertThat(toolResult.metadata().orElseThrow().get("cached").asBoolean().orElseThrow(), is(true));
+        assertThat(McpSamplingRequest.builder().addMessage(message).build().usesTool(), is(true));
+        assertThrows(UnsupportedOperationException.class, () -> message.contents().clear());
+
+        McpToolTextContent textContent = McpToolTextContent.builder()
+                .text("text")
+                .metadata(new McpParameters(JsonObject.builder().set("source", "tool").build()))
+                .build();
+        McpToolResult result = McpToolResult.builder()
+                .addTextContent(textContent)
+                .build();
+        assertThat(result.textContents().getFirst().type(), is(McpContentType.TEXT));
+        assertThat(textContent.metadata().orElseThrow().get("source").asString().orElseThrow(), is("tool"));
+        assertThat(McpToolTextContent.builder(textContent).clearMetadata().build().metadata().isEmpty(), is(true));
+
+        McpToolTextResourceContent resourceContent = McpToolTextResourceContent.builder()
+                .uri(URI.create("memory://forecast"))
+                .mediaType(MediaTypes.TEXT_PLAIN)
+                .text("sunny")
+                .metadata(new McpParameters(JsonObject.builder().set("source", "resource").build()))
+                .build();
+        assertThat(resourceContent.metadata().orElseThrow().get("source").asString().orElseThrow(), is("resource"));
+    }
+
+    @Test
+    void addsToolNameToSamplingRequest() {
+        McpSamplingRequest request = McpSamplingRequest.builder()
+                .addTool("weather")
+                .build();
+
+        assertThat(request.tools().getFirst(), is("weather"));
+        assertThat(request.usesTool(), is(true));
+    }
+
+    @Test
+    void reportsSamplingContextUse() {
+        McpSamplingRequest noContext = McpSamplingRequest.builder()
+                .includeContext(McpIncludeContext.NONE)
+                .build();
+        McpSamplingRequest withContext = McpSamplingRequest.builder()
+                .includeContext(McpIncludeContext.THIS_SERVER)
+                .build();
+
+        assertThat(noContext.usesContext(), is(false));
+        assertThat(withContext.usesContext(), is(true));
+    }
+
+    @Test
+    void rejectsNullParameterObject() {
+        NullPointerException exception = assertThrows(NullPointerException.class,
+                                                      () -> new McpParameters((JsonObject) null));
+
+        assertThat(exception.getMessage(), is("value is null"));
+    }
+}

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingToolsTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingToolsTest.java
@@ -31,9 +31,9 @@ class McpSamplingToolsTest {
 
     @Test
     void constructsToolContent() {
-        McpParameters input = McpParameters.create(JsonObject.builder()
-                                                          .set("city", "Prague")
-                                                          .build());
+        McpParameters input = new McpParameters(JsonObject.builder()
+                                                        .set("city", "Prague")
+                                                        .build());
         McpSamplingToolUseContent toolUse = McpSamplingToolUseContent.builder()
                 .id("call-1")
                 .name("weather")
@@ -118,7 +118,7 @@ class McpSamplingToolsTest {
     @Test
     void rejectsNullParameterObject() {
         NullPointerException exception = assertThrows(NullPointerException.class,
-                                                      () -> McpParameters.create(null));
+                                                      () -> new McpParameters((JsonObject) null));
 
         assertThat(exception.getMessage(), is("value is null"));
     }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingToolsTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingToolsTest.java
@@ -19,7 +19,6 @@ import java.net.URI;
 import java.util.Map;
 
 import io.helidon.common.media.type.MediaTypes;
-import io.helidon.json.JsonObject;
 
 import org.junit.jupiter.api.Test;
 
@@ -32,9 +31,7 @@ class McpSamplingToolsTest {
 
     @Test
     void constructsToolContent() {
-        McpParameters input = new McpParameters(JsonObject.builder()
-                                                        .set("city", "Prague")
-                                                        .build());
+        McpParameters input = McpParameters.create(Map.of("city", "Prague"));
         McpSamplingToolUseContent toolUse = McpSamplingToolUseContent.builder()
                 .id("call-1")
                 .name("weather")
@@ -43,7 +40,7 @@ class McpSamplingToolsTest {
         McpSamplingToolResultContent toolResult = McpSamplingToolResultContent.builder()
                 .toolUseId(toolUse.id())
                 .result(McpToolResult.create("18 C"))
-                .metadata(Map.of("cached", true))
+                .metadata(McpParameters.create(Map.of("cached", true)))
                 .build();
         McpSamplingMessage message = McpSamplingMessage.builder()
                 .role(McpRole.ASSISTANT)
@@ -55,7 +52,7 @@ class McpSamplingToolsTest {
                                                          .build())
                                     .build())
                 .addContent(toolUse)
-                .metadata(Map.of("traceId", "trace-1"))
+                .metadata(McpParameters.create(Map.of("traceId", "trace-1")))
                 .build();
 
         assertThat(toolUse.input().get("city").asString().orElseThrow(), is("Prague"));
@@ -64,29 +61,29 @@ class McpSamplingToolsTest {
         assertThat(((McpSamplingTextContent) message.contents().getFirst()).annotations().orElseThrow()
                            .audience().getFirst(),
                    is(McpRole.USER));
-        assertThat(message.metadata().orElseThrow(), is(Map.of("traceId", "trace-1")));
-        assertThat(toolResult.metadata().orElseThrow(), is(Map.of("cached", true)));
+        assertThat(message.metadata().orElseThrow().get("traceId").asString().orElseThrow(), is("trace-1"));
+        assertThat(toolResult.metadata().orElseThrow().get("cached").asBoolean().orElseThrow(), is(true));
         assertThat(McpSamplingRequest.builder().addMessage(message).build().usesTool(), is(true));
         assertThrows(UnsupportedOperationException.class, () -> message.contents().clear());
 
         McpToolTextContent textContent = McpToolTextContent.builder()
                 .text("text")
-                .metadata(Map.of("source", "tool"))
+                .metadata(McpParameters.create(Map.of("source", "tool")))
                 .build();
         McpToolResult result = McpToolResult.builder()
                 .addTextContent(textContent)
                 .build();
         assertThat(result.textContents().getFirst().type(), is(McpContentType.TEXT));
-        assertThat(textContent.metadata().orElseThrow(), is(Map.of("source", "tool")));
+        assertThat(textContent.metadata().orElseThrow().get("source").asString().orElseThrow(), is("tool"));
         assertThat(McpToolTextContent.builder(textContent).clearMetadata().build().metadata().isEmpty(), is(true));
 
         McpToolTextResourceContent resourceContent = McpToolTextResourceContent.builder()
                 .uri(URI.create("memory://forecast"))
                 .mediaType(MediaTypes.TEXT_PLAIN)
                 .text("sunny")
-                .metadata(Map.of("source", "resource"))
+                .metadata(McpParameters.create(Map.of("source", "resource")))
                 .build();
-        assertThat(resourceContent.metadata().orElseThrow(), is(Map.of("source", "resource")));
+        assertThat(resourceContent.metadata().orElseThrow().get("source").asString().orElseThrow(), is("resource"));
     }
 
     @Test
@@ -115,7 +112,7 @@ class McpSamplingToolsTest {
     @Test
     void rejectsNullParameterObject() {
         NullPointerException exception = assertThrows(NullPointerException.class,
-                                                      () -> new McpParameters((JsonObject) null));
+                                                      () -> McpParameters.create(null));
 
         assertThat(exception.getMessage(), is("value is null"));
     }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingToolsTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSamplingToolsTest.java
@@ -31,9 +31,9 @@ class McpSamplingToolsTest {
 
     @Test
     void constructsToolContent() {
-        McpParameters input = new McpParameters(JsonObject.builder()
-                                                         .set("city", "Prague")
-                                                         .build());
+        McpParameters input = McpParameters.create(JsonObject.builder()
+                                                          .set("city", "Prague")
+                                                          .build());
         McpSamplingToolUseContent toolUse = McpSamplingToolUseContent.builder()
                 .id("call-1")
                 .name("weather")
@@ -118,7 +118,7 @@ class McpSamplingToolsTest {
     @Test
     void rejectsNullParameterObject() {
         NullPointerException exception = assertThrows(NullPointerException.class,
-                                                      () -> new McpParameters((JsonObject) null));
+                                                      () -> McpParameters.create(null));
 
         assertThat(exception.getMessage(), is("value is null"));
     }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSessionTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSessionTest.java
@@ -16,6 +16,7 @@
 package io.helidon.extensions.mcp.server;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.common.context.Context;
@@ -172,23 +173,23 @@ class McpSessionTest {
                                             mock(McpTransportManager.class),
                                             config,
                                             "test-session");
-        JsonObject malformedResponse = JsonObject.builder()
+        McpResponse malformedResponse = new McpResponseImpl(JsonObject.builder()
                 .set("id", "not-a-number")
-                .build();
-        JsonObject expectedResponse = JsonObject.builder()
+                .build(), Context.create());
+        McpResponse expectedResponse = new McpResponseImpl(JsonObject.builder()
                 .set("id", 42)
-                .build();
+                .build(), Context.create());
 
         session.prepareResponse(42);
         session.acceptResponse(malformedResponse);
         session.acceptResponse(expectedResponse);
 
-        JsonObject response = pollResponse(session, 42, Duration.ofSeconds(1));
-        assertThat(response, is(expectedResponse));
+        McpResponse response = pollResponse(session, 42, Duration.ofSeconds(1)).orElseThrow();
+        assertThat(response, sameInstance(expectedResponse));
     }
 
     @Test
-    void correlatesOutOfOrderResponsesByRequestId() {
+    void correlatesOutOfOrderResponsesAndContextsByRequestId() {
         McpServerConfig config = McpServerFeature.builder()
                 .maxRequestsPerSession(2)
                 .buildPrototype();
@@ -197,14 +198,22 @@ class McpSessionTest {
         long secondId = session.jsonRpcId();
         session.prepareResponse(firstId);
         session.prepareResponse(secondId);
-        JsonObject firstResponse = JsonObject.builder().set("id", firstId).build();
-        JsonObject secondResponse = JsonObject.builder().set("id", secondId).build();
+        JsonObject firstJson = JsonObject.builder().set("id", firstId).build();
+        JsonObject secondJson = JsonObject.builder().set("id", secondId).build();
+        Context firstContext = Context.create();
+        Context secondContext = Context.create();
+        McpResponse firstResponse = new McpResponseImpl(firstJson, firstContext);
+        McpResponse secondResponse = new McpResponseImpl(secondJson, secondContext);
 
         session.acceptResponse(secondResponse);
         session.acceptResponse(firstResponse);
 
-        assertThat(pollResponse(session, firstId, Duration.ofSeconds(1)), sameInstance(firstResponse));
-        assertThat(pollResponse(session, secondId, Duration.ofSeconds(1)), sameInstance(secondResponse));
+        McpResponse polledFirst = pollResponse(session, firstId, Duration.ofSeconds(1)).orElseThrow();
+        McpResponse polledSecond = pollResponse(session, secondId, Duration.ofSeconds(1)).orElseThrow();
+        assertThat(polledFirst.asJsonObject(), sameInstance(firstJson));
+        assertThat(polledFirst.requestContext(), sameInstance(firstContext));
+        assertThat(polledSecond.asJsonObject(), sameInstance(secondJson));
+        assertThat(polledSecond.requestContext(), sameInstance(secondContext));
     }
 
     @Test
@@ -223,18 +232,21 @@ class McpSessionTest {
                                                        () -> session.prepareResponse(thirdId));
 
         assertThat(exception.getMessage(), is("Maximum pending response count reached"));
-        JsonObject firstResponse = JsonObject.builder().set("id", firstId).build();
-        JsonObject secondResponse = JsonObject.builder().set("id", secondId).build();
-        JsonObject thirdResponse = JsonObject.builder().set("id", thirdId).build();
+        JsonObject firstJson = JsonObject.builder().set("id", firstId).build();
+        JsonObject secondJson = JsonObject.builder().set("id", secondId).build();
+        JsonObject thirdJson = JsonObject.builder().set("id", thirdId).build();
+        McpResponse firstResponse = new McpResponseImpl(firstJson, Context.create());
+        McpResponse secondResponse = new McpResponseImpl(secondJson, Context.create());
+        McpResponse thirdResponse = new McpResponseImpl(thirdJson, Context.create());
         session.acceptResponse(secondResponse);
         session.acceptResponse(firstResponse);
-        assertThat(pollResponse(session, firstId, Duration.ofSeconds(1)), sameInstance(firstResponse));
+        assertThat(pollResponse(session, firstId, Duration.ofSeconds(1)).orElseThrow(), sameInstance(firstResponse));
 
         session.prepareResponse(thirdId);
         session.acceptResponse(thirdResponse);
 
-        assertThat(pollResponse(session, secondId, Duration.ofSeconds(1)), sameInstance(secondResponse));
-        assertThat(pollResponse(session, thirdId, Duration.ofSeconds(1)), sameInstance(thirdResponse));
+        assertThat(pollResponse(session, secondId, Duration.ofSeconds(1)).orElseThrow(), sameInstance(secondResponse));
+        assertThat(pollResponse(session, thirdId, Duration.ofSeconds(1)).orElseThrow(), sameInstance(thirdResponse));
     }
 
     @Test
@@ -266,20 +278,20 @@ class McpSessionTest {
     }
 
     @Test
-    void ignoresResponseWithoutPendingRequest() {
+    void ignoresResponseReceivedBeforeRequestIsPrepared() {
         McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, "{}");
         JsonObject unsolicited = JsonObject.builder().set("id", 0).build();
-        session.acceptResponse(unsolicited);
+        session.acceptResponse(new McpResponseImpl(unsolicited, Context.create()));
         long requestId = session.jsonRpcId();
         session.prepareResponse(requestId);
 
-        JsonObject response = pollResponse(session, requestId, Duration.ZERO);
+        Optional<McpResponse> response = pollResponse(session, requestId, Duration.ZERO);
 
-        assertThat(response.objectValue("error").isPresent(), is(true));
+        assertThat(response.isEmpty(), is(true));
     }
 
     @Test
-    void preservesRequestContextUntilResponseIsSent() {
+    void preservesFeaturesUntilResponseIsSent() {
         McpServerConfig config = McpServerConfig.create();
         McpTransportManager manager = mock(McpTransportManager.class);
         McpSession session = new McpSession(new McpSessions(config.maxSessionCount()),
@@ -289,20 +301,18 @@ class McpSessionTest {
         JsonRpcRequest request = mock(JsonRpcRequest.class);
         JsonRpcResponse response = mock(JsonRpcResponse.class);
         McpTransport transport = mock(McpStreamableHttpTransport.class);
-        Context requestContext = Context.create();
         JsonValue requestId = JsonObject.builder().set("id", 1).build().value("id").orElseThrow();
-        when(request.context()).thenReturn(requestContext);
         when(manager.create(request, response)).thenReturn(transport);
         session.createTransport(requestId, request, response);
 
-        McpFeatures features = session.createFeatures(requestId, request, response);
+        McpFeatures features = session.createFeatures(requestId);
 
-        assertThat(features.requestContext(), sameInstance(requestContext));
+        assertThat(session.findFeatures(requestId).orElseThrow(), sameInstance(features));
         session.send(requestId, response);
         assertThat(session.findFeatures(requestId).isEmpty(), is(true));
     }
 
-    private static JsonObject pollResponse(McpSession session, long requestId, Duration timeout) {
+    private static Optional<McpResponse> pollResponse(McpSession session, long requestId, Duration timeout) {
         try {
             return session.pollResponse(requestId, timeout);
         } finally {

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSessionTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSessionTest.java
@@ -183,7 +183,7 @@ class McpSessionTest {
         session.acceptResponse(malformedResponse);
         session.acceptResponse(expectedResponse);
 
-        JsonObject response = session.pollResponse(42, Duration.ofSeconds(1));
+        JsonObject response = pollResponse(session, 42, Duration.ofSeconds(1));
         assertThat(response, is(expectedResponse));
     }
 
@@ -203,8 +203,8 @@ class McpSessionTest {
         session.acceptResponse(secondResponse);
         session.acceptResponse(firstResponse);
 
-        assertThat(session.pollResponse(firstId, Duration.ofSeconds(1)), sameInstance(firstResponse));
-        assertThat(session.pollResponse(secondId, Duration.ofSeconds(1)), sameInstance(secondResponse));
+        assertThat(pollResponse(session, firstId, Duration.ofSeconds(1)), sameInstance(firstResponse));
+        assertThat(pollResponse(session, secondId, Duration.ofSeconds(1)), sameInstance(secondResponse));
     }
 
     @Test
@@ -228,13 +228,13 @@ class McpSessionTest {
         JsonObject thirdResponse = JsonObject.builder().set("id", thirdId).build();
         session.acceptResponse(secondResponse);
         session.acceptResponse(firstResponse);
-        assertThat(session.pollResponse(firstId, Duration.ofSeconds(1)), sameInstance(firstResponse));
+        assertThat(pollResponse(session, firstId, Duration.ofSeconds(1)), sameInstance(firstResponse));
 
         session.prepareResponse(thirdId);
         session.acceptResponse(thirdResponse);
 
-        assertThat(session.pollResponse(secondId, Duration.ofSeconds(1)), sameInstance(secondResponse));
-        assertThat(session.pollResponse(thirdId, Duration.ofSeconds(1)), sameInstance(thirdResponse));
+        assertThat(pollResponse(session, secondId, Duration.ofSeconds(1)), sameInstance(secondResponse));
+        assertThat(pollResponse(session, thirdId, Duration.ofSeconds(1)), sameInstance(thirdResponse));
     }
 
     @Test
@@ -245,7 +245,7 @@ class McpSessionTest {
         AtomicReference<Throwable> failure = new AtomicReference<>();
         Thread poller = Thread.ofVirtual().start(() -> {
             try {
-                session.pollResponse(requestId, Duration.ofSeconds(5));
+                pollResponse(session, requestId, Duration.ofSeconds(5));
             } catch (Throwable e) {
                 failure.set(e);
             }
@@ -273,7 +273,7 @@ class McpSessionTest {
         long requestId = session.jsonRpcId();
         session.prepareResponse(requestId);
 
-        JsonObject response = session.pollResponse(requestId, Duration.ZERO);
+        JsonObject response = pollResponse(session, requestId, Duration.ZERO);
 
         assertThat(response.objectValue("error").isPresent(), is(true));
     }
@@ -300,6 +300,14 @@ class McpSessionTest {
         assertThat(features.requestContext(), sameInstance(requestContext));
         session.send(requestId, response);
         assertThat(session.findFeatures(requestId).isEmpty(), is(true));
+    }
+
+    private static JsonObject pollResponse(McpSession session, long requestId, Duration timeout) {
+        try {
+            return session.pollResponse(requestId, timeout);
+        } finally {
+            session.discardResponse(requestId);
+        }
     }
 
     private static McpSession session(McpProtocolVersion protocolVersion, String capabilities) {

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSessionTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSessionTest.java
@@ -16,20 +16,31 @@
 package io.helidon.extensions.mcp.server;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
 
+import io.helidon.common.context.Context;
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonParser;
+import io.helidon.json.JsonValue;
 import io.helidon.jsonrpc.core.JsonRpcParams;
+import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.jsonrpc.JsonRpcRequest;
 import io.helidon.webserver.jsonrpc.JsonRpcResponse;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class McpSessionTest {
 
@@ -102,11 +113,29 @@ class McpSessionTest {
         McpSession samplingContext = session(McpProtocolVersion.VERSION_2025_11_25, """
                 {"sampling": {"context": {}}}
                 """);
+        McpSession samplingTools = session(McpProtocolVersion.VERSION_2025_11_25, """
+                {"sampling": {"tools": {}}}
+                """);
 
         assertThat(sampling.capabilities().contains(McpCapability.SAMPLING), is(true));
         assertThat(sampling.capabilities().contains(McpCapability.SAMPLING_CONTEXT), is(false));
+        assertThat(sampling.capabilities().contains(McpCapability.SAMPLING_TOOLS), is(false));
         assertThat(samplingContext.capabilities().contains(McpCapability.SAMPLING), is(true));
         assertThat(samplingContext.capabilities().contains(McpCapability.SAMPLING_CONTEXT), is(true));
+        assertThat(samplingTools.capabilities().contains(McpCapability.SAMPLING), is(true));
+        assertThat(samplingTools.capabilities().contains(McpCapability.SAMPLING_TOOLS), is(true));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = McpProtocolVersion.class,
+                names = {"VERSION_2024_11_05", "VERSION_2025_03_26", "VERSION_2025_06_18"})
+    void ignoresSamplingToolsCapabilityForLegacyProtocolVersions(McpProtocolVersion protocolVersion) {
+        McpSession session = session(protocolVersion, """
+                {"sampling": {"tools": {}}}
+                """);
+
+        assertThat(session.capabilities().contains(McpCapability.SAMPLING), is(true));
+        assertThat(session.capabilities().contains(McpCapability.SAMPLING_TOOLS), is(false));
     }
 
     @ParameterizedTest
@@ -150,6 +179,7 @@ class McpSessionTest {
                 .set("id", 42)
                 .build();
 
+        session.prepareResponse(42);
         session.acceptResponse(malformedResponse);
         session.acceptResponse(expectedResponse);
 
@@ -157,8 +187,129 @@ class McpSessionTest {
         assertThat(response, is(expectedResponse));
     }
 
+    @Test
+    void correlatesOutOfOrderResponsesByRequestId() {
+        McpServerConfig config = McpServerFeature.builder()
+                .maxRequestsPerSession(2)
+                .buildPrototype();
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, "{}", config);
+        long firstId = session.jsonRpcId();
+        long secondId = session.jsonRpcId();
+        session.prepareResponse(firstId);
+        session.prepareResponse(secondId);
+        JsonObject firstResponse = JsonObject.builder().set("id", firstId).build();
+        JsonObject secondResponse = JsonObject.builder().set("id", secondId).build();
+
+        session.acceptResponse(secondResponse);
+        session.acceptResponse(firstResponse);
+
+        assertThat(session.pollResponse(firstId, Duration.ofSeconds(1)), sameInstance(firstResponse));
+        assertThat(session.pollResponse(secondId, Duration.ofSeconds(1)), sameInstance(secondResponse));
+    }
+
+    @Test
+    void rejectsPendingResponseBeyondCapacityWithoutEviction() {
+        McpServerConfig config = McpServerFeature.builder()
+                .maxRequestsPerSession(2)
+                .buildPrototype();
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, "{}", config);
+        long firstId = session.jsonRpcId();
+        long secondId = session.jsonRpcId();
+        long thirdId = session.jsonRpcId();
+        session.prepareResponse(firstId);
+        session.prepareResponse(secondId);
+
+        McpInternalException exception = assertThrows(McpInternalException.class,
+                                                       () -> session.prepareResponse(thirdId));
+
+        assertThat(exception.getMessage(), is("Maximum pending response count reached"));
+        JsonObject firstResponse = JsonObject.builder().set("id", firstId).build();
+        JsonObject secondResponse = JsonObject.builder().set("id", secondId).build();
+        JsonObject thirdResponse = JsonObject.builder().set("id", thirdId).build();
+        session.acceptResponse(secondResponse);
+        session.acceptResponse(firstResponse);
+        assertThat(session.pollResponse(firstId, Duration.ofSeconds(1)), sameInstance(firstResponse));
+
+        session.prepareResponse(thirdId);
+        session.acceptResponse(thirdResponse);
+
+        assertThat(session.pollResponse(secondId, Duration.ofSeconds(1)), sameInstance(secondResponse));
+        assertThat(session.pollResponse(thirdId, Duration.ofSeconds(1)), sameInstance(thirdResponse));
+    }
+
+    @Test
+    void disconnectUnblocksPendingResponse() throws InterruptedException {
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, "{}");
+        long requestId = session.jsonRpcId();
+        session.prepareResponse(requestId);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        Thread poller = Thread.ofVirtual().start(() -> {
+            try {
+                session.pollResponse(requestId, Duration.ofSeconds(5));
+            } catch (Throwable e) {
+                failure.set(e);
+            }
+        });
+        assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
+            while (poller.getState() != Thread.State.WAITING
+                    && poller.getState() != Thread.State.TIMED_WAITING) {
+                Thread.onSpinWait();
+            }
+        });
+
+        session.onDisconnect(mock(ServerResponse.class));
+        poller.join(1000);
+
+        assertThat(poller.isAlive(), is(false));
+        assertThat(failure.get(), instanceOf(McpInternalException.class));
+        assertThat(failure.get().getMessage(), is("Session disconnected"));
+    }
+
+    @Test
+    void ignoresResponseWithoutPendingRequest() {
+        McpSession session = session(McpProtocolVersion.VERSION_2025_11_25, "{}");
+        JsonObject unsolicited = JsonObject.builder().set("id", 0).build();
+        session.acceptResponse(unsolicited);
+        long requestId = session.jsonRpcId();
+        session.prepareResponse(requestId);
+
+        JsonObject response = session.pollResponse(requestId, Duration.ZERO);
+
+        assertThat(response.objectValue("error").isPresent(), is(true));
+    }
+
+    @Test
+    void preservesRequestContextUntilResponseIsSent() {
+        McpServerConfig config = McpServerConfig.create();
+        McpTransportManager manager = mock(McpTransportManager.class);
+        McpSession session = new McpSession(new McpSessions(config.maxSessionCount()),
+                                            manager,
+                                            config,
+                                            "test-session");
+        JsonRpcRequest request = mock(JsonRpcRequest.class);
+        JsonRpcResponse response = mock(JsonRpcResponse.class);
+        McpTransport transport = mock(McpStreamableHttpTransport.class);
+        Context requestContext = Context.create();
+        JsonValue requestId = JsonObject.builder().set("id", 1).build().value("id").orElseThrow();
+        when(request.context()).thenReturn(requestContext);
+        when(manager.create(request, response)).thenReturn(transport);
+        session.createTransport(requestId, request, response);
+
+        McpFeatures features = session.createFeatures(requestId, request, response);
+
+        assertThat(features.requestContext(), sameInstance(requestContext));
+        session.send(requestId, response);
+        assertThat(session.findFeatures(requestId).isEmpty(), is(true));
+    }
+
     private static McpSession session(McpProtocolVersion protocolVersion, String capabilities) {
         McpServerConfig config = McpServerConfig.create();
+        return session(protocolVersion, capabilities, config);
+    }
+
+    private static McpSession session(McpProtocolVersion protocolVersion,
+                                      String capabilities,
+                                      McpServerConfig config) {
         McpSessions sessions = new McpSessions(config.maxSessionCount());
         McpSession session = new McpSession(sessions,
                                             mock(McpTransportManager.class),

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpSessionTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpSessionTest.java
@@ -166,29 +166,6 @@ class McpSessionTest {
     }
 
     @Test
-    void ignoresResponseWithNonNumericId() {
-        McpServerConfig config = McpServerConfig.create();
-        McpSessions sessions = new McpSessions(config.maxSessionCount());
-        McpSession session = new McpSession(sessions,
-                                            mock(McpTransportManager.class),
-                                            config,
-                                            "test-session");
-        McpResponse malformedResponse = new McpResponseImpl(JsonObject.builder()
-                .set("id", "not-a-number")
-                .build(), Context.create());
-        McpResponse expectedResponse = new McpResponseImpl(JsonObject.builder()
-                .set("id", 42)
-                .build(), Context.create());
-
-        session.prepareResponse(42);
-        session.acceptResponse(malformedResponse);
-        session.acceptResponse(expectedResponse);
-
-        McpResponse response = pollResponse(session, 42, Duration.ofSeconds(1)).orElseThrow();
-        assertThat(response, sameInstance(expectedResponse));
-    }
-
-    @Test
     void correlatesOutOfOrderResponsesAndContextsByRequestId() {
         McpServerConfig config = McpServerFeature.builder()
                 .maxRequestsPerSession(2)
@@ -210,8 +187,10 @@ class McpSessionTest {
 
         McpResponse polledFirst = pollResponse(session, firstId, Duration.ofSeconds(1)).orElseThrow();
         McpResponse polledSecond = pollResponse(session, secondId, Duration.ofSeconds(1)).orElseThrow();
+        assertThat(polledFirst.id(), is(firstId));
         assertThat(polledFirst.asJsonObject(), sameInstance(firstJson));
         assertThat(polledFirst.requestContext(), sameInstance(firstContext));
+        assertThat(polledSecond.id(), is(secondId));
         assertThat(polledSecond.asJsonObject(), sameInstance(secondJson));
         assertThat(polledSecond.requestContext(), sameInstance(secondContext));
     }

--- a/server/src/test/resources/application-server.yaml
+++ b/server/src/test/resources/application-server.yaml
@@ -28,5 +28,6 @@ mcp:
     subscription-timeout: "PT1S"
     root-list-timeout: "PT1S"
     instructions: "instructions"
+    max-sampling-tool-iterations: 3
     max-requests-per-session: 1
     max-session-count: 1

--- a/tests/2024-11-05/src/test/java/io/helidon/extensions/mcp/tests/McpSdkSseSamplingTest.java
+++ b/tests/2024-11-05/src/test/java/io/helidon/extensions/mcp/tests/McpSdkSseSamplingTest.java
@@ -31,15 +31,16 @@ import io.helidon.webserver.testing.junit5.SetUpRoute;
 
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import static io.modelcontextprotocol.spec.McpSchema.CreateMessageResult.StopReason.STOP_SEQUENCE;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ServerTest
 class McpSdkSseSamplingTest extends AbstractMcpSdkTest {
@@ -84,7 +85,6 @@ class McpSdkSseSamplingTest extends AbstractMcpSdkTest {
         assertThat(decode(image.data()), is(SAMPLING_CLIENT_TEXT));
         assertThat(image.mimeType(), is(MediaTypes.TEXT_PLAIN_VALUE));
 
-        var annotations = new McpSchema.Annotations(List.of(), 1.0);
         var result = new McpSchema.ImageContent(List.of(),
                                                 0.0,
                                                 encode(SAMPLING_CLIENT_TEXT),
@@ -123,10 +123,9 @@ class McpSdkSseSamplingTest extends AbstractMcpSdkTest {
         return Base64.getEncoder().encodeToString(data.getBytes(StandardCharsets.UTF_8));
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"image", "audio"})
-    void testContentTypeSamplingTool(String type) {
-        var request = new McpSchema.CallToolRequest("sampling-tool", Map.of("type", "text"));
+    @Test
+    void testImageContentTypeSamplingTool() {
+        var request = new McpSchema.CallToolRequest("sampling-tool", Map.of("type", "image"));
         var result = client().callTool(request);
         List<McpSchema.Content> contents = result.content();
         assertThat(contents.size(), is(1));
@@ -136,6 +135,15 @@ class McpSdkSseSamplingTest extends AbstractMcpSdkTest {
 
         McpSchema.TextContent textContent = (McpSchema.TextContent) content;
         assertThat(textContent.text(), is(SAMPLING_CLIENT_TEXT));
+    }
+
+    @Test
+    void rejectsAudioContentTypeSamplingTool() {
+        var request = new McpSchema.CallToolRequest("sampling-tool", Map.of("type", "audio"));
+
+        McpError exception = assertThrows(McpError.class, () -> client().callTool(request));
+
+        assertThat(exception.getMessage(), containsString("Wrong sampling message type"));
     }
 
     @Test

--- a/tests/2024-11-05/src/test/java/io/helidon/extensions/mcp/tests/McpSdkSseSamplingTest.java
+++ b/tests/2024-11-05/src/test/java/io/helidon/extensions/mcp/tests/McpSdkSseSamplingTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.extensions.mcp.tests;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +85,10 @@ class McpSdkSseSamplingTest extends AbstractMcpSdkTest {
         assertThat(image.mimeType(), is(MediaTypes.TEXT_PLAIN_VALUE));
 
         var annotations = new McpSchema.Annotations(List.of(), 1.0);
-        var result = new McpSchema.ImageContent(List.of(), 0.0, SAMPLING_CLIENT_TEXT, MediaTypes.TEXT_PLAIN_VALUE);
+        var result = new McpSchema.ImageContent(List.of(),
+                                                0.0,
+                                                encode(SAMPLING_CLIENT_TEXT),
+                                                MediaTypes.TEXT_PLAIN_VALUE);
         return new McpSchema.CreateMessageResult(McpSchema.Role.USER, result, "test-model", STOP_SEQUENCE);
     }
 
@@ -112,7 +116,11 @@ class McpSdkSseSamplingTest extends AbstractMcpSdkTest {
     }
 
     private String decode(String data) {
-        return new String(Base64.getDecoder().decode(data));
+        return new String(Base64.getDecoder().decode(data), StandardCharsets.UTF_8);
+    }
+
+    private String encode(String data) {
+        return Base64.getEncoder().encodeToString(data.getBytes(StandardCharsets.UTF_8));
     }
 
     @ParameterizedTest

--- a/tests/2025-03-26/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableSamplingTest.java
+++ b/tests/2025-03-26/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableSamplingTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.extensions.mcp.tests;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -85,7 +86,7 @@ class McpSdkStreamableSamplingTest extends AbstractMcpSdkTest {
         assertThat(audio.mimeType(), is(MediaTypes.TEXT_PLAIN_VALUE));
 
         var annotations = new McpSchema.Annotations(List.of(), 1.0);
-        var result = new McpSchema.AudioContent(annotations, SAMPLING_CLIENT_TEXT, MediaTypes.TEXT_PLAIN_VALUE);
+        var result = new McpSchema.AudioContent(annotations, encode(SAMPLING_CLIENT_TEXT), MediaTypes.TEXT_PLAIN_VALUE);
         return new McpSchema.CreateMessageResult(McpSchema.Role.USER,
                                                  result,
                                                  "test-model",
@@ -101,7 +102,7 @@ class McpSdkStreamableSamplingTest extends AbstractMcpSdkTest {
         assertThat(image.mimeType(), is(MediaTypes.TEXT_PLAIN_VALUE));
 
         var annotations = new McpSchema.Annotations(List.of(), 1.0);
-        var result = new McpSchema.ImageContent(annotations, SAMPLING_CLIENT_TEXT, MediaTypes.TEXT_PLAIN_VALUE);
+        var result = new McpSchema.ImageContent(annotations, encode(SAMPLING_CLIENT_TEXT), MediaTypes.TEXT_PLAIN_VALUE);
         return new McpSchema.CreateMessageResult(McpSchema.Role.USER, result, "test-model", STOP_SEQUENCE);
     }
 
@@ -129,7 +130,11 @@ class McpSdkStreamableSamplingTest extends AbstractMcpSdkTest {
     }
 
     private String decode(String data) {
-        return new String(Base64.getDecoder().decode(data));
+        return new String(Base64.getDecoder().decode(data), StandardCharsets.UTF_8);
+    }
+
+    private String encode(String data) {
+        return Base64.getEncoder().encodeToString(data.getBytes(StandardCharsets.UTF_8));
     }
 
     @ParameterizedTest

--- a/tests/2025-06-18/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableMetaTest.java
+++ b/tests/2025-06-18/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableMetaTest.java
@@ -67,6 +67,15 @@ class McpSdkStreamableMetaTest extends AbstractMcpSdkTest {
     }
 
     @Test
+    void testMissingMetaTool() {
+        McpSchema.CallToolResult result = client.callTool(McpSchema.CallToolRequest.builder()
+                                                                  .name("meta-tool")
+                                                                  .build());
+        McpSchema.TextContent text = (McpSchema.TextContent) result.content().getFirst();
+        assertThat(text.text(), is("Not found"));
+    }
+
+    @Test
     void testMetaPrompt() {
         McpSchema.GetPromptRequest request = new McpSchema.GetPromptRequest("meta-prompt", Map.of(), Map.of("foo", "bar"));
         McpSchema.GetPromptResult result = client.getPrompt(request);
@@ -89,6 +98,15 @@ class McpSdkStreamableMetaTest extends AbstractMcpSdkTest {
         assertThat(content, instanceOf(McpSchema.TextResourceContents.class));
 
         McpSchema.TextResourceContents text = (McpSchema.TextResourceContents) content;
+        assertThat(text.text(), is("bar"));
+    }
+
+    @Test
+    void testMetaResourceTemplate() {
+        McpSchema.ReadResourceRequest request = new McpSchema.ReadResourceRequest("https://template/test",
+                                                                                  Map.of("foo", "bar"));
+        McpSchema.ReadResourceResult result = client.readResource(request);
+        McpSchema.TextResourceContents text = (McpSchema.TextResourceContents) result.contents().getFirst();
         assertThat(text.text(), is("bar"));
     }
 

--- a/tests/2025-06-18/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableSamplingTest.java
+++ b/tests/2025-06-18/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableSamplingTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.extensions.mcp.tests;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -85,7 +86,7 @@ class McpSdkStreamableSamplingTest extends AbstractMcpSdkTest {
         assertThat(audio.mimeType(), is(MediaTypes.TEXT_PLAIN_VALUE));
 
         var annotations = new McpSchema.Annotations(List.of(), 1.0);
-        var result = new McpSchema.AudioContent(annotations, SAMPLING_CLIENT_TEXT, MediaTypes.TEXT_PLAIN_VALUE);
+        var result = new McpSchema.AudioContent(annotations, encode(SAMPLING_CLIENT_TEXT), MediaTypes.TEXT_PLAIN_VALUE);
         return new McpSchema.CreateMessageResult(McpSchema.Role.USER,
                                                  result,
                                                  "test-model",
@@ -101,7 +102,7 @@ class McpSdkStreamableSamplingTest extends AbstractMcpSdkTest {
         assertThat(image.mimeType(), is(MediaTypes.TEXT_PLAIN_VALUE));
 
         var annotations = new McpSchema.Annotations(List.of(), 1.0);
-        var result = new McpSchema.ImageContent(annotations, SAMPLING_CLIENT_TEXT, MediaTypes.TEXT_PLAIN_VALUE);
+        var result = new McpSchema.ImageContent(annotations, encode(SAMPLING_CLIENT_TEXT), MediaTypes.TEXT_PLAIN_VALUE);
         return new McpSchema.CreateMessageResult(McpSchema.Role.USER, result, "test-model", STOP_SEQUENCE);
     }
 
@@ -129,7 +130,11 @@ class McpSdkStreamableSamplingTest extends AbstractMcpSdkTest {
     }
 
     private String decode(String data) {
-        return new String(Base64.getDecoder().decode(data));
+        return new String(Base64.getDecoder().decode(data), StandardCharsets.UTF_8);
+    }
+
+    private String encode(String data) {
+        return Base64.getEncoder().encodeToString(data.getBytes(StandardCharsets.UTF_8));
     }
 
     @ParameterizedTest

--- a/tests/2025-11-25/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableSamplingToolsTest.java
+++ b/tests/2025-11-25/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableSamplingToolsTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
@@ -144,7 +145,7 @@ class McpSdkStreamableSamplingToolsTest {
         assertThat(tool.get("description"), is("Returns the supplied value."));
         Map<?, ?> inputSchema = asMap(tool.get("inputSchema"));
         assertThat(inputSchema.get("type"), is("object"));
-        assertThat(asMap(inputSchema.get("properties")).containsKey("value"), is(true));
+        assertThat(asMap(inputSchema.get("properties")), hasKey("value"));
         assertThat(inputSchema.get("required"), is(List.of("value")));
         assertThat(asMap(firstRequest.get("toolChoice")).get("mode"), is("required"));
 

--- a/tests/2025-11-25/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableSamplingToolsTest.java
+++ b/tests/2025-11-25/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableSamplingToolsTest.java
@@ -58,7 +58,9 @@ class McpSdkStreamableSamplingToolsTest {
                     "type", "tool_use",
                     "id", TOOL_USE_ID,
                     "name", SAMPLED_TOOL,
-                    "input", Map.of("value", TOOL_INPUT))),
+                    "input", Map.of("value", TOOL_INPUT),
+                    "_meta", Map.of("source", "client-content"))),
+            "_meta", Map.of("source", "client-message"),
             "model", "test-model",
             "stopReason", "toolUse");
     private static final Map<String, Object> FINAL_SAMPLING_RESPONSE = Map.of(
@@ -153,9 +155,11 @@ class McpSdkStreamableSamplingToolsTest {
         assertThat(firstMessages.size(), is(1));
         Map<?, ?> firstMessage = asMap(firstMessages.getFirst());
         assertThat(firstMessage.get("role"), is("user"));
+        assertThat(asMap(firstMessage.get("_meta")).get("source"), is("server-message"));
         Map<?, ?> firstContent = asMap(firstMessage.get("content"));
         assertThat(firstContent.get("type"), is("text"));
         assertThat(firstContent.get("text"), is("Use the sampled tool"));
+        assertThat(asMap(firstContent.get("_meta")).get("source"), is("server-content"));
 
         Map<String, Object> secondRequest = requests.get(1);
         assertThat(secondRequest.get("tools"), is(firstRequest.get("tools")));
@@ -165,11 +169,13 @@ class McpSdkStreamableSamplingToolsTest {
 
         Map<?, ?> toolUseMessage = asMap(messages.get(1));
         assertThat(toolUseMessage.get("role"), is("assistant"));
+        assertThat(asMap(toolUseMessage.get("_meta")).get("source"), is("client-message"));
         Map<?, ?> toolUse = asMap(toolUseMessage.get("content"));
         assertThat(toolUse.get("type"), is("tool_use"));
         assertThat(toolUse.get("id"), is(TOOL_USE_ID));
         assertThat(toolUse.get("name"), is(SAMPLED_TOOL));
         assertThat(asMap(toolUse.get("input")).get("value"), is(TOOL_INPUT));
+        assertThat(asMap(toolUse.get("_meta")).get("source"), is("client-content"));
 
         Map<?, ?> toolResultMessage = asMap(messages.get(2));
         assertThat(toolResultMessage.get("role"), is("user"));

--- a/tests/2025-11-25/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableSamplingToolsTest.java
+++ b/tests/2025-11-25/src/test/java/io/helidon/extensions/mcp/tests/McpSdkStreamableSamplingToolsTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.tests;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.extensions.mcp.tests.common.SamplingServer;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.spec.McpClientSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+@ServerTest
+class McpSdkStreamableSamplingToolsTest {
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(20);
+    private static final String PROTOCOL_VERSION = "2025-11-25";
+    private static final String SAMPLING_TOOL = "sampling-with-tools-tool";
+    private static final String SAMPLED_TOOL = "sampled-tool";
+    private static final String TOOL_USE_ID = "sampled-call-1";
+    private static final String TOOL_INPUT = "integration-value";
+    private static final String TOOL_RESULT = "sampled " + TOOL_INPUT;
+    private static final String FINAL_RESPONSE = "final sampling response";
+    private static final TypeRef<Map<String, Object>> MAP_TYPE = new TypeRef<>() {};
+    private static final TypeRef<McpSchema.InitializeResult> INITIALIZE_RESULT_TYPE = new TypeRef<>() {};
+    private static final TypeRef<McpSchema.CallToolResult> CALL_TOOL_RESULT_TYPE = new TypeRef<>() {};
+    private static final Map<String, Object> TOOL_USE_RESPONSE = Map.of(
+            "role", "assistant",
+            "content", List.of(Map.of(
+                    "type", "tool_use",
+                    "id", TOOL_USE_ID,
+                    "name", SAMPLED_TOOL,
+                    "input", Map.of("value", TOOL_INPUT))),
+            "model", "test-model",
+            "stopReason", "toolUse");
+    private static final Map<String, Object> FINAL_SAMPLING_RESPONSE = Map.of(
+            "role", "assistant",
+            "content", Map.of(
+                    "type", "text",
+                    "text", FINAL_RESPONSE),
+            "model", "test-model",
+            "stopReason", "endTurn");
+
+    private final int port;
+
+    McpSdkStreamableSamplingToolsTest(WebServer server) {
+        port = server.port();
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder builder) {
+        SamplingServer.setUpToolsRoute(builder);
+    }
+
+    @Test
+    void invokesSamplingToolAndReturnsFinalResponse() {
+        List<Map<String, Object>> samplingRequests = new CopyOnWriteArrayList<>();
+        AtomicInteger samplingRound = new AtomicInteger();
+        HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
+                .builder("http://localhost:" + port)
+                .endpoint("/")
+                .supportedProtocolVersions(List.of(PROTOCOL_VERSION))
+                .build();
+        McpClientSession.RequestHandler<Map<String, Object>> samplingHandler = params -> {
+            samplingRequests.add(transport.unmarshalFrom(params, MAP_TYPE));
+            return switch (samplingRound.getAndIncrement()) {
+                case 0 -> Mono.just(TOOL_USE_RESPONSE);
+                case 1 -> Mono.just(FINAL_SAMPLING_RESPONSE);
+                default -> Mono.error(new IllegalStateException("Unexpected sampling request"));
+            };
+        };
+        McpClientSession session = new McpClientSession(
+                REQUEST_TIMEOUT,
+                transport,
+                Map.of(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE, samplingHandler),
+                Map.of(),
+                connection -> connection);
+
+        try {
+            McpSchema.InitializeResult initializeResult = session.sendRequest(
+                    McpSchema.METHOD_INITIALIZE,
+                    Map.of("protocolVersion", PROTOCOL_VERSION,
+                           "capabilities", Map.of("sampling", Map.of("tools", Map.of())),
+                           "clientInfo", Map.of("name", "sampling-tools-test", "version", "1.0.0")),
+                    INITIALIZE_RESULT_TYPE)
+                    .block(REQUEST_TIMEOUT);
+            assertThat(initializeResult.protocolVersion(), is(PROTOCOL_VERSION));
+            session.sendNotification(McpSchema.METHOD_NOTIFICATION_INITIALIZED).block(REQUEST_TIMEOUT);
+
+            McpSchema.CallToolResult result = session.sendRequest(
+                    McpSchema.METHOD_TOOLS_CALL,
+                    new McpSchema.CallToolRequest(SAMPLING_TOOL, Map.of()),
+                    CALL_TOOL_RESULT_TYPE)
+                    .block(REQUEST_TIMEOUT);
+
+            assertThat(result.isError(), is(false));
+            assertThat(result.content().size(), is(1));
+            assertThat(result.content().getFirst(), instanceOf(McpSchema.TextContent.class));
+            assertThat(((McpSchema.TextContent) result.content().getFirst()).text(), is(FINAL_RESPONSE));
+        } finally {
+            session.closeGracefully()
+                    .then(transport.closeGracefully())
+                    .block(REQUEST_TIMEOUT);
+        }
+
+        assertSamplingRequests(samplingRequests);
+    }
+
+    private static void assertSamplingRequests(List<Map<String, Object>> requests) {
+        assertThat(requests.size(), is(2));
+
+        Map<String, Object> firstRequest = requests.getFirst();
+        List<?> tools = asList(firstRequest.get("tools"));
+        assertThat(tools.size(), is(1));
+        Map<?, ?> tool = asMap(tools.getFirst());
+        assertThat(tool.get("name"), is(SAMPLED_TOOL));
+        assertThat(tool.get("description"), is("Returns the supplied value."));
+        Map<?, ?> inputSchema = asMap(tool.get("inputSchema"));
+        assertThat(inputSchema.get("type"), is("object"));
+        assertThat(asMap(inputSchema.get("properties")).containsKey("value"), is(true));
+        assertThat(inputSchema.get("required"), is(List.of("value")));
+        assertThat(asMap(firstRequest.get("toolChoice")).get("mode"), is("required"));
+
+        List<?> firstMessages = asList(firstRequest.get("messages"));
+        assertThat(firstMessages.size(), is(1));
+        Map<?, ?> firstMessage = asMap(firstMessages.getFirst());
+        assertThat(firstMessage.get("role"), is("user"));
+        Map<?, ?> firstContent = asMap(firstMessage.get("content"));
+        assertThat(firstContent.get("type"), is("text"));
+        assertThat(firstContent.get("text"), is("Use the sampled tool"));
+
+        Map<String, Object> secondRequest = requests.get(1);
+        assertThat(secondRequest.get("tools"), is(firstRequest.get("tools")));
+        assertThat(asMap(secondRequest.get("toolChoice")).get("mode"), is("auto"));
+        List<?> messages = asList(secondRequest.get("messages"));
+        assertThat(messages.size(), is(3));
+
+        Map<?, ?> toolUseMessage = asMap(messages.get(1));
+        assertThat(toolUseMessage.get("role"), is("assistant"));
+        Map<?, ?> toolUse = asMap(toolUseMessage.get("content"));
+        assertThat(toolUse.get("type"), is("tool_use"));
+        assertThat(toolUse.get("id"), is(TOOL_USE_ID));
+        assertThat(toolUse.get("name"), is(SAMPLED_TOOL));
+        assertThat(asMap(toolUse.get("input")).get("value"), is(TOOL_INPUT));
+
+        Map<?, ?> toolResultMessage = asMap(messages.get(2));
+        assertThat(toolResultMessage.get("role"), is("user"));
+        Map<?, ?> toolResult = asMap(toolResultMessage.get("content"));
+        assertThat(toolResult.get("type"), is("tool_result"));
+        assertThat(toolResult.get("toolUseId"), is(TOOL_USE_ID));
+        assertThat(toolResult.get("isError"), is(false));
+        List<?> resultContent = asList(toolResult.get("content"));
+        assertThat(resultContent.size(), is(1));
+        Map<?, ?> text = asMap(resultContent.getFirst());
+        assertThat(text.get("type"), is("text"));
+        assertThat(text.get("text"), is(TOOL_RESULT));
+    }
+
+    private static Map<?, ?> asMap(Object value) {
+        assertThat(value, instanceOf(Map.class));
+        return (Map<?, ?>) value;
+    }
+
+    private static List<?> asList(Object value) {
+        assertThat(value, instanceOf(List.class));
+        return (List<?>) value;
+    }
+}

--- a/tests/common/src/main/java/io/helidon/extensions/mcp/tests/common/MetaServer.java
+++ b/tests/common/src/main/java/io/helidon/extensions/mcp/tests/common/MetaServer.java
@@ -43,7 +43,9 @@ public class MetaServer {
                                            .description("Meta Tool")
                                            .schema("")
                                            .tool(request -> {
-                                               String meta = request.meta().get("foo").asString().orElse("Not found");
+                                               String meta = request.metadata()
+                                                       .map(metadata -> metadata.get("foo").asString().orElse("Not found"))
+                                                       .orElse("Not found");
                                                return McpToolResult.builder()
                                                        .addTextContent(meta)
                                                        .build();
@@ -52,7 +54,9 @@ public class MetaServer {
                                    .addPrompt(prompt -> prompt.name("meta-prompt")
                                            .description("Meta Prompt")
                                            .prompt(request -> {
-                                               String meta = request.meta().get("foo").asString().orElse("Not found");
+                                               String meta = request.metadata()
+                                                       .map(metadata -> metadata.get("foo").asString().orElse("Not found"))
+                                                       .orElse("Not found");
                                                return McpPromptResult.builder()
                                                        .addTextContent(meta)
                                                        .build();
@@ -63,7 +67,22 @@ public class MetaServer {
                                            .name("meta-resource")
                                            .mediaType(MediaTypes.TEXT_PLAIN)
                                            .resource(request -> {
-                                               String meta = request.meta().get("foo").asString().orElse("Not found");
+                                               String meta = request.metadata()
+                                                       .map(metadata -> metadata.get("foo").asString().orElse("Not found"))
+                                                       .orElse("Not found");
+                                               return McpResourceResult.builder()
+                                                       .addTextContent(meta)
+                                                       .build();
+                                           }))
+
+                                   .addResource(resource -> resource.uri("https://template/{name}")
+                                           .description("Meta Resource Template")
+                                           .name("meta-resource-template")
+                                           .mediaType(MediaTypes.TEXT_PLAIN)
+                                           .resource(request -> {
+                                               String meta = request.metadata()
+                                                       .map(metadata -> metadata.get("foo").asString().orElse("Not found"))
+                                                       .orElse("Not found");
                                                return McpResourceResult.builder()
                                                        .addTextContent(meta)
                                                        .build();
@@ -71,7 +90,9 @@ public class MetaServer {
 
                                    .addCompletion(completion -> completion.reference("meta-completion")
                                            .completion(request -> {
-                                               String meta = request.meta().get("foo").asString().orElse("Not found");
+                                               String meta = request.metadata()
+                                                       .map(metadata -> metadata.get("foo").asString().orElse("Not found"))
+                                                       .orElse("Not found");
                                                return McpCompletionResult.builder()
                                                        .addValue(meta)
                                                        .build();

--- a/tests/common/src/main/java/io/helidon/extensions/mcp/tests/common/MetaServer.java
+++ b/tests/common/src/main/java/io/helidon/extensions/mcp/tests/common/MetaServer.java
@@ -18,9 +18,11 @@ package io.helidon.extensions.mcp.tests.common;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.extensions.mcp.server.McpCompletionResult;
 import io.helidon.extensions.mcp.server.McpPromptResult;
+import io.helidon.extensions.mcp.server.McpRequest;
 import io.helidon.extensions.mcp.server.McpResourceResult;
 import io.helidon.extensions.mcp.server.McpServerFeature;
 import io.helidon.extensions.mcp.server.McpToolResult;
+import io.helidon.json.JsonObject;
 import io.helidon.webserver.http.HttpRouting;
 
 /**
@@ -30,7 +32,6 @@ public class MetaServer {
     private MetaServer() {
     }
 
-    // Returns the "foo" key from "_meta" object sent by client
     /**
      * Setup webserver routing.
      *
@@ -43,9 +44,7 @@ public class MetaServer {
                                            .description("Meta Tool")
                                            .schema("")
                                            .tool(request -> {
-                                               String meta = request.metadata()
-                                                       .map(metadata -> metadata.get("foo").asString().orElse("Not found"))
-                                                       .orElse("Not found");
+                                               String meta = metadata(request);
                                                return McpToolResult.builder()
                                                        .addTextContent(meta)
                                                        .build();
@@ -54,9 +53,7 @@ public class MetaServer {
                                    .addPrompt(prompt -> prompt.name("meta-prompt")
                                            .description("Meta Prompt")
                                            .prompt(request -> {
-                                               String meta = request.metadata()
-                                                       .map(metadata -> metadata.get("foo").asString().orElse("Not found"))
-                                                       .orElse("Not found");
+                                               String meta = metadata(request);
                                                return McpPromptResult.builder()
                                                        .addTextContent(meta)
                                                        .build();
@@ -67,9 +64,7 @@ public class MetaServer {
                                            .name("meta-resource")
                                            .mediaType(MediaTypes.TEXT_PLAIN)
                                            .resource(request -> {
-                                               String meta = request.metadata()
-                                                       .map(metadata -> metadata.get("foo").asString().orElse("Not found"))
-                                                       .orElse("Not found");
+                                               String meta = metadata(request);
                                                return McpResourceResult.builder()
                                                        .addTextContent(meta)
                                                        .build();
@@ -80,9 +75,7 @@ public class MetaServer {
                                            .name("meta-resource-template")
                                            .mediaType(MediaTypes.TEXT_PLAIN)
                                            .resource(request -> {
-                                               String meta = request.metadata()
-                                                       .map(metadata -> metadata.get("foo").asString().orElse("Not found"))
-                                                       .orElse("Not found");
+                                               String meta = metadata(request);
                                                return McpResourceResult.builder()
                                                        .addTextContent(meta)
                                                        .build();
@@ -90,12 +83,18 @@ public class MetaServer {
 
                                    .addCompletion(completion -> completion.reference("meta-completion")
                                            .completion(request -> {
-                                               String meta = request.metadata()
-                                                       .map(metadata -> metadata.get("foo").asString().orElse("Not found"))
-                                                       .orElse("Not found");
+                                               String meta = metadata(request);
                                                return McpCompletionResult.builder()
                                                        .addValue(meta)
                                                        .build();
                                            })));
+    }
+
+    private static String metadata(McpRequest request) {
+        Object value = request.metadata().orElseGet(JsonObject::empty);
+        if (value instanceof JsonObject metadata) {
+            return metadata.stringValue("foo").orElse("Not found");
+        }
+        return "Not found";
     }
 }

--- a/tests/common/src/main/java/io/helidon/extensions/mcp/tests/common/MetaServer.java
+++ b/tests/common/src/main/java/io/helidon/extensions/mcp/tests/common/MetaServer.java
@@ -22,7 +22,6 @@ import io.helidon.extensions.mcp.server.McpRequest;
 import io.helidon.extensions.mcp.server.McpResourceResult;
 import io.helidon.extensions.mcp.server.McpServerFeature;
 import io.helidon.extensions.mcp.server.McpToolResult;
-import io.helidon.json.JsonObject;
 import io.helidon.webserver.http.HttpRouting;
 
 /**
@@ -91,10 +90,9 @@ public class MetaServer {
     }
 
     private static String metadata(McpRequest request) {
-        Object value = request.metadata().orElseGet(JsonObject::empty);
-        if (value instanceof JsonObject metadata) {
-            return metadata.stringValue("foo").orElse("Not found");
+        if (request.metadata().isEmpty()) {
+            return "Not found";
         }
-        return "Not found";
+        return request.metadata().orElseThrow().get("foo").asString().orElse("Not found");
     }
 }

--- a/tests/common/src/main/java/io/helidon/extensions/mcp/tests/common/SamplingServer.java
+++ b/tests/common/src/main/java/io/helidon/extensions/mcp/tests/common/SamplingServer.java
@@ -23,11 +23,16 @@ import io.helidon.common.media.type.MediaTypes;
 import io.helidon.extensions.mcp.server.McpContentType;
 import io.helidon.extensions.mcp.server.McpException;
 import io.helidon.extensions.mcp.server.McpSampling;
+import io.helidon.extensions.mcp.server.McpSamplingAudioContent;
 import io.helidon.extensions.mcp.server.McpSamplingException;
+import io.helidon.extensions.mcp.server.McpSamplingImageContent;
+import io.helidon.extensions.mcp.server.McpSamplingMessage;
 import io.helidon.extensions.mcp.server.McpSamplingRequest;
 import io.helidon.extensions.mcp.server.McpSamplingResponse;
+import io.helidon.extensions.mcp.server.McpSamplingTextContent;
 import io.helidon.extensions.mcp.server.McpServerFeature;
 import io.helidon.extensions.mcp.server.McpTool;
+import io.helidon.extensions.mcp.server.McpToolChoice;
 import io.helidon.extensions.mcp.server.McpToolRequest;
 import io.helidon.extensions.mcp.server.McpToolResult;
 import io.helidon.json.schema.Schema;
@@ -56,6 +61,18 @@ public class SamplingServer {
                                    .addTool(new TimeoutSamplingTool())
                                    .addTool(new MultipleSamplingRequestTool())
         );
+    }
+
+    /**
+     * Setup a webserver route for sampling with tools.
+     *
+     * @param builder routing builder
+     */
+    public static void setUpToolsRoute(HttpRouting.Builder builder) {
+        builder.addFeature(McpServerFeature.builder()
+                                   .path("/")
+                                   .addTool(new SamplingWithToolsTool())
+                                   .addTool(new SampledTool()));
     }
 
     private static class SamplingTool implements McpTool {
@@ -96,29 +113,41 @@ public class SamplingServer {
 
             McpSamplingRequest message = createMessage(requestType.get());
             McpSamplingResponse response = sampling.request(message);
-            var type = response.message().type();
+            var content = response.message().contents().getFirst();
+            var type = content.type();
             var result = McpToolResult.builder();
             return switch (type) {
-                case TEXT -> result.addTextContent(response.asTextMessage().text()).build();
-                case IMAGE -> result.addTextContent(new String(response.asImageMessage().data())).build();
-                case AUDIO -> result.addTextContent(new String(response.asAudioMessage().data())).build();
+                case TEXT -> result.addTextContent(((McpSamplingTextContent) content).text()).build();
+                case IMAGE -> result.addTextContent(new String(((McpSamplingImageContent) content).data(),
+                                                               StandardCharsets.UTF_8)).build();
+                case AUDIO -> result.addTextContent(new String(((McpSamplingAudioContent) content).data(),
+                                                               StandardCharsets.UTF_8)).build();
+                case TOOL_USE, TOOL_RESULT -> throw new McpException("Unsupported sampling response type: " + type);
             };
         }
 
         McpSamplingRequest createMessage(McpContentType type) {
             return switch (type) {
                 case TEXT -> McpSamplingRequest.builder()
-                        .addTextMessage(message -> message.text("samplingMessage").role(USER))
+                        .addTextMessage(USER, "samplingMessage")
                         .build();
                 case IMAGE -> McpSamplingRequest.builder()
-                        .addImageMessage(message -> message.data("samplingMessage".getBytes(StandardCharsets.UTF_8))
-                                .mediaType(MediaTypes.TEXT_PLAIN)
-                                .role(USER))
+                        .addMessage(McpSamplingMessage.builder()
+                                            .role(USER)
+                                            .addContent(McpSamplingImageContent.builder()
+                                                                .data("samplingMessage".getBytes(StandardCharsets.UTF_8))
+                                                                .mediaType(MediaTypes.TEXT_PLAIN)
+                                                                .build())
+                                            .build())
                         .build();
                 case AUDIO -> McpSamplingRequest.builder()
-                        .addAudioMessage(message -> message.data("samplingMessage".getBytes(StandardCharsets.UTF_8))
-                                .mediaType(MediaTypes.TEXT_PLAIN)
-                                .role(USER))
+                        .addMessage(McpSamplingMessage.builder()
+                                            .role(USER)
+                                            .addContent(McpSamplingAudioContent.builder()
+                                                                .data("samplingMessage".getBytes(StandardCharsets.UTF_8))
+                                                                .mediaType(MediaTypes.TEXT_PLAIN)
+                                                                .build())
+                                            .build())
                         .build();
                 default -> throw new McpException("Unsupported sampling message type: " + type);
             };
@@ -153,7 +182,7 @@ public class SamplingServer {
         @Override
         public McpToolResult tool(McpToolRequest request) {
             McpSampling sampling = request.features().sampling();
-            var response = sampling.request(req -> req.addTextMessage(message -> message.text("ignored").role(USER)));
+            var response = sampling.request(req -> req.addTextMessage(USER, "ignored"));
             return sampling(request);
         }
     }
@@ -170,7 +199,7 @@ public class SamplingServer {
                 request.features()
                         .sampling()
                         .request(req -> req.timeout(Duration.ofSeconds(2))
-                                .addTextMessage(message -> message.text("timeout").role(USER)));
+                                .addTextMessage(USER, "timeout"));
                 throw new McpException("Timeout should have been triggered");
             } catch (McpSamplingException e) {
                 return McpToolResult.builder()
@@ -192,7 +221,7 @@ public class SamplingServer {
             try {
                 request.features()
                         .sampling()
-                        .request(req -> req.addTextMessage(message -> message.text("error").role(USER)));
+                        .request(req -> req.addTextMessage(USER, "error"));
                 throw new McpException("MCP sampling exception should have been triggered");
             } catch (McpSamplingException e) {
                 return McpToolResult.builder()
@@ -200,6 +229,61 @@ public class SamplingServer {
                         .error(true)
                         .build();
             }
+        }
+    }
+
+    private static class SamplingWithToolsTool implements McpTool {
+        @Override
+        public String name() {
+            return "sampling-with-tools-tool";
+        }
+
+        @Override
+        public String description() {
+            return "Requests sampling with a server tool.";
+        }
+
+        @Override
+        public String schema() {
+            return Schema.builder().build().generate();
+        }
+
+        @Override
+        public McpToolResult tool(McpToolRequest request) {
+            McpSamplingResponse response = request.features()
+                    .sampling()
+                    .request(builder -> builder.addTextMessage(USER, "Use the sampled tool")
+                            .addTool(SampledTool.NAME)
+                            .toolChoice(McpToolChoice.REQUIRED));
+            return McpToolResult.create(response.asTextContent().text());
+        }
+    }
+
+    private static class SampledTool implements McpTool {
+        private static final String NAME = "sampled-tool";
+
+        @Override
+        public String name() {
+            return NAME;
+        }
+
+        @Override
+        public String description() {
+            return "Returns the supplied value.";
+        }
+
+        @Override
+        public String schema() {
+            return Schema.builder()
+                    .rootObject(root -> root.addStringProperty("value", value -> value.required(true)))
+                    .build()
+                    .generate();
+        }
+
+        @Override
+        public McpToolResult tool(McpToolRequest request) {
+            String value = request.arguments().get("value").asString().orElseThrow();
+            return McpToolResult.create("sampled " + value);
         }
     }
 }

--- a/tests/common/src/main/java/io/helidon/extensions/mcp/tests/common/SamplingServer.java
+++ b/tests/common/src/main/java/io/helidon/extensions/mcp/tests/common/SamplingServer.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.extensions.mcp.server.McpContentType;
 import io.helidon.extensions.mcp.server.McpException;
+import io.helidon.extensions.mcp.server.McpParameters;
 import io.helidon.extensions.mcp.server.McpSampling;
 import io.helidon.extensions.mcp.server.McpSamplingAudioContent;
 import io.helidon.extensions.mcp.server.McpSamplingException;
@@ -251,15 +252,16 @@ public class SamplingServer {
 
         @Override
         public McpToolResult tool(McpToolRequest request) {
+            McpParameters messageMetadata = McpParameters.create(Map.of("source", "server-message"));
+            McpParameters contentMetadata = McpParameters.create(Map.of("source", "server-content"));
             McpSamplingResponse response = request.features()
                     .sampling()
                     .request(builder -> builder.addMessage(McpSamplingMessage.builder()
                                                                   .role(USER)
-                                                                  .metadata(Map.of("source", "server-message"))
+                                                                  .metadata(messageMetadata)
                                                                   .addContent(McpSamplingTextContent.builder()
                                                                                       .text("Use the sampled tool")
-                                                                                      .metadata(Map.of("source",
-                                                                                                       "server-content"))
+                                                                                      .metadata(contentMetadata)
                                                                                       .build())
                                                                   .build())
                             .addTool(SampledTool.NAME)

--- a/tests/common/src/main/java/io/helidon/extensions/mcp/tests/common/SamplingServer.java
+++ b/tests/common/src/main/java/io/helidon/extensions/mcp/tests/common/SamplingServer.java
@@ -17,6 +17,7 @@ package io.helidon.extensions.mcp.tests.common;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
 
 import io.helidon.common.media.type.MediaTypes;
@@ -252,7 +253,15 @@ public class SamplingServer {
         public McpToolResult tool(McpToolRequest request) {
             McpSamplingResponse response = request.features()
                     .sampling()
-                    .request(builder -> builder.addTextMessage(USER, "Use the sampled tool")
+                    .request(builder -> builder.addMessage(McpSamplingMessage.builder()
+                                                                  .role(USER)
+                                                                  .metadata(Map.of("source", "server-message"))
+                                                                  .addContent(McpSamplingTextContent.builder()
+                                                                                      .text("Use the sampled tool")
+                                                                                      .metadata(Map.of("source",
+                                                                                                       "server-content"))
+                                                                                      .build())
+                                                                  .build())
                             .addTool(SampledTool.NAME)
                             .toolChoice(McpToolChoice.REQUIRED));
             return McpToolResult.create(response.asTextContent().text());


### PR DESCRIPTION
Fixes #114

- Specification change involves a backward incompatible change with our API and requires the introduction of Sampling contents as part of Sampling messages. 
- This PR introduces support for Sampling tool conversation and returns final response that keep track of all the messages exchanges.
- Maximum exchanged message during a conversation configurable through `max-sampling-tool-iterations` and guarded by timeout.