### PR TITLE
Add MCP 2025-11-25 icon metadata support

### DIFF
--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegen.java
@@ -34,6 +34,7 @@ import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 
+import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.addIconsToBuilder;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.generatedTypeName;
 import static io.helidon.extensions.mcp.codegen.McpTypes.HTTP_FEATURE;
 import static io.helidon.extensions.mcp.codegen.McpTypes.HTTP_ROUTING_BUILDER;
@@ -150,6 +151,8 @@ final class McpCodegen implements CodegenExtension {
                 .ifPresent(description -> method.addContent("builder.description(")
                         .addContentLiteral(description)
                         .addContentLine(");"));
+
+        addIconsToBuilder(method, type);
 
         type.findAnnotation(MCP_VERSION)
                 .flatMap(Annotation::value)

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegenUtil.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegenUtil.java
@@ -270,6 +270,14 @@ class McpCodegenUtil {
         });
     }
 
+    static void addIconsToBuilder(Method.Builder builder, TypeInfo serverType) {
+        for (Annotation icon : icons(serverType)) {
+            builder.addContent("builder.addIcon(");
+            addIcon(builder, icon);
+            builder.addContentLine(");");
+        }
+    }
+
     private static void addIconsField(Field.Builder builder, List<Annotation> icons) {
         builder.name(ICONS_FIELD)
                 .accessModifier(AccessModifier.PRIVATE)
@@ -289,14 +297,6 @@ class McpCodegenUtil {
         }
         builder.decreaseContentPadding()
                 .addContent(")");
-    }
-
-    static void addIconsToBuilder(Method.Builder builder, TypeInfo serverType) {
-        for (Annotation icon : icons(serverType)) {
-            builder.addContent("builder.addIcon(");
-            addIcon(builder, icon);
-            builder.addContentLine(");");
-        }
     }
 
     private static List<Annotation> icons(Annotated component) {

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegenUtil.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegenUtil.java
@@ -23,6 +23,9 @@ import java.util.stream.Collectors;
 
 import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.classmodel.ClassModel;
+import io.helidon.codegen.classmodel.ContentBuilder;
+import io.helidon.codegen.classmodel.Field;
+import io.helidon.codegen.classmodel.InnerClass;
 import io.helidon.codegen.classmodel.Method;
 import io.helidon.codegen.classmodel.Parameter;
 import io.helidon.common.types.AccessModifier;
@@ -63,11 +66,6 @@ import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_UNSUBSCRIBE_REQUEST
  * Utility class for methods used by several MCP code generator.
  */
 class McpCodegenUtil {
-    /**
-     * Pattern to match the first character of a string.
-     */
-    private static final Pattern PATTERN = Pattern.compile("^.");
-
     static final List<String> MCP_TYPES = List.of(MCP_REQUEST.classNameWithEnclosingNames(),
                                                   MCP_FEATURES.classNameWithEnclosingNames(),
                                                   MCP_LOGGER.classNameWithEnclosingNames(),
@@ -76,6 +74,13 @@ class McpCodegenUtil {
                                                   MCP_SAMPLING.classNameWithEnclosingNames(),
                                                   MCP_ELICITATION.classNameWithEnclosingNames(),
                                                   MCP_PARAMETERS.classNameWithEnclosingNames());
+
+    private static final String ICONS_FIELD = "ICONS";
+
+    /**
+     * Pattern to match the first character of a string.
+     */
+    private static final Pattern PATTERN = Pattern.compile("^.");
 
     private McpCodegenUtil() {
     }
@@ -244,19 +249,33 @@ class McpCodegenUtil {
         return Optional.empty();
     }
 
-    static void addIconsMethod(Method.Builder builder, Annotated component) {
+    static void addIcons(InnerClass.Builder builder, Annotated component) {
         List<Annotation> icons = icons(component);
-        builder.name("icons")
-                .addAnnotation(Annotations.OVERRIDE)
-                .returnType(LIST_MCP_ICON);
-        if (icons.isEmpty()) {
-            builder.addContent("return ")
-                    .addContent(LIST)
-                    .addContentLine(".of();");
-            return;
+        if (!icons.isEmpty()) {
+            builder.addField(field -> addIconsField(field, icons));
         }
+        builder.addMethod(method -> {
+            method.name("icons")
+                    .addAnnotation(Annotations.OVERRIDE)
+                    .returnType(LIST_MCP_ICON);
+            if (icons.isEmpty()) {
+                method.addContent("return ")
+                        .addContent(LIST)
+                        .addContentLine(".of();");
+            } else {
+                method.addContent("return ")
+                        .addContent(ICONS_FIELD)
+                        .addContentLine(";");
+            }
+        });
+    }
 
-        builder.addContent("return ")
+    private static void addIconsField(Field.Builder builder, List<Annotation> icons) {
+        builder.name(ICONS_FIELD)
+                .accessModifier(AccessModifier.PRIVATE)
+                .isStatic(true)
+                .isFinal(true)
+                .type(LIST_MCP_ICON)
                 .addContent(LIST)
                 .addContentLine(".of(")
                 .increaseContentPadding();
@@ -269,12 +288,14 @@ class McpCodegenUtil {
             }
         }
         builder.decreaseContentPadding()
-                .addContentLine(");");
+                .addContent(")");
     }
 
     static void addIconsToBuilder(Method.Builder builder, TypeInfo serverType) {
         for (Annotation icon : icons(serverType)) {
-            addIconToBuilder(builder, icon);
+            builder.addContent("builder.addIcon(");
+            addIcon(builder, icon);
+            builder.addContentLine(");");
         }
     }
 
@@ -290,13 +311,7 @@ class McpCodegenUtil {
         return List.copyOf(result);
     }
 
-    private static void addIconToBuilder(Method.Builder builder, Annotation icon) {
-        builder.addContent("builder.addIcon(");
-        addIcon(builder, icon);
-        builder.addContentLine(");");
-    }
-
-    private static void addIcon(Method.Builder builder, Annotation icon) {
+    private static void addIcon(ContentBuilder<?> builder, Annotation icon) {
         String source = icon.stringValue()
                 .orElseThrow(() -> new CodegenException("Icon must have a source."));
         String mimeType = icon.stringValue("mimeType").orElse("");

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegenUtil.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegenUtil.java
@@ -15,17 +15,20 @@
  */
 package io.helidon.extensions.mcp.codegen;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.classmodel.ClassModel;
 import io.helidon.codegen.classmodel.Method;
 import io.helidon.codegen.classmodel.Parameter;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotated;
 import io.helidon.common.types.Annotation;
+import io.helidon.common.types.Annotations;
 import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
@@ -33,11 +36,17 @@ import io.helidon.common.types.TypeNames;
 import io.helidon.common.types.TypedElementInfo;
 
 import static io.helidon.common.types.TypeNames.LIST;
+import static io.helidon.extensions.mcp.codegen.McpTypes.HELIDON_MEDIA_TYPES;
+import static io.helidon.extensions.mcp.codegen.McpTypes.LIST_MCP_ICON;
 import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_CANCELLATION;
 import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_COMPLETION_REQUEST;
 import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_DESCRIPTION;
 import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_ELICITATION;
 import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_FEATURES;
+import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_ICON;
+import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_ICONS;
+import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_ICON_ANNOTATION;
+import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_ICON_THEME;
 import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_LOGGER;
 import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_PARAMETERS;
 import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_PROGRESS;
@@ -233,5 +242,100 @@ class McpCodegenUtil {
             return description.stringValue();
         }
         return Optional.empty();
+    }
+
+    static void addIconsMethod(Method.Builder builder, Annotated component) {
+        List<Annotation> icons = icons(component);
+        builder.name("icons")
+                .addAnnotation(Annotations.OVERRIDE)
+                .returnType(LIST_MCP_ICON);
+        if (icons.isEmpty()) {
+            builder.addContent("return ")
+                    .addContent(LIST)
+                    .addContentLine(".of();");
+            return;
+        }
+
+        builder.addContent("return ")
+                .addContent(LIST)
+                .addContentLine(".of(")
+                .increaseContentPadding();
+        for (int i = 0; i < icons.size(); i++) {
+            addIcon(builder, icons.get(i));
+            if (i < icons.size() - 1) {
+                builder.addContentLine(",");
+            } else {
+                builder.addContentLine("");
+            }
+        }
+        builder.decreaseContentPadding()
+                .addContentLine(");");
+    }
+
+    static void addIconsToBuilder(Method.Builder builder, TypeInfo serverType) {
+        for (Annotation icon : icons(serverType)) {
+            addIconToBuilder(builder, icon);
+        }
+    }
+
+    private static List<Annotation> icons(Annotated component) {
+        List<Annotation> result = new ArrayList<>();
+        for (Annotation annotation : component.annotations()) {
+            if (MCP_ICON_ANNOTATION.equals(annotation.typeName())) {
+                result.add(annotation);
+            } else if (MCP_ICONS.equals(annotation.typeName())) {
+                result.addAll(annotation.annotationValues().orElseGet(List::of));
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    private static void addIconToBuilder(Method.Builder builder, Annotation icon) {
+        builder.addContent("builder.addIcon(");
+        addIcon(builder, icon);
+        builder.addContentLine(");");
+    }
+
+    private static void addIcon(Method.Builder builder, Annotation icon) {
+        String source = icon.stringValue()
+                .orElseThrow(() -> new CodegenException("Icon must have a source."));
+        String mimeType = icon.stringValue("mimeType").orElse("");
+        List<String> sizes = icon.stringValues("sizes").orElseGet(List::of);
+        String theme = icon.stringValue("theme").orElse("UNSPECIFIED");
+
+        builder.addContent(MCP_ICON)
+                .addContentLine(".builder()")
+                .increaseContentPadding()
+                .addContent(".source(")
+                .addContentLiteral(source)
+                .addContentLine(")");
+        if (!mimeType.isBlank()) {
+            builder.addContent(".mediaType(")
+                    .addContent(HELIDON_MEDIA_TYPES)
+                    .addContent(".create(")
+                    .addContentLiteral(mimeType)
+                    .addContentLine("))");
+        }
+        if (!sizes.isEmpty()) {
+            builder.addContent(".sizes(")
+                    .addContent(LIST)
+                    .addContent(".of(");
+            for (int sizeIndex = 0; sizeIndex < sizes.size(); sizeIndex++) {
+                if (sizeIndex > 0) {
+                    builder.addContent(", ");
+                }
+                builder.addContentLiteral(sizes.get(sizeIndex));
+            }
+            builder.addContentLine("))");
+        }
+        if (!theme.equals("UNSPECIFIED")) {
+            builder.addContent(".theme(")
+                    .addContent(MCP_ICON_THEME)
+                    .addContent(".")
+                    .addContent(theme)
+                    .addContentLine(")");
+        }
+        builder.addContent(".build()")
+                .decreaseContentPadding();
     }
 }

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpPromptCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpPromptCodegen.java
@@ -30,7 +30,7 @@ import io.helidon.common.types.TypeNames;
 import io.helidon.common.types.TypedElementInfo;
 
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.MCP_TYPES;
-import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.addIconsMethod;
+import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.addIcons;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.createClassName;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.getElementsWithAnnotation;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isIgnoredSchemaElement;
@@ -67,7 +67,7 @@ class McpPromptCodegen {
                     .addMethod(method -> addPromptNameMethod(method, element))
                     .addMethod(method -> addPromptDescriptionMethod(method, description))
                     .addMethod(method -> addPromptArgumentsMethod(method, element))
-                    .addMethod(method -> addIconsMethod(method, element))
+                    .update(component -> addIcons(component, element))
                     .addMethod(method -> addPromptMethod(method, classModel, element)));
         });
     }

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpPromptCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpPromptCodegen.java
@@ -30,6 +30,7 @@ import io.helidon.common.types.TypeNames;
 import io.helidon.common.types.TypedElementInfo;
 
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.MCP_TYPES;
+import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.addIconsMethod;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.createClassName;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.getElementsWithAnnotation;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isIgnoredSchemaElement;
@@ -55,7 +56,8 @@ class McpPromptCodegen {
     void generate(ClassModel.Builder classModel, TypeInfo type) {
         getElementsWithAnnotation(type, MCP_PROMPT).forEach(element -> {
             TypeName innerTypeName = createClassName(element, "__Prompt");
-            String description = element.annotation(MCP_PROMPT).value().orElse("");
+            Annotation promptAnnotation = element.annotation(MCP_PROMPT);
+            String description = promptAnnotation.value().orElse("");
 
             recorder.prompt(innerTypeName);
             classModel.addInnerClass(clazz -> clazz
@@ -65,6 +67,7 @@ class McpPromptCodegen {
                     .addMethod(method -> addPromptNameMethod(method, element))
                     .addMethod(method -> addPromptDescriptionMethod(method, description))
                     .addMethod(method -> addPromptArgumentsMethod(method, element))
+                    .addMethod(method -> addIconsMethod(method, element))
                     .addMethod(method -> addPromptMethod(method, classModel, element)));
         });
     }

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpResourceCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpResourceCodegen.java
@@ -30,7 +30,7 @@ import io.helidon.common.types.TypeNames;
 import io.helidon.common.types.TypedElementInfo;
 
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.MCP_TYPES;
-import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.addIconsMethod;
+import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.addIcons;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.createClassName;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.getElementsWithAnnotation;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isMcpType;
@@ -85,7 +85,7 @@ class McpResourceCodegen {
                     .addMethod(method -> addResourceUriMethod(method, uri))
                     .addMethod(method -> addResourceNameMethod(method, element))
                     .addMethod(method -> addResourceDescriptionMethod(method, description))
-                    .addMethod(method -> addIconsMethod(method, element))
+                    .update(component -> addIcons(component, element))
                     .addMethod(method -> addResourceMethod(method, uri, classModel, element))
                     .addMethod(method -> addResourceMediaTypeMethod(method, mediaTypeContent)));
         });

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpResourceCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpResourceCodegen.java
@@ -30,6 +30,7 @@ import io.helidon.common.types.TypeNames;
 import io.helidon.common.types.TypedElementInfo;
 
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.MCP_TYPES;
+import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.addIconsMethod;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.createClassName;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.getElementsWithAnnotation;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.isMcpType;
@@ -66,16 +67,14 @@ class McpResourceCodegen {
     private void generateResources(ClassModel.Builder classModel, TypeInfo type) {
         getElementsWithAnnotation(type, MCP_RESOURCE).forEach(element -> {
             TypeName innerTypeName = createClassName(element, "__Resource");
-            String uri = element.findAnnotation(MCP_RESOURCE)
-                    .flatMap(annotation -> annotation.stringValue("uri"))
+            Annotation resourceAnnotation = element.annotation(MCP_RESOURCE);
+            String uri = resourceAnnotation.stringValue("uri")
                     .orElseThrow(() -> new CodegenException("Resource " + element.elementName() + " must have a URI.",
                                                             element.originatingElementValue()));
-            String description = element.findAnnotation(MCP_RESOURCE)
-                    .flatMap(annotation -> annotation.stringValue("description"))
+            String description = resourceAnnotation.stringValue("description")
                     .orElseThrow(() -> new CodegenException("Resource " + element.elementName() + " must have a description.",
                                                             element.originatingElementValue()));
-            String mediaTypeContent = element.findAnnotation(MCP_RESOURCE)
-                    .flatMap(annotation -> annotation.stringValue("mediaType"))
+            String mediaTypeContent = resourceAnnotation.stringValue("mediaType")
                     .orElseThrow(() -> new CodegenException("Resource " + element.elementName() + " must have a Media Type.",
                                                             element.originatingElementValue()));
             recorder.resource(innerTypeName);
@@ -86,6 +85,7 @@ class McpResourceCodegen {
                     .addMethod(method -> addResourceUriMethod(method, uri))
                     .addMethod(method -> addResourceNameMethod(method, element))
                     .addMethod(method -> addResourceDescriptionMethod(method, description))
+                    .addMethod(method -> addIconsMethod(method, element))
                     .addMethod(method -> addResourceMethod(method, uri, classModel, element))
                     .addMethod(method -> addResourceMediaTypeMethod(method, mediaTypeContent)));
         });

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpToolCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpToolCodegen.java
@@ -33,6 +33,7 @@ import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypeNames;
 import io.helidon.common.types.TypedElementInfo;
 
+import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.addIconsMethod;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.addToListMethod;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.createClassName;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.getDescription;
@@ -79,6 +80,7 @@ class McpToolCodegen {
                     .addMethod(method -> addToolDescriptionMethod(method, description))
                     .addMethod(method -> addToolSchemaMethod(method, element))
                     .addMethod(method -> addToolMethod(method, classModel, element))
+                    .addMethod(method -> addIconsMethod(method, element))
                     .addMethod(method -> addToolAnnotationsMethod(method, toolAnnotation))
                     .addMethod(method -> addToolOutputSchema(method, element)));
         });

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpToolCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpToolCodegen.java
@@ -33,7 +33,7 @@ import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypeNames;
 import io.helidon.common.types.TypedElementInfo;
 
-import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.addIconsMethod;
+import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.addIcons;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.addToListMethod;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.createClassName;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.getDescription;
@@ -80,7 +80,7 @@ class McpToolCodegen {
                     .addMethod(method -> addToolDescriptionMethod(method, description))
                     .addMethod(method -> addToolSchemaMethod(method, element))
                     .addMethod(method -> addToolMethod(method, classModel, element))
-                    .addMethod(method -> addIconsMethod(method, element))
+                    .update(component -> addIcons(component, element))
                     .addMethod(method -> addToolAnnotationsMethod(method, toolAnnotation))
                     .addMethod(method -> addToolOutputSchema(method, element)));
         });

--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpTypes.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpTypes.java
@@ -26,15 +26,14 @@ import static io.helidon.common.types.TypeNames.LIST;
 import static io.helidon.common.types.TypeNames.OPTIONAL;
 
 final class McpTypes {
-    private McpTypes() {
-    }
-
     //Annotations
     static final TypeName MCP_NAME = TypeName.create("io.helidon.extensions.mcp.server.Mcp.Name");
     static final TypeName MCP_PATH = TypeName.create("io.helidon.extensions.mcp.server.Mcp.Path");
     static final TypeName MCP_ROLE = TypeName.create("io.helidon.extensions.mcp.server.Mcp.Role");
     static final TypeName MCP_TOOL = TypeName.create("io.helidon.extensions.mcp.server.Mcp.Tool");
     static final TypeName MCP_SERVER = TypeName.create("io.helidon.extensions.mcp.server.Mcp.Server");
+    static final TypeName MCP_ICON_ANNOTATION = TypeName.create("io.helidon.extensions.mcp.server.Mcp.Icon");
+    static final TypeName MCP_ICONS = TypeName.create("io.helidon.extensions.mcp.server.Mcp.Icons");
     static final TypeName MCP_PROMPT = TypeName.create("io.helidon.extensions.mcp.server.Mcp.Prompt");
     static final TypeName MCP_VERSION = TypeName.create("io.helidon.extensions.mcp.server.Mcp.Version");
     static final TypeName MCP_RESOURCE = TypeName.create("io.helidon.extensions.mcp.server.Mcp.Resource");
@@ -62,6 +61,8 @@ final class McpTypes {
     static final TypeName MCP_FEATURES = TypeName.create("io.helidon.extensions.mcp.server.McpFeatures");
     static final TypeName MCP_PROGRESS = TypeName.create("io.helidon.extensions.mcp.server.McpProgress");
     static final TypeName MCP_SAMPLING = TypeName.create("io.helidon.extensions.mcp.server.McpSampling");
+    static final TypeName MCP_ICON = TypeName.create("io.helidon.extensions.mcp.server.McpIcon");
+    static final TypeName MCP_ICON_THEME = TypeName.create("io.helidon.extensions.mcp.server.McpIconTheme");
     static final TypeName MCP_TOOL_INTERFACE = TypeName.create("io.helidon.extensions.mcp.server.McpTool");
     static final TypeName MCP_PARAMETERS = TypeName.create("io.helidon.extensions.mcp.server.McpParameters");
     static final TypeName MCP_TOOL_RESULT = TypeName.create("io.helidon.extensions.mcp.server.McpToolResult");
@@ -99,8 +100,12 @@ final class McpTypes {
     static final TypeName SERVICE_SINGLETON = TypeName.create("io.helidon.service.registry.Service.Singleton");
     static final TypeName HTTP_ROUTING_BUILDER = TypeName.create("io.helidon.webserver.http.HttpRouting.Builder");
     static final TypeName LIST_STRING = TypeName.builder(LIST).addTypeArgument(TypeNames.STRING).build();
+    static final TypeName LIST_MCP_ICON = TypeName.builder(LIST).addTypeArgument(MCP_ICON).build();
     static final TypeName CONSUMER_REQUEST = TypeName.builder(CONSUMER).addTypeArgument(MCP_REQUEST).build();
     static final TypeName OPTIONAL_STRING = TypeName.builder(OPTIONAL).addTypeArgument(TypeNames.STRING).build();
     static final TypeName LIST_MCP_PROMPT_ARGUMENT = TypeName.builder(LIST).addTypeArgument(MCP_PROMPT_ARGUMENT).build();
     static final TypeName OPTIONAL_TOOL_ANNOTATIONS = TypeName.builder(OPTIONAL).addTypeArgument(MCP_TOOL_ANNOTATIONS).build();
+
+    private McpTypes() {
+    }
 }

--- a/docs/mcp-declarative.md
+++ b/docs/mcp-declarative.md
@@ -132,8 +132,8 @@ String tool() {
 }
 ```
 
-The source can be an HTTP(S) URL or a `data:` URI. Sizes use the `WxH` format or `any`. The same `@Mcp.Resource`
-annotation configures icons for both resources and resource templates.
+The source can be an HTTP(S) URL or a `data:` URI with a Base64-encoded payload. Sizes use the `WxH` format or `any`.
+The same repeatable `@Mcp.Icon` annotations configure icons for both resources and resource templates.
 
 ### Tool
 

--- a/docs/mcp-declarative.md
+++ b/docs/mcp-declarative.md
@@ -61,6 +61,7 @@ class McpServer {
 
 - **`@Mcp.Server`**: Defines the class as an MCP server and can override the default server name.
 - **`@Mcp.Description`**: Sets the optional server description.
+- **`@Mcp.Icon`**: Adds icon metadata to the server.
 - **`@Mcp.Path`**: Sets the HTTP endpoint path for the server.
 - **`@Mcp.Version`**: Establishes the server version.
 - **`@Mcp.WebsiteUrl`**: Sets the optional server website URL.
@@ -72,11 +73,12 @@ class McpServer {
 @Mcp.Description("Provides tools and resources for Example")
 @Mcp.WebsiteUrl("https://example.com/mcp")
 @Mcp.Server("MyServer")
+@Mcp.Icon("https://example.com/server.svg")
 class McpServer {
 }
 ```
 
-The description and website URL are included in `serverInfo` when the negotiated protocol version is `2025-11-25`.
+The description, website URL, and icons are included in `serverInfo` when the negotiated protocol version is `2025-11-25`.
 
 #### Stateless mode
 
@@ -98,6 +100,40 @@ or reusing a server session. Because request-to-request session state is not kep
 - Data in `sessionContext()` is not preserved across independent requests.
 - Client capabilities are normally negotiated during initialization; if a client skips this phase, capability-dependent
   features will be unavailable.
+
+### Icons
+
+Servers, tools, prompts, resources, and resource templates can expose one or more icons to clients using the
+[MCP `2025-11-25` protocol version](https://modelcontextprotocol.io/specification/2025-11-25).
+Older negotiated protocol versions omit this metadata.
+
+Place one or more `@Mcp.Icon` annotations alongside `@Mcp.Server` to configure server icons:
+
+```java
+@Mcp.Server("MyServer")
+@Mcp.Icon("https://example.com/server.svg")
+@Mcp.Icon("data:image/png;base64,...")
+class McpServer {
+}
+```
+
+For tools, prompts, resources, and resource templates, place the `@Mcp.Icon` annotations alongside the component annotation:
+
+```java
+@Mcp.Tool("Tool description")
+@Mcp.Icon(
+        value = "https://example.com/icon.svg",
+        mimeType = "image/svg+xml",
+        sizes = {"48x48", "96x96"},
+        theme = McpIconTheme.DARK)
+@Mcp.Icon("data:image/png;base64,...")
+String tool() {
+    return "result";
+}
+```
+
+The source can be an HTTP(S) URL or a `data:` URI. Sizes use the `WxH` format or `any`. The same `@Mcp.Resource`
+annotation configures icons for both resources and resource templates.
 
 ### Tool
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -109,8 +109,8 @@ McpServerFeature.builder()
                 .tool(request -> McpToolResult.create("result")));
 ```
 
-The source can be an HTTP(S) URL or a `data:` URI. Sizes use the `WxH` format or `any`. Leave the theme unspecified when
-the icon is suitable for both light and dark backgrounds.
+The source can be an HTTP(S) URL or a `data:` URI with a Base64-encoded payload. Sizes use the `WxH` format or `any`.
+Leave the theme unspecified when the icon is suitable for both light and dark backgrounds.
 
 ### Tool
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -82,6 +82,36 @@ McpServerFeature.builder()
         .build();
 ```
 
+### Icons
+
+Servers, tools, prompts, resources, and resource templates implement `McpIcons` and can expose one or more icons to clients using the
+[MCP `2025-11-25` protocol version](https://modelcontextprotocol.io/specification/2025-11-25).
+Older negotiated protocol versions omit this metadata.
+
+Create an icon and add it to the server or any of its component builders:
+
+```java
+McpIcon icon = McpIcon.builder()
+        .source("https://example.com/icon.svg")
+        .mediaType(MediaTypes.create("image/svg+xml"))
+        .addSize("48x48")
+        .addSize("96x96")
+        .theme(McpIconTheme.DARK)
+        .build();
+
+McpServerFeature.builder()
+        .addIcon(icon)
+        .addTool(tool -> tool
+                .name("tool")
+                .description("Tool description")
+                .schema("")
+                .addIcon(icon)
+                .tool(request -> McpToolResult.create("result")));
+```
+
+The source can be an HTTP(S) URL or a `data:` URI. Sizes use the `WxH` format or `any`. Leave the theme unspecified when
+the icon is suitable for both light and dark backgrounds.
+
 ### Tool
 
 `Tools` enable models to interact with external systems: for example, by querying databases, calling APIs, or performing 
@@ -1487,12 +1517,18 @@ mcp:
     version: "0.0.1"
     description: "Provides tools and resources for Example"
     website-url: "https://example.com/mcp"
+    icons:
+      - source: "https://example.com/server.svg"
+        media-type: "image/svg+xml"
+        sizes: ["any"]
+        theme: "DARK"
     path: "/mcp"
     stateless: true
     max-sampling-tool-iterations: 10
 ```
 
-The optional description and website URL are included in `serverInfo` when the negotiated protocol version is `2025-11-25`.
+The optional description, website URL, and icons are included in `serverInfo` when the negotiated protocol version is
+`2025-11-25`.
 
 Register the configuration in code:
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -84,7 +84,7 @@ McpServerFeature.builder()
 
 ### Icons
 
-Servers, tools, prompts, resources, and resource templates implement `McpIcons` and can expose one or more icons to clients using the
+Server's configuration, tools, prompts, resources, and resource templates implement `McpIcons` and can expose one or more icons to clients using the
 [MCP `2025-11-25` protocol version](https://modelcontextprotocol.io/specification/2025-11-25).
 Older negotiated protocol versions omit this metadata.
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/Mcp.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/Mcp.java
@@ -189,7 +189,7 @@ public final class Mcp {
     public @interface Icon {
         /**
          * Icon source. This must be an {@code http} or {@code https} URL, or a
-         * {@code data} URI.
+         * {@code data} URI with a Base64-encoded payload.
          *
          * @return icon source
          */

--- a/server/src/main/java/io/helidon/extensions/mcp/server/Mcp.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/Mcp.java
@@ -16,6 +16,7 @@
 
 package io.helidon.extensions.mcp.server;
 
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -75,6 +76,10 @@ public final class Mcp {
      *     <li>
      *         {@link io.helidon.extensions.mcp.server.Mcp.WebsiteUrl} -
      *         Set the optional MCP server website URL.
+     *     </li>
+     *     <li>
+     *         {@link io.helidon.extensions.mcp.server.Mcp.Icon} -
+     *         Add icon metadata to the MCP server.
      *     </li>
      *     <li>
      *         {@link io.helidon.extensions.mcp.server.Mcp.Path} -
@@ -173,6 +178,57 @@ public final class Mcp {
          * @return server path
          */
         String value();
+    }
+
+    /**
+     * Icon metadata for a server, tool, prompt, resource, or resource template.
+     */
+    @Target({TYPE, METHOD})
+    @Retention(RUNTIME)
+    @Repeatable(Icons.class)
+    public @interface Icon {
+        /**
+         * Icon source. This must be an {@code http} or {@code https} URL, or a
+         * {@code data} URI.
+         *
+         * @return icon source
+         */
+        String value();
+
+        /**
+         * Icon MIME type.
+         *
+         * @return MIME type
+         */
+        String mimeType() default "";
+
+        /**
+         * Icon sizes, each formatted as {@code WxH} or {@code any}.
+         *
+         * @return icon sizes
+         */
+        String[] sizes() default {};
+
+        /**
+         * Optional icon theme.
+         *
+         * @return icon theme
+         */
+        McpIconTheme theme() default McpIconTheme.UNSPECIFIED;
+    }
+
+    /**
+     * Container for repeating {@link io.helidon.extensions.mcp.server.Mcp.Icon} annotations.
+     */
+    @Target({TYPE, METHOD})
+    @Retention(RUNTIME)
+    public @interface Icons {
+        /**
+         * Icons for the annotated MCP component.
+         *
+         * @return icons
+         */
+        Icon[] value();
     }
 
     /**

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpDecorators.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpDecorators.java
@@ -16,6 +16,7 @@
 package io.helidon.extensions.mcp.server;
 
 import java.net.URI;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -23,6 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.media.type.MediaTypes;
 
 import static io.helidon.extensions.mcp.server.McpPagination.DEFAULT_PAGE_SIZE;
 
@@ -109,6 +111,7 @@ final class McpDecorators {
      */
     static class IconSourceDecorator implements Prototype.OptionDecorator<McpIcon.BuilderBase<?, ?>, String> {
         private static final String INVALID_ICON_SOURCE = "Icon source must be a valid HTTP(S) URL or data URI";
+        private static final String BASE64_MARKER = ";base64";
 
         @Override
         public void decorate(McpIcon.BuilderBase<?, ?> builder, String value) {
@@ -140,9 +143,54 @@ final class McpDecorators {
                     if (!source.isOpaque() || separator < 0 || separator == data.length() - 1) {
                         throw new IllegalArgumentException(INVALID_ICON_SOURCE);
                     }
+                    String metadata = data.substring(0, separator);
+                    int base64Offset = metadata.length() - BASE64_MARKER.length();
+                    if (base64Offset < 0
+                            || !metadata.regionMatches(true, base64Offset, BASE64_MARKER, 0, BASE64_MARKER.length())) {
+                        throw new IllegalArgumentException(INVALID_ICON_SOURCE);
+                    }
+                    String mediaType = metadata.substring(0, base64Offset);
+                    if (!mediaType.isEmpty()) {
+                        try {
+                            MediaTypes.create(mediaType.charAt(0) == ';' ? "text/plain" + mediaType : mediaType);
+                        } catch (IllegalArgumentException e) {
+                            throw new IllegalArgumentException(INVALID_ICON_SOURCE, e);
+                        }
+                    }
+                    try {
+                        Base64.getDecoder().decode(decodePercentEncoded(data.substring(separator + 1)));
+                    } catch (IllegalArgumentException e) {
+                        throw new IllegalArgumentException(INVALID_ICON_SOURCE, e);
+                    }
                 }
                 default -> throw new IllegalArgumentException(INVALID_ICON_SOURCE);
             }
+        }
+
+        private static String decodePercentEncoded(String value) {
+            int firstEscape = value.indexOf('%');
+            if (firstEscape == -1) {
+                return value;
+            }
+            StringBuilder decoded = new StringBuilder(value.length());
+            decoded.append(value, 0, firstEscape);
+            for (int i = firstEscape; i < value.length(); i++) {
+                char character = value.charAt(i);
+                if (character != '%') {
+                    decoded.append(character);
+                    continue;
+                }
+                if (i + 2 >= value.length()) {
+                    throw new IllegalArgumentException(INVALID_ICON_SOURCE);
+                }
+                int high = Character.digit(value.charAt(++i), 16);
+                int low = Character.digit(value.charAt(++i), 16);
+                if (high == -1 || low == -1) {
+                    throw new IllegalArgumentException(INVALID_ICON_SOURCE);
+                }
+                decoded.append((char) ((high << 4) | low));
+            }
+            return decoded.toString();
         }
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpDecorators.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpDecorators.java
@@ -18,6 +18,7 @@ package io.helidon.extensions.mcp.server;
 import java.net.URI;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
@@ -100,6 +101,48 @@ final class McpDecorators {
                     .ifPresent(priority -> {
                         throw new IllegalArgumentException("Annotation priority must be in range [0, 1]");
                     });
+        }
+    }
+
+    /**
+     * Enforce a valid HTTP(S) URL or data URI for an icon source.
+     */
+    static class IconSourceDecorator implements Prototype.OptionDecorator<McpIcon.BuilderBase<?, ?>, String> {
+        private static final String INVALID_ICON_SOURCE = "Icon source must be a valid HTTP(S) URL or data URI";
+
+        @Override
+        public void decorate(McpIcon.BuilderBase<?, ?> builder, String value) {
+            if (value.isBlank()) {
+                throw new IllegalArgumentException(INVALID_ICON_SOURCE);
+            }
+
+            URI source;
+            try {
+                source = URI.create(value);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(INVALID_ICON_SOURCE, e);
+            }
+
+            String scheme = source.getScheme();
+            if (scheme == null) {
+                throw new IllegalArgumentException(INVALID_ICON_SOURCE);
+            }
+
+            switch (scheme.toLowerCase(Locale.ROOT)) {
+                case "http", "https" -> {
+                    if (source.getHost() == null) {
+                        throw new IllegalArgumentException(INVALID_ICON_SOURCE);
+                    }
+                }
+                case "data" -> {
+                    String data = source.getRawSchemeSpecificPart();
+                    int separator = data.indexOf(',');
+                    if (!source.isOpaque() || separator < 0 || separator == data.length() - 1) {
+                        throw new IllegalArgumentException(INVALID_ICON_SOURCE);
+                    }
+                }
+                default -> throw new IllegalArgumentException(INVALID_ICON_SOURCE);
+            }
         }
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpDecorators.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpDecorators.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import io.helidon.builder.api.Prototype;
-import io.helidon.common.media.type.MediaTypes;
 
 import static io.helidon.extensions.mcp.server.McpPagination.DEFAULT_PAGE_SIZE;
 
@@ -150,12 +149,8 @@ final class McpDecorators {
                         throw new IllegalArgumentException(INVALID_ICON_SOURCE);
                     }
                     String mediaType = metadata.substring(0, base64Offset);
-                    if (!mediaType.isEmpty()) {
-                        try {
-                            MediaTypes.create(mediaType.charAt(0) == ';' ? "text/plain" + mediaType : mediaType);
-                        } catch (IllegalArgumentException e) {
-                            throw new IllegalArgumentException(INVALID_ICON_SOURCE, e);
-                        }
+                    if (!isValidMediaType(mediaType)) {
+                        throw new IllegalArgumentException(INVALID_ICON_SOURCE);
                     }
                     try {
                         Base64.getDecoder().decode(decodePercentEncoded(data.substring(separator + 1)));
@@ -165,6 +160,109 @@ final class McpDecorators {
                 }
                 default -> throw new IllegalArgumentException(INVALID_ICON_SOURCE);
             }
+        }
+
+        private static boolean isValidMediaType(String value) {
+            if (value.isEmpty()) {
+                return true;
+            }
+
+            int firstParameter = value.indexOf(';');
+            int mediaTypeEnd = firstParameter == -1 ? value.length() : firstParameter;
+            if (mediaTypeEnd > 0) {
+                int slash = value.indexOf('/');
+                if (slash <= 0 || slash >= mediaTypeEnd - 1) {
+                    return false;
+                }
+                int secondSlash = value.indexOf('/', slash + 1);
+                if ((secondSlash >= 0 && secondSlash < mediaTypeEnd)
+                        || !isMimeToken(value, 0, slash)
+                        || !isMimeToken(value, slash + 1, mediaTypeEnd)) {
+                    return false;
+                }
+            }
+
+            for (int offset = mediaTypeEnd; offset < value.length();) {
+                if (value.charAt(offset) != ';') {
+                    return false;
+                }
+                int end = value.indexOf(';', offset + 1);
+                end = end == -1 ? value.length() : end;
+                int equals = value.indexOf('=', offset + 1);
+                if (equals < offset + 2 || equals >= end - 1
+                        || !isMimeToken(value, offset + 1, equals)
+                        || !isParameterValue(value, equals + 1, end)) {
+                    return false;
+                }
+                int secondEquals = value.indexOf('=', equals + 1);
+                if (secondEquals >= 0 && secondEquals < end) {
+                    return false;
+                }
+                offset = end;
+            }
+            return true;
+        }
+
+        private static boolean isMimeToken(String value, int start, int end) {
+            if (start == end) {
+                return false;
+            }
+            for (int i = start; i < end; i++) {
+                char character = value.charAt(i);
+                if (character == '%') {
+                    if (i + 2 >= end) {
+                        return false;
+                    }
+                    int high = Character.digit(value.charAt(++i), 16);
+                    int low = Character.digit(value.charAt(++i), 16);
+                    if (high == -1 || low == -1) {
+                        return false;
+                    }
+                    character = (char) ((high << 4) | low);
+                }
+                if (!isMimeTokenCharacter(character)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static boolean isParameterValue(String value, int start, int end) {
+            if (start == end) {
+                return false;
+            }
+            for (int i = start; i < end; i++) {
+                char character = value.charAt(i);
+                if (character != '%') {
+                    if (!isMimeTokenCharacter(character)) {
+                        return false;
+                    }
+                    continue;
+                }
+                if (i + 2 >= end) {
+                    return false;
+                }
+                int high = Character.digit(value.charAt(++i), 16);
+                int low = Character.digit(value.charAt(++i), 16);
+                if (high == -1 || low == -1) {
+                    return false;
+                }
+                int decoded = (high << 4) | low;
+                if (decoded < 0x20 || decoded > 0x7e) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static boolean isMimeTokenCharacter(char character) {
+            if (character < 0x21 || character > 0x7e) {
+                return false;
+            }
+            return switch (character) {
+                case '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=' -> false;
+                default -> true;
+            };
         }
 
         private static String decodePercentEncoded(String value) {

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpIconBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpIconBlueprint.java
@@ -31,7 +31,7 @@ import io.helidon.common.media.type.MediaType;
 interface McpIconBlueprint {
     /**
      * Icon source. This must be an {@code http} or {@code https} URL, or a
-     * {@code data} URI.
+     * {@code data} URI with a Base64-encoded payload.
      *
      * @return icon source
      */

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpIconBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpIconBlueprint.java
@@ -23,30 +23,37 @@ import io.helidon.builder.api.Prototype;
 import io.helidon.common.media.type.MediaType;
 
 /**
- * An optionally-sized MCP icon.
+ * Icon metadata.
  */
 @Prototype.Blueprint
+@Prototype.Configured
+@Prototype.CustomMethods(McpIconSupport.class)
 interface McpIconBlueprint {
     /**
-     * Icon source URI or data URI.
+     * Icon source. This must be an {@code http} or {@code https} URL, or a
+     * {@code data} URI.
      *
      * @return icon source
      */
-    String src();
+    @Option.Configured
+    @Option.Decorator(McpDecorators.IconSourceDecorator.class)
+    String source();
 
     /**
      * Optional MIME type override.
      *
      * @return MIME type
      */
+    @Option.Configured
     Optional<MediaType> mediaType();
 
     /**
-     * Sizes at which the icon can be used.
+     * Icon sizes, each formatted as {@code WxH} or {@code any}.
      *
      * @return icon sizes
      */
     @Option.Singular
+    @Option.Configured
     List<String> sizes();
 
     /**
@@ -54,5 +61,6 @@ interface McpIconBlueprint {
      *
      * @return icon theme
      */
+    @Option.Configured
     Optional<McpIconTheme> theme();
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpIconSupport.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpIconSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,18 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.helidon.extensions.mcp.server;
 
-package io.helidon.extensions.mcp.tests.declarative;
+import io.helidon.builder.api.Prototype;
+import io.helidon.common.media.type.MediaType;
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.config.Config;
 
-import io.helidon.extensions.mcp.server.Mcp;
+final class McpIconSupport {
+    private McpIconSupport() {
+    }
 
-@Mcp.Path("/mcp-custom")
-@Mcp.Version("0.0.1-SNAPSHOT")
-@Mcp.WebsiteUrl("https://example.com/mcp")
-@Mcp.Description("Declarative Helidon MCP server")
-@Mcp.Server("mcp-server-custom-path")
-@Mcp.Icon(
-        value = "https://example.com/server-only.svg",
-        sizes = "any")
-class McpConfigurationServer {
+    @Prototype.ConfigFactoryMethod("mediaType")
+    static MediaType createMediaType(Config config) {
+        return config.asString()
+                .as(MediaTypes::create)
+                .get();
+    }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpIconTheme.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpIconTheme.java
@@ -22,6 +22,11 @@ import java.util.Locale;
  */
 public enum McpIconTheme {
     /**
+     * No theme preference. This value is omitted from MCP responses.
+     */
+    UNSPECIFIED,
+
+    /**
      * Icon intended for a light background.
      */
     LIGHT,

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpIcons.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpIcons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,18 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.helidon.extensions.mcp.server;
 
-package io.helidon.extensions.mcp.tests.declarative;
+import java.util.List;
 
-import io.helidon.extensions.mcp.server.Mcp;
-
-@Mcp.Path("/mcp-custom")
-@Mcp.Version("0.0.1-SNAPSHOT")
-@Mcp.WebsiteUrl("https://example.com/mcp")
-@Mcp.Description("Declarative Helidon MCP server")
-@Mcp.Server("mcp-server-custom-path")
-@Mcp.Icon(
-        value = "https://example.com/server-only.svg",
-        sizes = "any")
-class McpConfigurationServer {
+/**
+ * A component with icon metadata.
+ */
+public interface McpIcons {
+    /**
+     * Icons for this component.
+     *
+     * @return icons, never {@code null}
+     */
+    default List<McpIcon> icons() {
+        return List.of();
+    }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
@@ -50,6 +50,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
         JsonObject.Builder builder = super.serverInfo(config);
         config.description().ifPresent(description -> builder.set("description", description));
         config.websiteUrl().ifPresent(websiteUrl -> builder.set("websiteUrl", websiteUrl));
+        addIcons(builder, config);
         return builder;
     }
 
@@ -144,12 +145,8 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
     @Override
     public Optional<JsonObject.Builder> toJson(McpContent content) {
         Optional<JsonObject.Builder> result = super.toJson(content);
-        if (content instanceof McpToolResourceLinkContent link) {
-            result.ifPresent(builder -> {
-                if (!link.icons().isEmpty()) {
-                    builder.setValues("icons", link.icons().stream().map(this::toJson).toList());
-                }
-            });
+        if (content instanceof McpIcons component) {
+            result.ifPresent(builder -> addIcons(builder, component));
         }
         return result;
     }
@@ -169,6 +166,34 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
                 .set("name", content.name())
                 .set("input", content.input().asJsonObject()
                         .orElseThrow(() -> new McpSamplingException("Sampling tool input must be a JSON object")));
+    }
+
+    @Override
+    public JsonObject.Builder toJson(McpTool tool) {
+        JsonObject.Builder builder = super.toJson(tool);
+        addIcons(builder, tool);
+        return builder;
+    }
+
+    @Override
+    public JsonObject.Builder toJson(McpPrompt prompt) {
+        JsonObject.Builder builder = super.toJson(prompt);
+        addIcons(builder, prompt);
+        return builder;
+    }
+
+    @Override
+    public JsonObject.Builder toJson(McpResource resource) {
+        JsonObject.Builder builder = super.toJson(resource);
+        addIcons(builder, resource);
+        return builder;
+    }
+
+    @Override
+    public JsonObject.Builder resourceTemplates(McpResource resource) {
+        JsonObject.Builder builder = super.resourceTemplates(resource);
+        addIcons(builder, resource);
+        return builder;
     }
 
     @Override
@@ -359,26 +384,41 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
     }
 
     private McpIcon parseIcon(JsonObject icon) {
-        McpIcon.Builder builder = McpIcon.builder().src(icon.stringValue("src").orElseThrow());
+        McpIcon.Builder builder = McpIcon.builder().source(icon.stringValue("src").orElseThrow());
         icon.stringValue("mimeType").map(MediaTypes::create).ifPresent(builder::mediaType);
         icon.arrayValue("sizes").ifPresent(sizes -> sizes.values().stream()
                 .map(JsonValue::asString)
                 .map(JsonString::value)
                 .forEach(builder::addSize));
         icon.stringValue("theme")
-                .map(value -> value.toUpperCase(Locale.ROOT))
-                .map(McpIconTheme::valueOf)
+                .map(value -> switch (value.toLowerCase(Locale.ROOT)) {
+                    case "light" -> McpIconTheme.LIGHT;
+                    case "dark" -> McpIconTheme.DARK;
+                    default -> throw new IllegalArgumentException("Unsupported icon theme: " + value);
+                })
                 .ifPresent(builder::theme);
         return builder.build();
     }
 
+    private void addIcons(JsonObject.Builder builder, McpIcons component) {
+        List<JsonValue> values = component.icons().stream()
+                .map(this::toJson)
+                .map(JsonValue.class::cast)
+                .toList();
+        if (!values.isEmpty()) {
+            builder.setValues("icons", values);
+        }
+    }
+
     private JsonObject toJson(McpIcon icon) {
-        JsonObject.Builder builder = JsonObject.builder().set("src", icon.src());
+        JsonObject.Builder builder = JsonObject.builder().set("src", icon.source());
         icon.mediaType().ifPresent(mediaType -> builder.set("mimeType", mediaType.text()));
         if (!icon.sizes().isEmpty()) {
             builder.setStrings("sizes", icon.sizes());
         }
-        icon.theme().ifPresent(theme -> builder.set("theme", theme.text()));
+        icon.theme()
+                .filter(theme -> theme != McpIconTheme.UNSPECIFIED)
+                .ifPresent(theme -> builder.set("theme", theme.text()));
         return builder.build();
     }
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpPrompt.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpPrompt.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 /**
  * MCP Prompt.
  */
-public interface McpPrompt {
+public interface McpPrompt extends McpIcons {
     /**
      * Prompt name.
      *
@@ -59,4 +59,5 @@ public interface McpPrompt {
     default Optional<String> title() {
         return Optional.empty();
     }
+
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpPromptConfigBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpPromptConfigBlueprint.java
@@ -62,4 +62,12 @@ interface McpPromptConfigBlueprint {
      * @return the prompt title
      */
     Optional<String> title();
+
+    /**
+     * Icons for this prompt.
+     *
+     * @return icons
+     */
+    @Option.Singular
+    List<McpIcon> icons();
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpPromptImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpPromptImpl.java
@@ -49,4 +49,9 @@ final class McpPromptImpl implements McpPrompt {
     public Optional<String> title() {
         return config.title();
     }
+
+    @Override
+    public List<McpIcon> icons() {
+        return config.icons();
+    }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResource.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResource.java
@@ -22,7 +22,7 @@ import io.helidon.common.media.type.MediaType;
 /**
  * MCP Resource.
  */
-public interface McpResource {
+public interface McpResource extends McpIcons {
     /**
      * Resource URI.
      *
@@ -67,4 +67,5 @@ public interface McpResource {
     default Optional<String> title() {
         return Optional.empty();
     }
+
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceConfigBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceConfigBlueprint.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.extensions.mcp.server;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -55,6 +56,14 @@ interface McpResourceConfigBlueprint {
      * @return type
      */
     MediaType mediaType();
+
+    /**
+     * Icons for this resource.
+     *
+     * @return icons
+     */
+    @Option.Singular
+    List<McpIcon> icons();
 
     /**
      * Resource reader.

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceImpl.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.extensions.mcp.server;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.helidon.common.media.type.MediaType;
@@ -54,5 +55,10 @@ final class McpResourceImpl implements McpResource {
     @Override
     public Optional<String> title() {
         return config.title();
+    }
+
+    @Override
+    public List<McpIcon> icons() {
+        return config.icons();
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceLinkContent.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceLinkContent.java
@@ -22,7 +22,7 @@ import io.helidon.common.media.type.MediaType;
 /**
  * MCP resource link content.
  */
-interface McpResourceLinkContent extends McpContent {
+interface McpResourceLinkContent extends McpContent, McpIcons {
     /**
      * Resource URI.
      *

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceTemplate.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpResourceTemplate.java
@@ -67,6 +67,11 @@ class McpResourceTemplate implements McpResource {
         return delegate.title();
     }
 
+    @Override
+    public List<McpIcon> icons() {
+        return delegate.icons();
+    }
+
     boolean matches(String uri) {
         return pattern.get().matcher(uri).matches();
     }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpServerConfigBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpServerConfigBlueprint.java
@@ -33,7 +33,7 @@ import static io.helidon.extensions.mcp.server.McpSampling.DEFAULT_MAX_TOOL_ITER
 @Prototype.IncludeDefaultMethods
 @Prototype.CustomMethods(McpServerFeatureSupport.class)
 @Prototype.Configured(McpServerConfigBlueprint.CONFIG_ROOT)
-interface McpServerConfigBlueprint extends Prototype.Factory<McpServerFeature> {
+interface McpServerConfigBlueprint extends Prototype.Factory<McpServerFeature>, McpIcons {
     String CONFIG_ROOT = "mcp.server";
 
     /**
@@ -80,6 +80,16 @@ interface McpServerConfigBlueprint extends Prototype.Factory<McpServerFeature> {
     default Optional<String> websiteUrl() {
         return Optional.empty();
     }
+
+    /**
+     * Icons for this server.
+     *
+     * @return icons
+     */
+    @Override
+    @Option.Singular
+    @Option.Configured
+    List<McpIcon> icons();
 
     /**
      * Enable stateless mode. MCP client are not required to go

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpTool.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpTool.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 /**
  * MCP Tool.
  */
-public interface McpTool {
+public interface McpTool extends McpIcons {
     /**
      * Tool name.
      *
@@ -82,4 +82,5 @@ public interface McpTool {
     default Optional<String> outputSchema() {
         return Optional.empty();
     }
+
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpToolConfigBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpToolConfigBlueprint.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.extensions.mcp.server;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -74,6 +75,14 @@ interface McpToolConfigBlueprint {
      * @return the tool output schema
      */
     Optional<String> outputSchema();
+
+    /**
+     * Icons for this tool.
+     *
+     * @return icons
+     */
+    @Option.Singular
+    List<McpIcon> icons();
 
     /**
      * Tool execution.

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpToolImpl.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpToolImpl.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.extensions.mcp.server;
 
+import java.util.List;
 import java.util.Optional;
 
 final class McpToolImpl implements McpTool {
@@ -57,5 +58,10 @@ final class McpToolImpl implements McpTool {
     @Override
     public Optional<String> outputSchema() {
         return config.outputSchema();
+    }
+
+    @Override
+    public List<McpIcon> icons() {
+        return config.icons();
     }
 }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpToolResourceLinkContentBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpToolResourceLinkContentBlueprint.java
@@ -26,10 +26,11 @@ import io.helidon.builder.api.Prototype;
 @Prototype.Blueprint
 interface McpToolResourceLinkContentBlueprint extends McpResourceLinkContent, McpToolContent {
     /**
-     * Optional icons for this resource link.
+     * Icons for this resource link.
      *
      * @return icons
      */
+    @Override
     @Option.Singular
     List<McpIcon> icons();
 }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/ConfigurationTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/ConfigurationTest.java
@@ -17,8 +17,10 @@
 package io.helidon.extensions.mcp.server;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 
+import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 
@@ -30,6 +32,7 @@ import static io.helidon.extensions.mcp.server.McpPagination.DEFAULT_PAGE_SIZE;
 import static io.helidon.extensions.mcp.server.McpSampling.DEFAULT_MAX_TOOL_ITERATIONS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class ConfigurationTest {
@@ -41,6 +44,13 @@ class ConfigurationTest {
 
         assertThat(config.path(), is("/path"));
         assertThat(config.version(), is("1.0.0"));
+        assertThat(config.icons().size(), is(2));
+        McpIcon icon = config.icons().getFirst();
+        assertThat(icon.source(), is("https://example.com/server.svg"));
+        assertThat(icon.mediaType().orElseThrow(), is(MediaTypes.create("image/svg+xml")));
+        assertThat(icon.sizes(), is(List.of("48x48", "96x96")));
+        assertThat(icon.theme().orElseThrow(), is(McpIconTheme.DARK));
+        assertThat(config.icons().get(1).source(), is("data:image/png;base64,iVBORw0KGgo="));
         assertThat(config.name(), is("helidon-mcp-server"));
         assertThat(config.description().orElseThrow(), is("Helidon MCP server"));
         assertThat(config.websiteUrl().orElseThrow(), is("https://example.com/mcp"));
@@ -64,6 +74,7 @@ class ConfigurationTest {
 
         assertThat(config.path(), is("/mcp"));
         assertThat(config.version(), is("0.0.1"));
+        assertThat(config.icons(), is(List.of()));
         assertThat(config.name(), is("mcp-server"));
         assertThat(config.websiteUrl().isEmpty(), is(true));
         assertThat(config.description().isEmpty(), is(true));
@@ -78,6 +89,25 @@ class ConfigurationTest {
         assertThat(config.maxSamplingToolIterations(), is(DEFAULT_MAX_TOOL_ITERATIONS));
         assertThat(config.maxSessionCount(), is(1000));
         assertThat(config.maxRequestsPerSession(), is(1000));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            "icon.svg",
+            "not a uri",
+            "data://example.com/icon,abc",
+            "data:/image/png,abc",
+            "file:///tmp/icon.svg",
+            "javascript:alert(1)"
+    })
+    void testConfigurationInvalidIconSource(String source) {
+        Config config = Config.just(ConfigSources.create(Map.of("source", source)));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                           () -> McpIcon.create(config));
+
+        assertThat(exception.getMessage(), is("Icon source must be a valid HTTP(S) URL or data URI"));
     }
 
     @ParameterizedTest

--- a/server/src/test/java/io/helidon/extensions/mcp/server/ConfigurationTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/ConfigurationTest.java
@@ -98,6 +98,8 @@ class ConfigurationTest {
             "not a uri",
             "data:image/png,not-base64",
             "data:image/png;base64,@@@@",
+            "data:image/;base64,AAAA",
+            "data:image/png;broken;base64,AAAA",
             "data://example.com/icon,abc",
             "data:/image/png,abc",
             "file:///tmp/icon.svg",

--- a/server/src/test/java/io/helidon/extensions/mcp/server/ConfigurationTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/ConfigurationTest.java
@@ -96,6 +96,8 @@ class ConfigurationTest {
             "",
             "icon.svg",
             "not a uri",
+            "data:image/png,not-base64",
+            "data:image/png;base64,@@@@",
             "data://example.com/icon,abc",
             "data:/image/png,abc",
             "file:///tmp/icon.svg",

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpElicitationTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpElicitationTest.java
@@ -62,7 +62,7 @@ class McpElicitationTest {
                   "result": {
                     "action": "accept",
                     "content": {
-                      "secret": "must-not-be-exposed"
+                      "marker": "ignored-content"
                     }
                   }
                 }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpIconTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpIconTest.java
@@ -72,8 +72,12 @@ class McpIconTest {
     @ValueSource(strings = {
             "data:;base64,AA==",
             "data:;base64,+w==",
+            "data:;charset=utf-8;base64,AA==",
             "data:image/png;base64,AQ%3D%3D",
-            "data:image/png;charset=utf-8;BASE64,iVBORw0KGgo="
+            "data:image/png;charset=utf-8;BASE64,iVBORw0KGgo=",
+            "data:image/svg+xml;profile=a%2Fb;base64,PHN2Zy8+",
+            "data:application/vnd.example.icon+png;name=small%20icon;base64,AAAA",
+            "data:image/png;base64=1;base64,AAAA"
     })
     void acceptsValidDataSources(String source) {
         assertThat(McpIcon.builder().source(source).build().source(), is(source));
@@ -105,6 +109,18 @@ class McpIconTest {
             "data:image/png;base64=1,AAAA",
             "data:image/png;base64;charset=utf-8,AAAA",
             "data:image;base64,AAAA",
+            "data:/png;base64,AAAA",
+            "data:image/;base64,AAAA",
+            "data:image/png/extra;base64,AAAA",
+            "data:image/png;;base64,AAAA",
+            "data:image/png;broken;base64,AAAA",
+            "data:image/png;=value;base64,AAAA",
+            "data:image/png;name=;base64,AAAA",
+            "data:image/png;name=a=b;base64,AAAA",
+            "data:image/png;name=a/b;base64,AAAA",
+            "data:image/png;name=%0A;base64,AAAA",
+            "data:image/png;name=%80;base64,AAAA",
+            "data:image/png;base64;base64,AAAA",
             "data:image/png;base64,AQ%3",
             "data://example.com/icon,abc",
             "data:/image/png,abc",

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpIconTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpIconTest.java
@@ -68,6 +68,17 @@ class McpIconTest {
         assertThat(metadata, is("data:image/png;base64,iVBORw0KGgo=|true|true|true"));
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "data:;base64,AA==",
+            "data:;base64,+w==",
+            "data:image/png;base64,AQ%3D%3D",
+            "data:image/png;charset=utf-8;BASE64,iVBORw0KGgo="
+    })
+    void acceptsValidDataSources(String source) {
+        assertThat(McpIcon.builder().source(source).build().source(), is(source));
+    }
+
     @Test
     void keepsSizesImmutable() {
         McpIcon icon = McpIcon.builder()
@@ -87,6 +98,14 @@ class McpIconTest {
             "https://",
             "https:/icon.svg",
             "data:image/png;base64,",
+            "data:image/png,not-base64",
+            "data:image/png;base64,@@@@",
+            "data:image/png;base64,A",
+            "data:image/png;base64,AA=A",
+            "data:image/png;base64=1,AAAA",
+            "data:image/png;base64;charset=utf-8,AAAA",
+            "data:image;base64,AAAA",
+            "data:image/png;base64,AQ%3",
             "data://example.com/icon,abc",
             "data:/image/png,abc",
             "file:///tmp/icon.svg",

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpIconTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpIconTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.server;
+
+import java.util.List;
+
+import io.helidon.common.media.type.MediaTypes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class McpIconTest {
+    @Test
+    void defaultsComponentIconsToEmpty() {
+        McpIcons component = new McpIcons() {
+        };
+
+        assertThat(component.icons(), is(List.of()));
+    }
+
+    @Test
+    void buildsFullIconMetadata() {
+        McpIcon icon = McpIcon.builder()
+                .source("https://example.com/icon.svg")
+                .mediaType(MediaTypes.create("image/svg+xml"))
+                .addSize("48x48")
+                .addSize("96x96")
+                .theme(McpIconTheme.DARK)
+                .build();
+
+        String metadata = String.join("|",
+                                      icon.source(),
+                                      icon.mediaType().orElseThrow().text(),
+                                      String.join(",", icon.sizes()),
+                                      icon.theme().orElseThrow().text());
+        assertThat(metadata, is("https://example.com/icon.svg|image/svg+xml|48x48,96x96|dark"));
+    }
+
+    @Test
+    void buildsMinimalIconMetadata() {
+        McpIcon icon = McpIcon.builder()
+                .source("data:image/png;base64,iVBORw0KGgo=")
+                .build();
+
+        String metadata = String.join("|",
+                                      icon.source(),
+                                      Boolean.toString(icon.mediaType().isEmpty()),
+                                      Boolean.toString(icon.sizes().isEmpty()),
+                                      Boolean.toString(icon.theme().isEmpty()));
+        assertThat(metadata, is("data:image/png;base64,iVBORw0KGgo=|true|true|true"));
+    }
+
+    @Test
+    void keepsSizesImmutable() {
+        McpIcon icon = McpIcon.builder()
+                .source("https://example.com/icon.svg")
+                .addSize("any")
+                .build();
+
+        assertThrows(UnsupportedOperationException.class, () -> icon.sizes().add("48x48"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            " ",
+            "icon.svg",
+            "not a uri",
+            "https://",
+            "https:/icon.svg",
+            "data:image/png;base64,",
+            "data://example.com/icon,abc",
+            "data:/image/png,abc",
+            "file:///tmp/icon.svg",
+            "javascript:alert(1)"
+    })
+    void rejectsInvalidSources(String source) {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                           () -> McpIcon.builder().source(source));
+
+        assertThat(exception.getMessage(), is("Icon source must be a valid HTTP(S) URL or data URI"));
+    }
+}

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3Test.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV3Test.java
@@ -200,7 +200,7 @@ class McpJsonSerializerV3Test {
         JsonObject params = JsonObject.builder()
                 .set("action", action.text())
                 .set("content", JsonObject.builder()
-                        .set("secret", "must-not-be-exposed")
+                        .set("marker", "ignored-content")
                         .build())
                 .build();
         JsonObject elicitation = MJS.createJsonRpcResultResponse(1, params);

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4Test.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4Test.java
@@ -22,6 +22,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import io.helidon.common.media.type.MediaTypes;
 import io.helidon.json.JsonArray;
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonParser;
@@ -35,6 +36,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import static io.helidon.extensions.mcp.server.McpMetadata.META;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
@@ -45,12 +47,179 @@ class McpJsonSerializerV4Test {
             McpJsonSerializer.create(McpProtocolVersion.VERSION_2025_11_25);
     private static final McpJsonSerializer LEGACY_SERIALIZER =
             McpJsonSerializer.create(McpProtocolVersion.VERSION_2025_06_18);
+    private static final McpIcon FULL_ICON = McpIcon.builder()
+            .source("https://example.com/icon.svg")
+            .mediaType(MediaTypes.create("image/svg+xml"))
+            .addSize("48x48")
+            .addSize("96x96")
+            .theme(McpIconTheme.DARK)
+            .build();
+    private static final McpIcon MINIMAL_ICON = McpIcon.builder()
+            .source("data:image/png;base64,iVBORw0KGgo=")
+            .build();
+    private static final JsonArray EXPECTED_ICONS = JsonParser.create("""
+            [
+              {
+                "src": "https://example.com/icon.svg",
+                "mimeType": "image/svg+xml",
+                "sizes": ["48x48", "96x96"],
+                "theme": "dark"
+              },
+              {
+                "src": "data:image/png;base64,iVBORw0KGgo="
+              }
+            ]
+            """).readJsonArray();
+    private static final JsonObject EXPECTED_TOOL = JsonObject.builder()
+            .set("name", "tool")
+            .set("description", "description")
+            .set("inputSchema", McpJsonSerializerV1.EMPTY_OBJECT_SCHEMA)
+            .set("annotations", JsonObject.builder()
+                    .set("title", "annotation title")
+                    .set("destructiveHint", false)
+                    .set("idempotentHint", true)
+                    .set("openWorldHint", false)
+                    .set("readOnlyHint", true)
+                    .build())
+            .set("title", "tool title")
+            .set("outputSchema", McpJsonSerializerV1.EMPTY_OBJECT_SCHEMA)
+            .set("icons", EXPECTED_ICONS)
+            .build();
+    private static final JsonObject EXPECTED_PROMPT = JsonObject.builder()
+            .set("name", "prompt")
+            .set("description", "description")
+            .set("arguments", JsonArray.empty())
+            .set("title", "prompt title")
+            .set("icons", EXPECTED_ICONS)
+            .build();
+    private static final JsonObject EXPECTED_RESOURCE = JsonObject.builder()
+            .set("uri", "https://example.com/resource")
+            .set("name", "resource")
+            .set("description", "description")
+            .set("mimeType", MediaTypes.TEXT_PLAIN.text())
+            .set("title", "resource title")
+            .set("icons", EXPECTED_ICONS)
+            .build();
+    private static final JsonObject EXPECTED_RESOURCE_TEMPLATE = JsonObject.builder()
+            .set("uriTemplate", "https://example.com/resource/{id}")
+            .set("name", "resource")
+            .set("description", "description")
+            .set("mimeType", MediaTypes.TEXT_PLAIN.text())
+            .set("icons", EXPECTED_ICONS)
+            .build();
+
+    @Test
+    void serializesToolIcons() {
+        JsonObject response = SERIALIZER.listTools(new McpPage<>(List.of(tool())));
+
+        assertThat(component(response, "tools"), is(EXPECTED_TOOL));
+    }
+
+    @Test
+    void serializesPromptIcons() {
+        JsonObject response = SERIALIZER.listPrompts(new McpPage<>(List.of(prompt())));
+
+        assertThat(component(response, "prompts"), is(EXPECTED_PROMPT));
+    }
+
+    @Test
+    void serializesResourceIcons() {
+        JsonObject response = SERIALIZER.listResources(new McpPage<>(List.of(resource("https://example.com/resource"))));
+
+        assertThat(component(response, "resources"), is(EXPECTED_RESOURCE));
+    }
+
+    @Test
+    void serializesResourceTemplateIcons() {
+        McpResourceTemplate template = new McpResourceTemplate(resource("https://example.com/resource/{id}"));
+        JsonObject response = SERIALIZER.listResourceTemplates(new McpPage<>(List.of(template)));
+
+        assertThat(component(response, "resourceTemplates"), is(EXPECTED_RESOURCE_TEMPLATE));
+    }
+
+    @Test
+    void omitsEmptyIconMetadata() {
+        McpToolConfig config = McpToolConfig.builder()
+                .name("tool")
+                .description("description")
+                .schema("")
+                .icons(List.of())
+                .tool(request -> McpToolResult.create())
+                .build();
+        JsonObject response = SERIALIZER.listTools(new McpPage<>(List.of(new McpToolImpl(config))));
+
+        assertThat(component(response, "tools").containsKey("icons"), is(false));
+    }
+
+    @Test
+    void serializesThemeIndependentlyOfDefaultLocale() {
+        McpPromptConfig config = McpPromptConfig.builder()
+                .name("prompt")
+                .description("description")
+                .addIcon(icon -> icon.source("https://example.com/light.svg").theme(McpIconTheme.LIGHT))
+                .prompt(request -> McpPromptResult.create())
+                .build();
+        Locale defaultLocale = Locale.getDefault();
+        String theme;
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            JsonObject response = SERIALIZER.listPrompts(new McpPage<>(List.of(new McpPromptImpl(config))));
+            theme = component(response, "prompts")
+                    .arrayValue("icons")
+                    .flatMap(icons -> icons.get(0))
+                    .map(JsonValue::asObject)
+                    .flatMap(icon -> icon.stringValue("theme"))
+                    .orElseThrow();
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
+
+        assertThat(theme, is("light"));
+    }
+
+    @Test
+    void omitsUnspecifiedIconTheme() {
+        McpPromptConfig config = McpPromptConfig.builder()
+                .name("prompt")
+                .description("description")
+                .addIcon(icon -> icon.source("https://example.com/icon.svg").theme(McpIconTheme.UNSPECIFIED))
+                .prompt(request -> McpPromptResult.create())
+                .build();
+        JsonObject response = SERIALIZER.listPrompts(new McpPage<>(List.of(new McpPromptImpl(config))));
+        JsonObject icon = component(response, "prompts")
+                .arrayValue("icons")
+                .flatMap(icons -> icons.get(0))
+                .map(JsonValue::asObject)
+                .orElseThrow();
+
+        assertThat(icon.containsKey("theme"), is(false));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = McpProtocolVersion.class,
+                names = {"VERSION_2024_11_05", "VERSION_2025_03_26", "VERSION_2025_06_18"})
+    void omitsIconsFromLegacyProtocolVersions(McpProtocolVersion version) {
+        McpJsonSerializer serializer = McpJsonSerializer.create(version);
+        McpResource resource = resource("https://example.com/resource");
+        McpResourceTemplate template = new McpResourceTemplate(resource("https://example.com/resource/{id}"));
+
+        List<Boolean> iconProperties = List.of(
+                component(serializer.listTools(new McpPage<>(List.of(tool()))), "tools").containsKey("icons"),
+                component(serializer.listPrompts(new McpPage<>(List.of(prompt()))), "prompts").containsKey("icons"),
+                component(serializer.listResources(new McpPage<>(List.of(resource))), "resources").containsKey("icons"),
+                component(serializer.listResourceTemplates(new McpPage<>(List.of(template))),
+                          "resourceTemplates").containsKey("icons"));
+
+        assertThat(iconProperties, everyItem(is(false)));
+    }
 
     @Test
     void serializesServerMetadata() {
         McpServerConfig config = McpServerConfig.builder()
                 .description("Helidon MCP server")
                 .websiteUrl("https://example.com/mcp")
+                .addIcon(FULL_ICON)
+                .addIcon(MINIMAL_ICON)
                 .buildPrototype();
         JsonObject response = SERIALIZER.createJsonInitializeResponse(Set.of(), config).build();
         JsonObject expected = JsonObject.builder()
@@ -58,6 +227,7 @@ class McpJsonSerializerV4Test {
                 .set("version", "0.0.1")
                 .set("description", "Helidon MCP server")
                 .set("websiteUrl", "https://example.com/mcp")
+                .set("icons", EXPECTED_ICONS)
                 .build();
 
         assertThat(response.objectValue("serverInfo").orElseThrow(), is(expected));
@@ -82,6 +252,7 @@ class McpJsonSerializerV4Test {
         McpServerConfig config = McpServerConfig.builder()
                 .description("Helidon MCP server")
                 .websiteUrl("https://example.com/mcp")
+                .addIcon(FULL_ICON)
                 .buildPrototype();
         JsonObject response = McpJsonSerializer.create(version)
                 .createJsonInitializeResponse(Set.of(), config)
@@ -154,7 +325,7 @@ class McpJsonSerializerV4Test {
         JsonObject result = JsonObject.builder()
                 .set("action", action.text())
                 .set("content", JsonObject.builder()
-                        .set("secret", "must-not-be-exposed")
+                        .set("marker", "ignored-content")
                         .build())
                 .build();
         JsonObject clientResponse = SERIALIZER.createJsonRpcResultResponse(1, result);
@@ -528,6 +699,37 @@ class McpJsonSerializerV4Test {
         assertThat(replayedBinaryResource.objectValue("resource").orElseThrow()
                            .objectValue(META).isEmpty(),
                    is(true));
+    }
+
+    @Test
+    void rejectsUnspecifiedWireIconTheme() {
+        JsonObject wireResponse = response("""
+                {
+                  "type": "tool_result",
+                  "toolUseId": "call-1",
+                  "content": [
+                    {
+                      "type": "resource_link",
+                      "uri": "https://example.com/resource",
+                      "name": "resource",
+                      "icons": [
+                        {
+                          "src": "https://example.com/icon.svg",
+                          "theme": "unspecified"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """, "endTurn", "user");
+        McpJsonSerializerV4 serializer = (McpJsonSerializerV4) SERIALIZER;
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                           () -> serializer.parseContent(wireResponse
+                                                                   .objectValue("result").orElseThrow()
+                                                                   .objectValue("content").orElseThrow()));
+
+        assertThat(exception.getMessage(), is("Unsupported icon theme: unspecified"));
     }
 
     @Test
@@ -1462,5 +1664,57 @@ class McpJsonSerializerV4Test {
                 .set("id", 1)
                 .set("result", result)
                 .build();
+    }
+
+    private static JsonObject component(JsonObject response, String property) {
+        JsonArray components = response.arrayValue(property).orElseThrow();
+        return components.get(0).map(JsonValue::asObject).orElseThrow();
+    }
+
+    private static McpTool tool() {
+        McpToolConfig config = McpToolConfig.builder()
+                .name("tool")
+                .description("description")
+                .schema("")
+                .title("tool title")
+                .annotations(McpToolAnnotations.builder()
+                                     .title("annotation title")
+                                     .destructiveHint(false)
+                                     .idempotentHint(true)
+                                     .openWorldHint(false)
+                                     .readOnlyHint(true)
+                                     .build())
+                .outputSchema("")
+                .addIcon(FULL_ICON)
+                .addIcon(MINIMAL_ICON)
+                .tool(request -> McpToolResult.create())
+                .build();
+        return new McpToolImpl(config);
+    }
+
+    private static McpPrompt prompt() {
+        McpPromptConfig config = McpPromptConfig.builder()
+                .name("prompt")
+                .description("description")
+                .title("prompt title")
+                .addIcon(FULL_ICON)
+                .addIcon(MINIMAL_ICON)
+                .prompt(request -> McpPromptResult.create())
+                .build();
+        return new McpPromptImpl(config);
+    }
+
+    private static McpResource resource(String uri) {
+        McpResourceConfig config = McpResourceConfig.builder()
+                .uri(uri)
+                .name("resource")
+                .description("description")
+                .title("resource title")
+                .mediaType(MediaTypes.TEXT_PLAIN)
+                .addIcon(FULL_ICON)
+                .addIcon(MINIMAL_ICON)
+                .resource(request -> McpResourceResult.create())
+                .build();
+        return new McpResourceImpl(config);
     }
 }

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpPromptTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpPromptTest.java
@@ -49,6 +49,7 @@ class McpPromptTest {
         assertThat(prompt.name(), is("name"));
         assertThat(prompt.title().isEmpty(), is(true));
         assertThat(prompt.description(), is("description"));
+        assertThat(config.icons().isEmpty(), is(true));
     }
 
     @Test

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpResourceTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpResourceTest.java
@@ -41,6 +41,7 @@ class McpResourceTest {
         assertThat(resource.title().isEmpty(), is(true));
         assertThat(resource.mediaType(), is(MediaTypes.TEXT_PLAIN));
         assertThat(resource.description(), is("No description available"));
+        assertThat(resource.icons().isEmpty(), is(true));
     }
 
     @Test

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpToolTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpToolTest.java
@@ -53,6 +53,7 @@ class McpToolTest {
         assertThat(tool.title().isEmpty(), is(true));
         assertThat(tool.description(), is("description"));
         assertThat(tool.outputSchema().isPresent(), is(false));
+        assertThat(config.icons().isEmpty(), is(true));
     }
 
     @Test

--- a/server/src/test/resources/application-server.yaml
+++ b/server/src/test/resources/application-server.yaml
@@ -20,6 +20,12 @@ mcp:
     version: "1.0.0"
     description: "Helidon MCP server"
     website-url: "https://example.com/mcp"
+    icons:
+      - source: "https://example.com/server.svg"
+        media-type: "image/svg+xml"
+        sizes: ["48x48", "96x96"]
+        theme: "DARK"
+      - source: "data:image/png;base64,iVBORw0KGgo="
     path: "/path"
     stateless: "true"
     tools-page-size: 10

--- a/tests/codegen/pom.xml
+++ b/tests/codegen/pom.xml
@@ -42,6 +42,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.helidon.codegen</groupId>
+            <artifactId>helidon-codegen-class-model</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/tests/codegen/src/test/java/io/helidon/extensions/mcp/codegen/McpCodegenUtilTest.java
+++ b/tests/codegen/src/test/java/io/helidon/extensions/mcp/codegen/McpCodegenUtilTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.codegen;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.List;
+
+import io.helidon.codegen.classmodel.ClassModel;
+import io.helidon.common.types.Annotated;
+import io.helidon.common.types.Annotation;
+import io.helidon.extensions.mcp.server.McpIcons;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.addIcons;
+import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_ICON_ANNOTATION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
+
+class McpCodegenUtilTest {
+    @Test
+    void cachesGeneratedIcons() throws IOException {
+        String source = render(Annotation.create(MCP_ICON_ANNOTATION, "https://example.com/icon.svg"));
+
+        assertThat(source, containsString("private static final List<McpIcon> ICONS = List.of("));
+        assertThat(source, containsString("return ICONS;"));
+        assertThat(source.lastIndexOf("McpIcon.builder()"), lessThan(source.indexOf("public List<McpIcon> icons()")));
+    }
+
+    @Test
+    void generatesSharedEmptyListWithoutCacheField() throws IOException {
+        String source = render();
+
+        assertThat(source, not(containsString("static final List<McpIcon> ICONS")));
+        assertThat(source, containsString("return List.of();"));
+    }
+
+    private static String render(Annotation... annotations) throws IOException {
+        Annotated component = new Annotated() {
+            @Override
+            public List<Annotation> annotations() {
+                return List.of(annotations);
+            }
+
+            @Override
+            public List<Annotation> inheritedAnnotations() {
+                return List.of();
+            }
+        };
+        StringWriter writer = new StringWriter();
+        ClassModel.builder()
+                .packageName("example")
+                .name("Generated")
+                .addInnerClass(innerClass -> {
+                    innerClass.name("Component")
+                            .addInterface(McpIcons.class);
+                    addIcons(innerClass, component);
+                })
+                .build()
+                .write(writer);
+        return writer.toString();
+    }
+}

--- a/tests/codegen/src/test/java/io/helidon/extensions/mcp/codegen/McpTypesTest.java
+++ b/tests/codegen/src/test/java/io/helidon/extensions/mcp/codegen/McpTypesTest.java
@@ -39,6 +39,8 @@ import io.helidon.extensions.mcp.server.McpCompletionResult;
 import io.helidon.extensions.mcp.server.McpCompletionType;
 import io.helidon.extensions.mcp.server.McpElicitation;
 import io.helidon.extensions.mcp.server.McpFeatures;
+import io.helidon.extensions.mcp.server.McpIcon;
+import io.helidon.extensions.mcp.server.McpIconTheme;
 import io.helidon.extensions.mcp.server.McpLogger;
 import io.helidon.extensions.mcp.server.McpParameters;
 import io.helidon.extensions.mcp.server.McpProgress;
@@ -129,6 +131,8 @@ class McpTypesTest {
         checkField(toCheck, checked, fields, "MCP_COMPLETION", Mcp.Completion.class);
         checkField(toCheck, checked, fields, "MCP_DESCRIPTION", Mcp.Description.class);
         checkField(toCheck, checked, fields, "MCP_REQUIRED", Mcp.Required.class);
+        checkField(toCheck, checked, fields, "MCP_ICON_ANNOTATION", Mcp.Icon.class);
+        checkField(toCheck, checked, fields, "MCP_ICONS", Mcp.Icons.class);
         checkField(toCheck, checked, fields, "MCP_ROOTS", McpRoots.class);
         checkField(toCheck, checked, fields, "MCP_LOGGER", McpLogger.class);
         checkField(toCheck, checked, fields, "MCP_ROLE_ENUM", McpRole.class);
@@ -136,6 +140,8 @@ class McpTypesTest {
         checkField(toCheck, checked, fields, "MCP_FEATURES", McpFeatures.class);
         checkField(toCheck, checked, fields, "MCP_PROGRESS", McpProgress.class);
         checkField(toCheck, checked, fields, "MCP_SAMPLING", McpSampling.class);
+        checkField(toCheck, checked, fields, "MCP_ICON", McpIcon.class);
+        checkField(toCheck, checked, fields, "MCP_ICON_THEME", McpIconTheme.class);
         checkField(toCheck, checked, fields, "MCP_TOOL_INTERFACE", McpTool.class);
         checkField(toCheck, checked, fields, "MCP_PARAMETERS", McpParameters.class);
         checkField(toCheck, checked, fields, "MCP_TOOL_RESULT", McpToolResult.class);
@@ -167,6 +173,7 @@ class McpTypesTest {
         checkField(toCheck, checked, fields, "SCOPE_ANNOTATION", Service.Scope.class);
         checkField(toCheck, checked, fields, "SERVICE_SINGLETON", Service.Singleton.class);
         checkField(toCheck, checked, fields, "LIST_STRING", List.class);
+        checkField(toCheck, checked, fields, "LIST_MCP_ICON", List.class);
         checkField(toCheck, checked, fields, "LIST_MCP_PROMPT_ARGUMENT", List.class);
         checkField(toCheck, checked, fields, "MCP_COMPLETION_RESULT", McpCompletionResult.class);
         checkField(toCheck, checked, fields, "MCP_TOOL_REQUEST", McpToolRequest.class);

--- a/tests/declarative/src/main/java/io/helidon/extensions/mcp/tests/declarative/McpIconMetadataServer.java
+++ b/tests/declarative/src/main/java/io/helidon/extensions/mcp/tests/declarative/McpIconMetadataServer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.tests.declarative;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.extensions.mcp.server.Mcp;
+import io.helidon.extensions.mcp.server.McpIconTheme;
+
+@Mcp.Server("icon-metadata")
+@Mcp.Icon(
+        value = "https://example.com/server.svg",
+        mimeType = "image/svg+xml",
+        sizes = "any",
+        theme = McpIconTheme.LIGHT)
+@Mcp.Icon("data:image/png;base64,iVBORw0KGgo=")
+@Mcp.Path("/icon-metadata")
+@Mcp.Stateless
+class McpIconMetadataServer {
+    @Mcp.Tool("Tool with icons")
+    @Mcp.Icon(
+            value = "https://example.com/tool.svg",
+            mimeType = "image/svg+xml",
+            sizes = {"48x48", "96x96"},
+            theme = McpIconTheme.DARK)
+    @Mcp.Icon("data:image/png;base64,iVBORw0KGgo=")
+    String tool() {
+        return "tool";
+    }
+
+    @Mcp.Prompt("Prompt with an icon")
+    @Mcp.Icon(
+            value = "https://example.com/prompt.png",
+            mimeType = "image/png",
+            theme = McpIconTheme.LIGHT)
+    String prompt() {
+        return "prompt";
+    }
+
+    @Mcp.Resource(
+            uri = "https://example.com/resource",
+            mediaType = MediaTypes.TEXT_PLAIN_VALUE,
+            description = "Resource with an icon")
+    @Mcp.Icon("https://example.com/resource.svg")
+    String resource() {
+        return "resource";
+    }
+
+    @Mcp.Resource(
+            uri = "https://example.com/resource/{id}",
+            mediaType = MediaTypes.TEXT_PLAIN_VALUE,
+            description = "Resource template with an icon")
+    @Mcp.Icon(
+            value = "https://example.com/template.svg",
+            sizes = "any")
+    String resourceTemplate(String id) {
+        return id;
+    }
+}

--- a/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/McpIconAnnotationTest.java
+++ b/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/McpIconAnnotationTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.mcp.tests.declarative;
+
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonParser;
+import io.helidon.json.JsonValue;
+import io.helidon.webclient.jsonrpc.JsonRpcClient;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.testing.junit5.ServerTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@ServerTest
+class McpIconAnnotationTest {
+    private static final JsonArray SERVER_ICONS = JsonParser.create("""
+            [
+              {
+                "src": "https://example.com/server.svg",
+                "mimeType": "image/svg+xml",
+                "sizes": ["any"],
+                "theme": "light"
+              },
+              {
+                "src": "data:image/png;base64,iVBORw0KGgo="
+              }
+            ]
+            """).readJsonArray();
+    private static final JsonArray TOOL_ICONS = JsonParser.create("""
+            [
+              {
+                "src": "https://example.com/tool.svg",
+                "mimeType": "image/svg+xml",
+                "sizes": ["48x48", "96x96"],
+                "theme": "dark"
+              },
+              {
+                "src": "data:image/png;base64,iVBORw0KGgo="
+              }
+            ]
+            """).readJsonArray();
+    private static final JsonArray PROMPT_ICONS = JsonParser.create("""
+            [
+              {
+                "src": "https://example.com/prompt.png",
+                "mimeType": "image/png",
+                "theme": "light"
+              }
+            ]
+            """).readJsonArray();
+    private static final JsonArray RESOURCE_ICONS = JsonParser.create("""
+            [
+              {
+                "src": "https://example.com/resource.svg"
+              }
+            ]
+            """).readJsonArray();
+    private static final JsonArray TEMPLATE_ICONS = JsonParser.create("""
+            [
+              {
+                "src": "https://example.com/template.svg",
+                "sizes": ["any"]
+              }
+            ]
+            """).readJsonArray();
+
+    private final JsonRpcClient client;
+
+    McpIconAnnotationTest(WebServer server) {
+        this.client = JsonRpcClient.create(config -> config.baseUri("http://localhost:"
+                                                                           + server.port()
+                                                                           + "/icon-metadata"));
+    }
+
+    @Test
+    void generatesServerIcons() {
+        JsonObject clientInfo = JsonObject.builder()
+                .set("name", "test-client")
+                .set("version", "1.0.0")
+                .build();
+
+        try (var response = client.rpcMethod("initialize")
+                .rpcId(1)
+                .param("protocolVersion", "2025-11-25")
+                .param("capabilities", JsonObject.empty())
+                .param("clientInfo", clientInfo)
+                .submit()) {
+            JsonObject serverInfo = response.result()
+                    .map(result -> result.asJsonObject())
+                    .flatMap(result -> result.objectValue("serverInfo"))
+                    .orElseThrow();
+
+            assertThat(serverInfo.arrayValue("icons").orElseThrow(), is(SERVER_ICONS));
+        }
+    }
+
+    @Test
+    void generatesToolIcons() {
+        JsonObject tool = listComponent("tools/list", "tools");
+
+        assertThat(tool.arrayValue("icons").orElseThrow(), is(TOOL_ICONS));
+    }
+
+    @Test
+    void generatesPromptIcons() {
+        JsonObject prompt = listComponent("prompts/list", "prompts");
+
+        assertThat(prompt.arrayValue("icons").orElseThrow(), is(PROMPT_ICONS));
+    }
+
+    @Test
+    void generatesResourceIcons() {
+        JsonObject resource = listComponent("resources/list", "resources");
+
+        assertThat(resource.arrayValue("icons").orElseThrow(), is(RESOURCE_ICONS));
+    }
+
+    @Test
+    void generatesResourceTemplateIcons() {
+        JsonObject template = listComponent("resources/templates/list", "resourceTemplates");
+
+        assertThat(template.arrayValue("icons").orElseThrow(), is(TEMPLATE_ICONS));
+    }
+
+    private JsonObject listComponent(String method, String property) {
+        try (var response = client.rpcMethod(method)
+                .rpcId(1)
+                .submit()) {
+            JsonArray components = response.result()
+                    .map(result -> result.asJsonObject())
+                    .flatMap(result -> result.arrayValue(property))
+                    .orElseThrow();
+            return components.get(0)
+                    .map(JsonValue::asObject)
+                    .orElseThrow();
+        }
+    }
+}

--- a/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/McpSdkAnnotationConfigurationTest.java
+++ b/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/McpSdkAnnotationConfigurationTest.java
@@ -18,7 +18,9 @@ package io.helidon.extensions.mcp.tests.declarative;
 
 import java.time.Duration;
 
+import io.helidon.json.JsonArray;
 import io.helidon.json.JsonObject;
+import io.helidon.json.JsonParser;
 import io.helidon.jsonrpc.core.JsonRpcResult;
 import io.helidon.webclient.jsonrpc.JsonRpcClient;
 import io.helidon.webserver.WebServer;
@@ -35,6 +37,15 @@ import static org.hamcrest.Matchers.is;
 
 @ServerTest
 class McpSdkAnnotationConfigurationTest {
+    private static final JsonArray SERVER_ICONS = JsonParser.create("""
+            [
+              {
+                "src": "https://example.com/server-only.svg",
+                "sizes": ["any"]
+              }
+            ]
+            """).readJsonArray();
+
     private final int port;
     private final JsonRpcClient jsonRpcClient;
 
@@ -81,6 +92,7 @@ class McpSdkAnnotationConfigurationTest {
 
             assertThat(serverInfo.stringValue("description").orElseThrow(), is("Declarative Helidon MCP server"));
             assertThat(serverInfo.stringValue("websiteUrl").orElseThrow(), is("https://example.com/mcp"));
+            assertThat(serverInfo.arrayValue("icons").orElseThrow(), is(SERVER_ICONS));
         }
     }
 }


### PR DESCRIPTION
Fixes #110 

## Summary

Implements MCP icon metadata from SEP-973 for protocol version `2025-11-25`.

- Adds the `McpIcon`, `McpIconTheme`, and `McpIcons` APIs.
- Supports icons for server information, tools, prompts, resources, resource templates, and resource links.
- Supports programmatic builders, Helidon configuration, and repeatable `@Mcp.Icon` annotations.
- Serializes icon metadata only for MCP `2025-11-25`; older protocol versions remain unchanged.
- Supports `src`, MIME type, sizes, and light/dark themes.
- Validates icon sources as HTTP(S) URLs or valid `data:` URIs.
- Documents programmatic, declarative, and configuration usage.
- Replaces scanner-sensitive elicitation test metadata with neutral fixture values.

Specification: https://modelcontextprotocol.io/specification/2025-11-25/schema#icon