### PR TITLE
Fix Helidoc documentation links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,18 +2,9 @@
 site:
   title: "Helidon MCP"
   version: "27.0.0"
-  sourceUrl: "https://github.com/helidon-io/helidon-mcp/"
-  editRef: "main"
-  editUrlTemplate: "https://github.com/helidon-io/helidon-mcp/\
-    blob/{editRef}/{repoPath}"
-  issueUrlTemplate: "https://github.com/helidon-io/helidon-mcp/issues"
--->
-<!--
-pages:
-  - config/manifest.md
 -->
 
-Helidon MCP is an extension that provides servier-side support for Model Context Protocol (MCP) in your Helidon application.
+Helidon MCP is an extension that provides server-side support for Model Context Protocol (MCP) in your Helidon application.
 You can use it via an imperative or a declarative API. Both provide the same functionality.
 
 - [MCP](mcp.md) <!--@icon i-lucide-network -->

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1139,7 +1139,7 @@ McpSamplingRequest request = McpSamplingRequest.builder()
 
 Sampling metadata is serialized using Helidon JSON binding. The metadata option accepts `Object`; maps, collections,
 arrays, primitives, and converter-backed custom classes are supported. See
-[Migrate from JSON-B to Helidon JSON Binding](upgrade_guide_1.2.md#migrate-from-json-b-to-helidon-json-binding) for the
+[Migrate from JSON-B to Helidon JSON Binding](./upgrade/upgrade_guide_1.2.md#migrate-from-json-b-to-helidon-json-binding) for the
 compatibility impact and migration steps.
 
 Once your request is built, send it using the sampling feature.

--- a/docs/upgrade/upgrade_guide_1.1.md
+++ b/docs/upgrade/upgrade_guide_1.1.md
@@ -33,7 +33,7 @@ public McpToolResult tool(McpToolRequest request) {
 }
 ```
 
-For details about the `McpToolResult` builder, see [Tool Result](README.md#tool-result-builder-and-content-types).
+For details about the `McpToolResult` builder, see [Tool Result](../mcp.md#tool-result).
 
 ### Migrate McpRequest to McpToolRequest
 
@@ -245,7 +245,7 @@ public McpPromptResult prompt(McpPromptRequest request) {
 }
 ```
 
-For details about the `McpPromptResult` builder, see [Prompt Result](README.md#prompt-result-builder-and-content-types).
+For details about the `McpPromptResult` builder, see [Prompt Result](../mcp.md#prompt-result).
 
 ### Migrate McpRequest to McpPromptRequest
 
@@ -426,7 +426,7 @@ public McpResourceResult resource(McpResourceRequest request) {
 }
 ```
 
-For details about the `McpResourceResult` builder, see [Resource Result](README.md#resource-result-builder-and-content-types).
+For details about the `McpResourceResult` builder, see [Resource Result](../mcp.md#resource-result).
 
 ### Migrate McpRequest to McpResourceRequest
 
@@ -523,7 +523,7 @@ public McpCompletionResult completion(McpCompletionRequest request) {
 }
 ```
 
-For details about the `McpCompletionResult` builder, see [Completion Result](README.md#completion-result-builder).
+For details about the `McpCompletionResult` builder, see [Completion Result](../mcp.md#completion-result).
 
 ### Migrate McpRequest to McpCompletionRequest
 

--- a/docs/upgrade/upgrade_guide_declarative_1.1.md
+++ b/docs/upgrade/upgrade_guide_declarative_1.1.md
@@ -28,8 +28,8 @@ McpToolResult tool() {
 }
 ```
 
-For details about the `McpToolResult` class, see [README.md](README.md#tool-result) and
-[Upgrade Guide](../mcp/upgrade_guide_1.1.md#migrate-from-mcptoolcontents).
+For details about the `McpToolResult` class, see [Tool Result](../mcp-declarative.md#tool-result) and
+[Upgrade Guide](upgrade_guide_1.1.md#migrate-from-mcptoolcontents).
 
 ## Prompts
 
@@ -51,8 +51,8 @@ McpPromptResult prompt() {
 }
 ```
 
-For details about the `McpPromptResult` class, see [README.md](README.md#prompt-content-types) and
-[Upgrade Guide](../mcp/upgrade_guide_1.1.md#migrate-from-mcppromptcontents).
+For details about the `McpPromptResult` class, see [Prompt Result](../mcp-declarative.md#prompt-result) and
+[Upgrade Guide](upgrade_guide_1.1.md#migrate-from-mcppromptcontents).
 
 ## Resources
 
@@ -74,8 +74,8 @@ McpResourceResult resource() {
 }
 ```
 
-For details about the `McpResourceResult` class, see [README.md](README.md#resource-content-types) and
-[Upgrade Guide](../mcp/upgrade_guide_1.1.md#migrate-from-mcpresourcecontents).
+For details about the `McpResourceResult` class, see [Resource Result](../mcp-declarative.md#resource-result) and
+[Upgrade Guide](upgrade_guide_1.1.md#migrate-from-mcpresourcecontents).
 
 ## Completions
 
@@ -97,5 +97,5 @@ McpCompletionResult completion() {
 }
 ```
 
-For details about the `McpCompletionResult` class, see [README.md](README.md#completion-content-type) and
-[Upgrade Guide](../mcp/upgrade_guide_1.1.md#migrate-mcpcompletion-interface).
+For details about the `McpCompletionResult` class, see [Completion Result](../mcp-declarative.md#completion-result) and
+[Upgrade Guide](upgrade_guide_1.1.md#migrate-mcpcompletion-interface).


### PR DESCRIPTION
## Summary

- remove redundant source-link configuration and an unused page manifest placeholder
- fix documentation links after the Helidoc file layout changes
- point declarative upgrade guidance to the corresponding result sections
- correct the server-side documentation typo

## Testing

- hdock --no-ansi build --no-rolling --content docs