### PR TITLE
Add server implementation descriptions

### DIFF
--- a/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegen.java
+++ b/codegen/src/main/java/io/helidon/extensions/mcp/codegen/McpCodegen.java
@@ -37,6 +37,7 @@ import io.helidon.common.types.TypeName;
 import static io.helidon.extensions.mcp.codegen.McpCodegenUtil.generatedTypeName;
 import static io.helidon.extensions.mcp.codegen.McpTypes.HTTP_FEATURE;
 import static io.helidon.extensions.mcp.codegen.McpTypes.HTTP_ROUTING_BUILDER;
+import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_DESCRIPTION;
 import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_PATH;
 import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_PROMPTS_PAGE_SIZE;
 import static io.helidon.extensions.mcp.codegen.McpTypes.MCP_RESOURCES_PAGE_SIZE;
@@ -143,6 +144,12 @@ final class McpCodegen implements CodegenExtension {
                 .addContent("builder.name(")
                 .addContentLiteral(serverName)
                 .addContentLine(");");
+
+        type.findAnnotation(MCP_DESCRIPTION)
+                .flatMap(Annotation::value)
+                .ifPresent(description -> method.addContent("builder.description(")
+                        .addContentLiteral(description)
+                        .addContentLine(");"));
 
         type.findAnnotation(MCP_VERSION)
                 .flatMap(Annotation::value)

--- a/docs/mcp-declarative.md
+++ b/docs/mcp-declarative.md
@@ -60,6 +60,7 @@ class McpServer {
 #### Configuration
 
 - **`@Mcp.Server`**: Defines the class as an MCP server and can override the default server name.
+- **`@Mcp.Description`**: Sets the optional server description.
 - **`@Mcp.Path`**: Sets the HTTP endpoint path for the server.
 - **`@Mcp.Version`**: Establishes the server version.
 - **`@Mcp.WebsiteUrl`**: Sets the optional server website URL.
@@ -68,13 +69,14 @@ class McpServer {
 ```java
 @Mcp.Path("/mcp")
 @Mcp.Version("0.0.1")
+@Mcp.Description("Provides tools and resources for Example")
 @Mcp.WebsiteUrl("https://example.com/mcp")
 @Mcp.Server("MyServer")
 class McpServer {
 }
 ```
 
-The website URL is included in `serverInfo` when the negotiated protocol version is `2025-11-25`.
+The description and website URL are included in `serverInfo` when the negotiated protocol version is `2025-11-25`.
 
 #### Stateless mode
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -45,6 +45,7 @@ class McpServer {
                     .path("/mcp")
                     .version("0.0.1")
                     .name("MyServer")
+                    .description("Provides tools and resources for Example")
                     .websiteUrl("https://example.com/mcp")
                     .build()));
     }
@@ -1442,13 +1443,14 @@ mcp:
   server:
     name: "MyServer"
     version: "0.0.1"
+    description: "Provides tools and resources for Example"
     website-url: "https://example.com/mcp"
     path: "/mcp"
     stateless: true
     max-sampling-tool-iterations: 10
 ```
 
-The optional website URL is included in `serverInfo` when the negotiated protocol version is `2025-11-25`.
+The optional description and website URL are included in `serverInfo` when the negotiated protocol version is `2025-11-25`.
 
 Register the configuration in code:
 

--- a/server/src/main/java/io/helidon/extensions/mcp/server/Mcp.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/Mcp.java
@@ -65,6 +65,10 @@ public final class Mcp {
      * The MCP server can be configured using the following annotations:
      * <ul>
      *     <li>
+     *         {@link io.helidon.extensions.mcp.server.Mcp.Description} -
+     *         Set the optional human-readable MCP server description.
+     *     </li>
+     *     <li>
      *         {@link io.helidon.extensions.mcp.server.Mcp.Version} -
      *         Set the MCP server version. It will be communicated to MCP client when connecting to this server.
      *     </li>
@@ -91,13 +95,13 @@ public final class Mcp {
     }
 
     /**
-     * Annotation to describe a prompt argument.
+     * Annotation to describe an MCP server, prompt argument, or generated JSON schema element.
      */
     @Target({TYPE, METHOD, FIELD, PARAMETER})
     @Retention(RUNTIME)
     public @interface Description {
         /**
-         * Prompt argument description.
+         * Description of the annotated server or element.
          *
          * @return description
          */

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4.java
@@ -48,6 +48,7 @@ class McpJsonSerializerV4 extends McpJsonSerializerV3 {
     @Override
     public JsonObject.Builder serverInfo(McpServerConfig config) {
         JsonObject.Builder builder = super.serverInfo(config);
+        config.description().ifPresent(description -> builder.set("description", description));
         config.websiteUrl().ifPresent(websiteUrl -> builder.set("websiteUrl", websiteUrl));
         return builder;
     }

--- a/server/src/main/java/io/helidon/extensions/mcp/server/McpServerConfigBlueprint.java
+++ b/server/src/main/java/io/helidon/extensions/mcp/server/McpServerConfigBlueprint.java
@@ -64,6 +64,14 @@ interface McpServerConfigBlueprint extends Prototype.Factory<McpServerFeature> {
     String version();
 
     /**
+     * Human-readable description of this server.
+     *
+     * @return server description
+     */
+    @Option.Configured
+    Optional<String> description();
+
+    /**
      * Website URL for this server.
      *
      * @return website URL

--- a/server/src/test/java/io/helidon/extensions/mcp/server/ConfigurationTest.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/ConfigurationTest.java
@@ -41,8 +41,9 @@ class ConfigurationTest {
 
         assertThat(config.path(), is("/path"));
         assertThat(config.version(), is("1.0.0"));
-        assertThat(config.websiteUrl().orElseThrow(), is("https://example.com/mcp"));
         assertThat(config.name(), is("helidon-mcp-server"));
+        assertThat(config.description().orElseThrow(), is("Helidon MCP server"));
+        assertThat(config.websiteUrl().orElseThrow(), is("https://example.com/mcp"));
         assertThat(config.toolsPageSize(), is(10));
         assertThat(config.promptsPageSize(), is(10));
         assertThat(config.resourcesPageSize(), is(10));
@@ -63,8 +64,9 @@ class ConfigurationTest {
 
         assertThat(config.path(), is("/mcp"));
         assertThat(config.version(), is("0.0.1"));
-        assertThat(config.websiteUrl().isEmpty(), is(true));
         assertThat(config.name(), is("mcp-server"));
+        assertThat(config.websiteUrl().isEmpty(), is(true));
+        assertThat(config.description().isEmpty(), is(true));
         assertThat(config.instructions().isEmpty(), is(true));
         assertThat(config.toolsPageSize(), is(DEFAULT_PAGE_SIZE));
         assertThat(config.promptsPageSize(), is(DEFAULT_PAGE_SIZE));
@@ -88,7 +90,7 @@ class ConfigurationTest {
     void testConfigurationNegativePageSizeValues(String key) {
         try {
             var configSource = ConfigSources.create(Map.of(key, "-1"));
-            var config = McpServerConfig.create(Config.just(configSource));
+            McpServerConfig.create(Config.just(configSource));
             fail("Page size with negative value are not allowed and must be checked.");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), is("Page size must be greater than zero"));
@@ -100,7 +102,7 @@ class ConfigurationTest {
     void testConfigurationNegativeSessionPoolSize(String key) {
         try {
             var configSource = ConfigSources.create(Map.of(key, "-1"));
-            var config = McpServerConfig.create(Config.just(configSource));
+            McpServerConfig.create(Config.just(configSource));
             fail("negative value are not allowed and must be checked.");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), is("value must be greater than zero"));
@@ -112,7 +114,7 @@ class ConfigurationTest {
     void testConfigurationInvalidSamplingToolIterations(int value) {
         try {
             var configSource = ConfigSources.create(Map.of("max-sampling-tool-iterations", Integer.toString(value)));
-            var config = McpServerConfig.create(Config.just(configSource));
+            McpServerConfig.create(Config.just(configSource));
             fail("Sampling tool iterations must be greater than zero.");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), is("Maximum sampling tool iterations must be greater than zero"));

--- a/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4Test.java
+++ b/server/src/test/java/io/helidon/extensions/mcp/server/McpJsonSerializerV4Test.java
@@ -47,14 +47,16 @@ class McpJsonSerializerV4Test {
             McpJsonSerializer.create(McpProtocolVersion.VERSION_2025_06_18);
 
     @Test
-    void serializesServerWebsiteUrl() {
+    void serializesServerMetadata() {
         McpServerConfig config = McpServerConfig.builder()
+                .description("Helidon MCP server")
                 .websiteUrl("https://example.com/mcp")
                 .buildPrototype();
         JsonObject response = SERIALIZER.createJsonInitializeResponse(Set.of(), config).build();
         JsonObject expected = JsonObject.builder()
                 .set("name", "mcp-server")
                 .set("version", "0.0.1")
+                .set("description", "Helidon MCP server")
                 .set("websiteUrl", "https://example.com/mcp")
                 .build();
 
@@ -62,7 +64,7 @@ class McpJsonSerializerV4Test {
     }
 
     @Test
-    void omitsUnconfiguredServerWebsiteUrl() {
+    void omitsUnconfiguredServerMetadata() {
         McpServerConfig config = McpServerConfig.builder().buildPrototype();
         JsonObject response = SERIALIZER.createJsonInitializeResponse(Set.of(), config).build();
         JsonObject expected = JsonObject.builder()
@@ -76,8 +78,9 @@ class McpJsonSerializerV4Test {
     @ParameterizedTest
     @EnumSource(value = McpProtocolVersion.class,
                 names = {"VERSION_2024_11_05", "VERSION_2025_03_26", "VERSION_2025_06_18"})
-    void omitsServerWebsiteUrlFromLegacyProtocolVersions(McpProtocolVersion version) {
+    void omitsServerMetadataFromLegacyProtocolVersions(McpProtocolVersion version) {
         McpServerConfig config = McpServerConfig.builder()
+                .description("Helidon MCP server")
                 .websiteUrl("https://example.com/mcp")
                 .buildPrototype();
         JsonObject response = McpJsonSerializer.create(version)

--- a/server/src/test/resources/application-server.yaml
+++ b/server/src/test/resources/application-server.yaml
@@ -18,6 +18,7 @@ mcp:
   server:
     name: "helidon-mcp-server"
     version: "1.0.0"
+    description: "Helidon MCP server"
     website-url: "https://example.com/mcp"
     path: "/path"
     stateless: "true"

--- a/tests/declarative/src/main/java/io/helidon/extensions/mcp/tests/declarative/McpConfigurationServer.java
+++ b/tests/declarative/src/main/java/io/helidon/extensions/mcp/tests/declarative/McpConfigurationServer.java
@@ -21,6 +21,7 @@ import io.helidon.extensions.mcp.server.Mcp;
 @Mcp.Path("/mcp-custom")
 @Mcp.Version("0.0.1-SNAPSHOT")
 @Mcp.WebsiteUrl("https://example.com/mcp")
+@Mcp.Description("Declarative Helidon MCP server")
 @Mcp.Server("mcp-server-custom-path")
 class McpConfigurationServer {
 }

--- a/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/McpSdkAnnotationConfigurationTest.java
+++ b/tests/declarative/src/test/java/io/helidon/extensions/mcp/tests/declarative/McpSdkAnnotationConfigurationTest.java
@@ -62,7 +62,7 @@ class McpSdkAnnotationConfigurationTest {
     }
 
     @Test
-    void websiteUrlAnnotationConfig() {
+    void serverMetadataAnnotationConfig() {
         JsonObject clientInfo = JsonObject.builder()
                 .set("name", "test-client")
                 .set("version", "1.0.0")
@@ -74,13 +74,13 @@ class McpSdkAnnotationConfigurationTest {
                 .param("capabilities", JsonObject.empty())
                 .param("clientInfo", clientInfo)
                 .submit()) {
-            String websiteUrl = response.result()
+            JsonObject serverInfo = response.result()
                     .map(JsonRpcResult::asJsonObject)
                     .flatMap(result -> result.objectValue("serverInfo"))
-                    .flatMap(serverInfo -> serverInfo.stringValue("websiteUrl"))
                     .orElseThrow();
 
-            assertThat(websiteUrl, is("https://example.com/mcp"));
+            assertThat(serverInfo.stringValue("description").orElseThrow(), is("Declarative Helidon MCP server"));
+            assertThat(serverInfo.stringValue("websiteUrl").orElseThrow(), is("https://example.com/mcp"));
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds an optional configured description to `McpServerConfig`.
- Includes the description in `serverInfo` for MCP `2025-11-25` while preserving legacy protocol output.
- Uses type-level `@Mcp.Description` to configure declarative servers.
- Updates public Javadocs and programmatic, configuration, and declarative documentation.

Fixes #117